### PR TITLE
Add centralized messaging service with realtime interview chat

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -13,7 +13,8 @@
       "Bash(node scripts/fix-file-urls.js:*)",
       "Bash(node:*)",
       "Bash(dir:*)",
-      "Bash(git checkout:*)"
+      "Bash(git checkout:*)",
+      "Bash(npm install *)"
     ]
   }
 }

--- a/client/.env.example
+++ b/client/.env.example
@@ -1,0 +1,6 @@
+# Supabase configuration for realtime messaging (interview chat).
+# Find these in your Supabase dashboard: Settings → API.
+# These are exposed to the browser (Vite inlines VITE_* vars at build time),
+# so only use the *anon* key here — never the service role key.
+VITE_SUPABASE_URL=https://your-project-ref.supabase.co
+VITE_SUPABASE_ANON_KEY=your-anon-key

--- a/client/src/components/chat/ChatWidget.css
+++ b/client/src/components/chat/ChatWidget.css
@@ -1,0 +1,284 @@
+.chat-widget-launcher {
+  position: fixed;
+  right: 24px;
+  bottom: 24px;
+  z-index: 1300;
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  border: none;
+  background: #6366f1;
+  color: #fff;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.chat-widget-launcher:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.22);
+}
+
+.chat-widget-launcher__badge {
+  position: absolute;
+  top: -4px;
+  right: -4px;
+  min-width: 20px;
+  height: 20px;
+  padding: 0 6px;
+  border-radius: 10px;
+  background: #ef4444;
+  color: #fff;
+  font-size: 11px;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 2px solid #fff;
+}
+
+.chat-widget-panel {
+  position: fixed;
+  right: 24px;
+  bottom: 24px;
+  z-index: 1301;
+  width: 380px;
+  max-width: calc(100vw - 32px);
+  height: 560px;
+  max-height: calc(100vh - 48px);
+  background: #fff;
+  border-radius: 16px;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.18);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.chat-widget-panel__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 16px;
+  border-bottom: 1px solid #eef0f4;
+  flex-shrink: 0;
+}
+
+.chat-widget-panel__header-text {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.chat-widget-panel__title {
+  font-weight: 600;
+  color: #111827;
+  font-size: 15px;
+  margin: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.chat-widget-panel__subtitle {
+  font-size: 12px;
+  color: #6b7280;
+  margin: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.chat-widget-panel__close {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: #6b7280;
+  padding: 6px;
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.chat-widget-panel__close:hover {
+  background: #f3f4f6;
+  color: #111827;
+}
+
+.chat-widget-panel__messages {
+  flex: 1;
+  overflow-y: auto;
+  padding: 16px;
+  background: #fafafa;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.chat-widget-panel__empty,
+.chat-widget-panel__loading,
+.chat-widget-panel__error {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #6b7280;
+  font-size: 13px;
+  text-align: center;
+  padding: 24px;
+}
+
+.chat-widget-panel__error {
+  color: #b91c1c;
+}
+
+.chat-message-row {
+  display: flex;
+  gap: 8px;
+  align-items: flex-end;
+  max-width: 85%;
+}
+
+.chat-message-row--mine {
+  align-self: flex-end;
+  flex-direction: row-reverse;
+}
+
+.chat-message-row__avatar {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: #e5e7eb;
+  flex-shrink: 0;
+  font-size: 11px;
+  color: #4b5563;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+  overflow: hidden;
+}
+
+.chat-message-row__avatar img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.chat-message-row__bubble-col {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.chat-message-row--mine .chat-message-row__bubble-col {
+  align-items: flex-end;
+}
+
+.chat-message-bubble {
+  padding: 10px 14px;
+  border-radius: 18px;
+  font-size: 14px;
+  line-height: 1.4;
+  white-space: pre-wrap;
+  word-break: break-word;
+  background: #f1f1f3;
+  color: #111827;
+}
+
+.chat-message-row--mine .chat-message-bubble {
+  background: #6366f1;
+  color: #fff;
+}
+
+.chat-message-row--pending .chat-message-bubble {
+  opacity: 0.7;
+}
+
+.chat-message-row--failed .chat-message-bubble {
+  background: #fee2e2;
+  color: #991b1b;
+}
+
+.chat-message-row--failed .chat-message-row__meta {
+  color: #b91c1c;
+}
+
+.chat-message-row__meta {
+  font-size: 11px;
+  color: #9ca3af;
+  margin-top: 4px;
+  padding: 0 6px;
+}
+
+.chat-message-row__sender {
+  font-size: 11px;
+  color: #6b7280;
+  font-weight: 500;
+  margin: 0 6px 2px;
+}
+
+.chat-day-divider {
+  align-self: center;
+  font-size: 11px;
+  color: #9ca3af;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin: 8px 0 4px;
+}
+
+.chat-widget-panel__composer {
+  border-top: 1px solid #eef0f4;
+  padding: 10px 12px;
+  display: flex;
+  align-items: flex-end;
+  gap: 8px;
+  background: #fff;
+  flex-shrink: 0;
+}
+
+.chat-widget-panel__composer textarea {
+  flex: 1;
+  resize: none;
+  border: 1px solid #e5e7eb;
+  border-radius: 18px;
+  padding: 10px 14px;
+  font-size: 14px;
+  font-family: inherit;
+  max-height: 120px;
+  outline: none;
+  background: #fff;
+  color: #111827;
+}
+
+.chat-widget-panel__composer textarea:focus {
+  border-color: #6366f1;
+  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.15);
+}
+
+.chat-widget-panel__send {
+  background: #6366f1;
+  color: #fff;
+  border: none;
+  border-radius: 50%;
+  width: 36px;
+  height: 36px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  transition: background 0.15s ease;
+}
+
+.chat-widget-panel__send:hover:not(:disabled) {
+  background: #4f46e5;
+}
+
+.chat-widget-panel__send:disabled {
+  background: #d1d5db;
+  cursor: not-allowed;
+}

--- a/client/src/components/chat/ChatWidget.jsx
+++ b/client/src/components/chat/ChatWidget.jsx
@@ -1,0 +1,192 @@
+import React, { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { ChatBubbleLeftRightIcon, XMarkIcon, PaperAirplaneIcon } from '@heroicons/react/24/solid';
+import useConversation from '../../hooks/useConversation';
+import { useAuth } from '../../context/AuthContext';
+import './ChatWidget.css';
+
+function initialsFor(name = '') {
+  return name
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((n) => n[0]?.toUpperCase() || '')
+    .join('') || '?';
+}
+
+function formatTime(date) {
+  const d = new Date(date);
+  return d.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
+}
+
+function formatDayLabel(date) {
+  const d = new Date(date);
+  const today = new Date();
+  const yesterday = new Date();
+  yesterday.setDate(yesterday.getDate() - 1);
+  const sameDay = (a, b) => a.toDateString() === b.toDateString();
+  if (sameDay(d, today)) return 'Today';
+  if (sameDay(d, yesterday)) return 'Yesterday';
+  return d.toLocaleDateString([], { month: 'short', day: 'numeric', year: d.getFullYear() === today.getFullYear() ? undefined : 'numeric' });
+}
+
+function MessageList({ messages, currentUserId }) {
+  const items = useMemo(() => {
+    const result = [];
+    let lastDay = null;
+    let lastSender = null;
+    for (const msg of messages) {
+      const day = new Date(msg.createdAt).toDateString();
+      if (day !== lastDay) {
+        result.push({ kind: 'divider', label: formatDayLabel(msg.createdAt), key: `d-${day}` });
+        lastDay = day;
+        lastSender = null;
+      }
+      const showSender = msg.sender.id !== currentUserId && msg.sender.id !== lastSender;
+      result.push({ kind: 'message', msg, showSender, key: msg.id });
+      lastSender = msg.sender.id;
+    }
+    return result;
+  }, [messages, currentUserId]);
+
+  return (
+    <>
+      {items.map((item) => {
+        if (item.kind === 'divider') {
+          return <div className="chat-day-divider" key={item.key}>{item.label}</div>;
+        }
+        const { msg, showSender } = item;
+        const mine = msg.sender.id === currentUserId;
+        const classes = ['chat-message-row'];
+        if (mine) classes.push('chat-message-row--mine');
+        if (msg._pending) classes.push('chat-message-row--pending');
+        if (msg._failed) classes.push('chat-message-row--failed');
+        return (
+          <div className={classes.join(' ')} key={item.key}>
+            {!mine && (
+              <div className="chat-message-row__avatar" title={msg.sender.fullName}>
+                {msg.sender.profileImage
+                  ? <img src={msg.sender.profileImage} alt={msg.sender.fullName} />
+                  : initialsFor(msg.sender.fullName)}
+              </div>
+            )}
+            <div className="chat-message-row__bubble-col">
+              {showSender && <div className="chat-message-row__sender">{msg.sender.fullName}</div>}
+              <div className="chat-message-bubble">{msg.body}</div>
+              <div className="chat-message-row__meta">
+                {msg._failed ? 'Failed to send' : msg._pending ? 'Sending…' : formatTime(msg.createdAt)}
+              </div>
+            </div>
+          </div>
+        );
+      })}
+    </>
+  );
+}
+
+export default function ChatWidget({ resolve, title, subtitle }) {
+  const { user } = useAuth();
+  const [open, setOpen] = useState(false);
+  const [draft, setDraft] = useState('');
+  const messagesRef = useRef(null);
+  const textareaRef = useRef(null);
+
+  const { conversation, messages, loading, sending, error, unreadCount, send, markRead } =
+    useConversation({ resolve, currentUser: user });
+
+  useLayoutEffect(() => {
+    if (!messagesRef.current) return;
+    messagesRef.current.scrollTop = messagesRef.current.scrollHeight;
+  }, [messages, open]);
+
+  useEffect(() => {
+    if (open && conversation) markRead();
+  }, [open, conversation, markRead, messages.length]);
+
+  const handleSubmit = async (e) => {
+    e?.preventDefault();
+    const body = draft.trim();
+    if (!body) return;
+    setDraft('');
+    send(body);
+    textareaRef.current?.focus();
+  };
+
+  const handleKeyDown = (e) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      handleSubmit();
+    }
+  };
+
+  if (!user) return null;
+
+  return (
+    <>
+      {!open && (
+        <button
+          type="button"
+          className="chat-widget-launcher"
+          onClick={() => setOpen(true)}
+          aria-label="Open chat"
+        >
+          <ChatBubbleLeftRightIcon style={{ width: 24, height: 24 }} />
+          {unreadCount > 0 && (
+            <span className="chat-widget-launcher__badge">{unreadCount > 99 ? '99+' : unreadCount}</span>
+          )}
+        </button>
+      )}
+
+      {open && (
+        <div className="chat-widget-panel" role="dialog" aria-label="Chat">
+          <div className="chat-widget-panel__header">
+            <div className="chat-widget-panel__header-text">
+              <h4 className="chat-widget-panel__title">{title || 'Interview chat'}</h4>
+              {subtitle && <p className="chat-widget-panel__subtitle">{subtitle}</p>}
+            </div>
+            <button
+              type="button"
+              className="chat-widget-panel__close"
+              onClick={() => setOpen(false)}
+              aria-label="Close chat"
+            >
+              <XMarkIcon style={{ width: 20, height: 20 }} />
+            </button>
+          </div>
+
+          <div className="chat-widget-panel__messages" ref={messagesRef}>
+            {loading && <div className="chat-widget-panel__loading">Loading…</div>}
+            {!loading && error && <div className="chat-widget-panel__error">{error}</div>}
+            {!loading && !error && messages.length === 0 && (
+              <div className="chat-widget-panel__empty">
+                No messages yet. Say hi to your fellow interviewers.
+              </div>
+            )}
+            {!loading && !error && messages.length > 0 && (
+              <MessageList messages={messages} currentUserId={user.id} />
+            )}
+          </div>
+
+          <form className="chat-widget-panel__composer" onSubmit={handleSubmit}>
+            <textarea
+              ref={textareaRef}
+              rows={1}
+              placeholder="Write a reply..."
+              value={draft}
+              onChange={(e) => setDraft(e.target.value)}
+              onKeyDown={handleKeyDown}
+              disabled={!conversation}
+            />
+            <button
+              type="submit"
+              className="chat-widget-panel__send"
+              disabled={!draft.trim() || !conversation}
+              aria-label="Send"
+            >
+              <PaperAirplaneIcon style={{ width: 16, height: 16 }} />
+            </button>
+          </form>
+        </div>
+      )}
+    </>
+  );
+}

--- a/client/src/components/chat/InterviewChatWidget.jsx
+++ b/client/src/components/chat/InterviewChatWidget.jsx
@@ -1,0 +1,20 @@
+import React, { useCallback } from 'react';
+import apiClient from '../../utils/api';
+import ChatWidget from './ChatWidget';
+
+export default function InterviewChatWidget({ interviewId, interviewTitle }) {
+  const resolve = useCallback(async () => {
+    if (!interviewId) return null;
+    return apiClient.get(`/conversations/interviews/${interviewId}`);
+  }, [interviewId]);
+
+  if (!interviewId) return null;
+
+  return (
+    <ChatWidget
+      resolve={resolve}
+      title="Interview chat"
+      subtitle={interviewTitle || 'Talk to other interviewers'}
+    />
+  );
+}

--- a/client/src/hooks/useConversation.js
+++ b/client/src/hooks/useConversation.js
@@ -1,0 +1,141 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import apiClient from '../utils/api';
+import { supabase } from '../supabaseClient';
+
+export default function useConversation({ resolve, currentUser }) {
+  const currentUserId = currentUser?.id;
+  const [conversation, setConversation] = useState(null);
+  const [messages, setMessages] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [sending, setSending] = useState(false);
+  const [error, setError] = useState(null);
+  const [unreadCount, setUnreadCount] = useState(0);
+  const channelRef = useRef(null);
+  const conversationIdRef = useRef(null);
+
+  const upsertMessage = useCallback((incoming) => {
+    setMessages((prev) => {
+      if (prev.some((m) => m.id === incoming.id)) return prev;
+      const next = [...prev, incoming];
+      next.sort((a, b) => new Date(a.createdAt) - new Date(b.createdAt));
+      return next;
+    });
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function load() {
+      setLoading(true);
+      setError(null);
+      try {
+        const conv = await resolve();
+        if (cancelled || !conv) return;
+        setConversation(conv);
+        conversationIdRef.current = conv.id;
+
+        const history = await apiClient.get(`/conversations/${conv.id}/messages`);
+        if (cancelled) return;
+        setMessages(history);
+
+        const lastReadAt = conv.participants.find((p) => p.userId === currentUserId)?.lastReadAt;
+        const unread = lastReadAt
+          ? history.filter((m) => m.sender.id !== currentUserId && new Date(m.createdAt) > new Date(lastReadAt)).length
+          : history.filter((m) => m.sender.id !== currentUserId).length;
+        setUnreadCount(unread);
+      } catch (err) {
+        if (!cancelled) setError(err.message || 'Failed to load conversation');
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+
+    load();
+    return () => { cancelled = true; };
+  }, [resolve, currentUserId]);
+
+  useEffect(() => {
+    if (!conversation || !supabase) return;
+    const channelName = conversation.channelName || `conv:${conversation.id}`;
+    const channel = supabase.channel(channelName, { config: { broadcast: { self: false } } });
+
+    channel.on('broadcast', { event: 'message:created' }, ({ payload }) => {
+      if (!payload || payload.conversationId !== conversationIdRef.current) return;
+      upsertMessage(payload);
+      if (payload.sender.id !== currentUserId) {
+        setUnreadCount((c) => c + 1);
+      }
+    });
+
+    channel.subscribe();
+    channelRef.current = channel;
+
+    return () => {
+      try { channel.unsubscribe(); } catch (_) {}
+      try { supabase.removeChannel(channel); } catch (_) {}
+      channelRef.current = null;
+    };
+  }, [conversation, currentUserId, upsertMessage]);
+
+  const send = useCallback(async (body) => {
+    if (!conversation || !currentUser) return;
+    const trimmed = body?.trim();
+    if (!trimmed) return;
+
+    const tempId = `temp-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const optimistic = {
+      id: tempId,
+      conversationId: conversation.id,
+      body: trimmed,
+      createdAt: new Date().toISOString(),
+      editedAt: null,
+      deletedAt: null,
+      sender: {
+        id: currentUser.id,
+        fullName: currentUser.fullName,
+        email: currentUser.email,
+        profileImage: currentUser.profileImage,
+        role: currentUser.role
+      },
+      _pending: true
+    };
+    setMessages((prev) => [...prev, optimistic]);
+    setSending(true);
+    setError(null);
+
+    try {
+      const created = await apiClient.post(`/conversations/${conversation.id}/messages`, { body: trimmed });
+      setMessages((prev) => {
+        const filtered = prev.filter((m) => m.id !== tempId);
+        if (filtered.some((m) => m.id === created.id)) return filtered;
+        const next = [...filtered, created];
+        next.sort((a, b) => new Date(a.createdAt) - new Date(b.createdAt));
+        return next;
+      });
+    } catch (err) {
+      setError(err.message || 'Failed to send');
+      setMessages((prev) => prev.map((m) => (m.id === tempId ? { ...m, _pending: false, _failed: true } : m)));
+    } finally {
+      setSending(false);
+    }
+  }, [conversation, currentUser]);
+
+  const markRead = useCallback(async () => {
+    if (!conversation) return;
+    try {
+      await apiClient.post(`/conversations/${conversation.id}/read`, {});
+      setUnreadCount(0);
+    } catch (_) {}
+  }, [conversation]);
+
+  return useMemo(() => ({
+    conversation,
+    messages,
+    loading,
+    sending,
+    error,
+    unreadCount,
+    send,
+    markRead
+  }), [conversation, messages, loading, sending, error, unreadCount, send, markRead]);
+}

--- a/client/src/pages/FinalRoundInterviewInterface.jsx
+++ b/client/src/pages/FinalRoundInterviewInterface.jsx
@@ -19,6 +19,7 @@ import apiClient from '../utils/api';
 import AccessControl from '../components/AccessControl';
 import DocumentPreviewModal from '../components/DocumentPreviewModal';
 import AuthenticatedImage from '../components/AuthenticatedImage';
+import InterviewChatWidget from '../components/chat/InterviewChatWidget';
 import '../styles/FinalRoundInterviewInterface.css';
 
 export default function FinalRoundInterviewInterface() {
@@ -838,6 +839,7 @@ export default function FinalRoundInterviewInterface() {
             title={preview.title}
           />
         )}
+        <InterviewChatWidget interviewId={interviewId} interviewTitle={interview?.title} />
       </div>
     </AccessControl>
   );

--- a/client/src/pages/FirstRoundInterviewInterface.jsx
+++ b/client/src/pages/FirstRoundInterviewInterface.jsx
@@ -16,6 +16,7 @@ import apiClient from '../utils/api';
 import AccessControl from '../components/AccessControl';
 import DocumentPreviewModal from '../components/DocumentPreviewModal';
 import AuthenticatedImage from '../components/AuthenticatedImage';
+import InterviewChatWidget from '../components/chat/InterviewChatWidget';
 import '../styles/FirstRoundInterviewInterface.css';
 
 export default function FirstRoundInterviewInterface() {
@@ -1164,6 +1165,7 @@ export default function FirstRoundInterviewInterface() {
             title={preview.title}
           />
         )}
+        <InterviewChatWidget interviewId={interviewId} interviewTitle={interview?.title} />
       </div>
     </AccessControl>
   );

--- a/client/src/pages/InterviewInterface.jsx
+++ b/client/src/pages/InterviewInterface.jsx
@@ -8,6 +8,7 @@ import {
 } from '@heroicons/react/24/outline';
 import apiClient from '../utils/api';
 import AccessControl from '../components/AccessControl';
+import InterviewChatWidget from '../components/chat/InterviewChatWidget';
 import '../styles/InterviewInterface.css';
 
 export default function InterviewInterface() {
@@ -639,6 +640,7 @@ export default function InterviewInterface() {
           </div>
         </div>
       )}
+      <InterviewChatWidget interviewId={interviewId} interviewTitle={interview?.title} />
     </div>
     </AccessControl>
   );

--- a/client/src/pages/MemberInterviewInterface.jsx
+++ b/client/src/pages/MemberInterviewInterface.jsx
@@ -8,6 +8,7 @@ import {
 } from '@heroicons/react/24/outline';
 import apiClient from '../utils/api';
 import AccessControl from '../components/AccessControl';
+import InterviewChatWidget from '../components/chat/InterviewChatWidget';
 import '../styles/InterviewInterface.css';
 
 export default function MemberInterviewInterface() {
@@ -631,6 +632,7 @@ export default function MemberInterviewInterface() {
           </div>
         </div>
       )}
+      <InterviewChatWidget interviewId={interviewId} interviewTitle={interview?.title} />
     </div>
     </AccessControl>
   );

--- a/client/src/supabaseClient.js
+++ b/client/src/supabaseClient.js
@@ -1,9 +1,12 @@
 import { createClient } from '@supabase/supabase-js'
 
-export const supabase = createClient(
-  import.meta.env.VITE_SUPABASE_URL,
-  import.meta.env.VITE_SUPABASE_ANON_KEY
-)
-//for debugging
-console.log("URL:", import.meta.env.VITE_SUPABASE_URL);
-console.log("KEY:", import.meta.env.VITE_SUPABASE_ANON_KEY?.slice(0, 10));
+const url = import.meta.env.VITE_SUPABASE_URL;
+const anonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
+
+if (!url || !anonKey) {
+  console.warn(
+    '[supabase] VITE_SUPABASE_URL / VITE_SUPABASE_ANON_KEY missing — realtime features disabled'
+  );
+}
+
+export const supabase = url && anonKey ? createClient(url, anonKey) : null;

--- a/server/.env.example
+++ b/server/.env.example
@@ -16,3 +16,9 @@ EMAIL_PASS='your-app-specific-password'
 
 # Slack configuration for admin messaging
 SLACK_WEBHOOK_URL='https://hooks.slack.com/services/YOUR/SLACK/WEBHOOK'
+
+# Supabase configuration for realtime messaging (interview chat).
+# Find these in your Supabase dashboard: Settings → API.
+# SUPABASE_SERVICE_ROLE_KEY is server-only — never expose to the client.
+SUPABASE_URL=https://your-project-ref.supabase.co
+SUPABASE_SERVICE_ROLE_KEY=your-service-role-key

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -12,6 +12,7 @@
         "@google-cloud/local-auth": "^3.0.1",
         "@googleapis/forms": "^2.5.1",
         "@prisma/client": "^6.11.1",
+        "@supabase/supabase-js": "^2.105.3",
         "bcryptjs": "^3.0.2",
         "cors": "^2.8.5",
         "date-fns": "^3.0.0",
@@ -138,6 +139,110 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@prisma/debug": "6.11.1"
+      }
+    },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.105.3",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.105.3.tgz",
+      "integrity": "sha512-hMFuzP++mjRfe0/BUq4/e82CXIDgyjUgg0khLN8waol/gzoM1t2iGmhfJSGvQHQ1dr3XqWpP6ThAw4bLHMot5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.105.3",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.105.3.tgz",
+      "integrity": "sha512-KyutUwLLUZ9fRXsiFACL6lq7akBVHFl0fnqQnrxjbsPco8jeb4EyirQuvr52QCLnikzjMRC0uxAHOSM54aDrZA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/phoenix": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@supabase/phoenix/-/phoenix-0.4.1.tgz",
+      "integrity": "sha512-hWGJkDAfWUNY8k0C080u3sGNFd2ncl9erhKgP7hnGkgJWEfT5Pd/SXal4QmWXBECVlZrannMAc9sBaaRyWpiUA==",
+      "license": "MIT"
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "2.105.3",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.105.3.tgz",
+      "integrity": "sha512-jFVYRHcri0ZMcTzKpQ2r2wWOB8/rPsbj92kxmCmVJUiRrdgiMtuYlkS06Fhs8UJZhEOL0UpGhh06XDwh8JwtBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.105.3",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.105.3.tgz",
+      "integrity": "sha512-L+qPiJlq1RKh3QD2fORGCFo2RKDKlvG9mjvPtUEQJ2tMixrx70VIV6j8BdWzQkbc1Nao6mvTWajyDhX3TFgljw==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/phoenix": "^0.4.1",
+        "@types/ws": "^8.18.1",
+        "tslib": "2.8.1",
+        "ws": "^8.18.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.105.3",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.105.3.tgz",
+      "integrity": "sha512-M7oPCCcHim/FsR6rKIs10Nd9mW051N2SQvA27jiVLa7oQMFFb7faX5dCQRV4GS5QeFsBcV5J/fWl4Ppoaw8cBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "iceberg-js": "^0.8.1",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.105.3",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.105.3.tgz",
+      "integrity": "sha512-5Dm9+I61LAWwjw+0zcqXhSmTxUJaYHBPyHwMCIBH4TBUNwDn2pYUIsi6oUu0I5r9HtLtaFl7w4wa+DV9gRsbDg==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.105.3",
+        "@supabase/functions-js": "2.105.3",
+        "@supabase/postgrest-js": "2.105.3",
+        "@supabase/realtime-js": "2.105.3",
+        "@supabase/storage-js": "2.105.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "25.6.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.2.tgz",
+      "integrity": "sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.19.0"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/accepts": {
@@ -992,6 +1097,15 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/iceberg-js": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/iconv-lite": {
@@ -1953,6 +2067,12 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/type-is": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
@@ -1992,6 +2112,12 @@
       "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
       "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
       "license": "MIT"
     },
     "node_modules/unpipe": {
@@ -2063,6 +2189,27 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/xtend": {
       "version": "4.0.2",

--- a/server/package.json
+++ b/server/package.json
@@ -21,6 +21,7 @@
     "@google-cloud/local-auth": "^3.0.1",
     "@googleapis/forms": "^2.5.1",
     "@prisma/client": "^6.11.1",
+    "@supabase/supabase-js": "^2.105.3",
     "bcryptjs": "^3.0.2",
     "cors": "^2.8.5",
     "date-fns": "^3.0.0",

--- a/server/prisma/migrations/20260507191433_add_messaging/migration.sql
+++ b/server/prisma/migrations/20260507191433_add_messaging/migration.sql
@@ -1,0 +1,65 @@
+-- CreateEnum
+CREATE TYPE "ConversationContextType" AS ENUM ('INTERVIEW', 'APPLICATION', 'CYCLE', 'DIRECT_MESSAGE');
+
+-- CreateTable
+CREATE TABLE "conversations" (
+    "id" TEXT NOT NULL,
+    "contextType" "ConversationContextType" NOT NULL,
+    "contextId" TEXT,
+    "title" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "conversations_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "conversation_participants" (
+    "id" TEXT NOT NULL,
+    "conversationId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "joinedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "lastReadAt" TIMESTAMP(3),
+
+    CONSTRAINT "conversation_participants_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "messages" (
+    "id" TEXT NOT NULL,
+    "conversationId" TEXT NOT NULL,
+    "senderId" TEXT NOT NULL,
+    "body" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "editedAt" TIMESTAMP(3),
+    "deletedAt" TIMESTAMP(3),
+
+    CONSTRAINT "messages_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "conversations_contextType_contextId_idx" ON "conversations"("contextType", "contextId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "conversations_contextType_contextId_key" ON "conversations"("contextType", "contextId");
+
+-- CreateIndex
+CREATE INDEX "conversation_participants_userId_idx" ON "conversation_participants"("userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "conversation_participants_conversationId_userId_key" ON "conversation_participants"("conversationId", "userId");
+
+-- CreateIndex
+CREATE INDEX "messages_conversationId_createdAt_idx" ON "messages"("conversationId", "createdAt");
+
+-- AddForeignKey
+ALTER TABLE "conversation_participants" ADD CONSTRAINT "conversation_participants_conversationId_fkey" FOREIGN KEY ("conversationId") REFERENCES "conversations"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "conversation_participants" ADD CONSTRAINT "conversation_participants_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "messages" ADD CONSTRAINT "messages_conversationId_fkey" FOREIGN KEY ("conversationId") REFERENCES "conversations"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "messages" ADD CONSTRAINT "messages_senderId_fkey" FOREIGN KEY ("senderId") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -39,6 +39,8 @@ model User {
   memberEventRsvp            MemberEventRsvp[]
   resumeScores               ResumeScore[]
   videoScores                VideoScore[]
+  conversationParticipants   ConversationParticipant[]       @relation("ConversationParticipantUser")
+  sentMessages               Message[]                       @relation("MessageSender")
 
   @@map("users")
 }
@@ -589,6 +591,57 @@ model BehavioralQuestion {
   @@index([groupId])
   @@index([createdBy])
   @@map("behavioral_questions")
+}
+
+model Conversation {
+  id           String                    @id @default(uuid())
+  contextType  ConversationContextType
+  contextId    String?
+  title        String?
+  createdAt    DateTime                  @default(now())
+  updatedAt    DateTime                  @updatedAt
+  participants ConversationParticipant[]
+  messages     Message[]
+
+  @@unique([contextType, contextId])
+  @@index([contextType, contextId])
+  @@map("conversations")
+}
+
+model ConversationParticipant {
+  id             String       @id @default(uuid())
+  conversationId String
+  userId         String
+  joinedAt       DateTime     @default(now())
+  lastReadAt     DateTime?
+  conversation   Conversation @relation(fields: [conversationId], references: [id], onDelete: Cascade)
+  user           User         @relation("ConversationParticipantUser", fields: [userId], references: [id])
+
+  @@unique([conversationId, userId])
+  @@index([userId])
+  @@map("conversation_participants")
+}
+
+model Message {
+  id             String       @id @default(uuid())
+  conversationId String
+  senderId       String
+  body           String
+  createdAt      DateTime     @default(now())
+  editedAt       DateTime?
+  deletedAt      DateTime?
+  conversation   Conversation @relation(fields: [conversationId], references: [id], onDelete: Cascade)
+  sender         User         @relation("MessageSender", fields: [senderId], references: [id])
+
+  @@index([conversationId, createdAt])
+  @@map("messages")
+}
+
+enum ConversationContextType {
+  INTERVIEW
+  APPLICATION
+  CYCLE
+  DIRECT_MESSAGE
 }
 
 enum UserRole {

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -13,6 +13,7 @@ import usersRoutes from './routes/users.js';
 import publicRoutes from './routes/public.js';
 import interviewResourcesRoutes from './routes/interviewResources.js';
 import memberRoutes from './routes/member.js';
+import conversationsRoutes from './routes/conversations.js';
 import { requireAuth, requireAdmin } from './middleware/auth.js';
 
 const app = express();
@@ -36,6 +37,7 @@ app.use('/api/review-teams', reviewTeamsRoutes);
 app.use('/api/users', usersRoutes);
 app.use('/api/interview-resources', interviewResourcesRoutes);
 app.use('/api/member', memberRoutes);
+app.use('/api/conversations', conversationsRoutes);
 app.use('/api', publicRoutes);
 
 // Test endpoint to check if uploads directory is accessible

--- a/server/src/routes/conversations.js
+++ b/server/src/routes/conversations.js
@@ -1,0 +1,114 @@
+import express from 'express';
+import { requireAuth, requireAdminOrMember } from '../middleware/auth.js';
+import prisma from '../prismaClient.js';
+import {
+  getOrCreateInterviewConversation,
+  getConversationForUser,
+  listConversationsForUser,
+  listMessages,
+  sendMessage,
+  markRead,
+  userCanAccessConversation
+} from '../services/messaging.js';
+
+const router = express.Router();
+
+router.get('/', requireAuth, requireAdminOrMember, async (req, res) => {
+  try {
+    const conversations = await listConversationsForUser(req.user);
+    res.json(conversations);
+  } catch (err) {
+    console.error('[GET /api/conversations]', err);
+    res.status(500).json({ error: 'Failed to list conversations' });
+  }
+});
+
+router.get('/interviews/:interviewId', requireAuth, requireAdminOrMember, async (req, res) => {
+  try {
+    const { interviewId } = req.params;
+    const conversation = await getOrCreateInterviewConversation(interviewId);
+    // Until InterviewAssignment is wired into the UI, treat any member who reaches
+    // the interview interface as a participant. Lazily insert their row so they
+    // pass the access check and get unread tracking.
+    if (req.user.role === 'MEMBER') {
+      await prisma.conversationParticipant.upsert({
+        where: { conversationId_userId: { conversationId: conversation.id, userId: req.user.id } },
+        update: {},
+        create: { conversationId: conversation.id, userId: req.user.id }
+      });
+    }
+    const dto = await getConversationForUser(conversation.id, req.user);
+    if (!dto) return res.status(403).json({ error: 'Forbidden' });
+    res.json(dto);
+  } catch (err) {
+    if (err.status) return res.status(err.status).json({ error: err.message });
+    console.error('[GET /api/conversations/interviews/:id]', err);
+    res.status(500).json({ error: 'Failed to load interview conversation' });
+  }
+});
+
+router.get('/:id', requireAuth, requireAdminOrMember, async (req, res) => {
+  try {
+    const dto = await getConversationForUser(req.params.id, req.user);
+    if (!dto) return res.status(404).json({ error: 'Conversation not found' });
+    res.json(dto);
+  } catch (err) {
+    console.error('[GET /api/conversations/:id]', err);
+    res.status(500).json({ error: 'Failed to load conversation' });
+  }
+});
+
+router.get('/:id/messages', requireAuth, requireAdminOrMember, async (req, res) => {
+  try {
+    const conversation = await prisma.conversation.findUnique({ where: { id: req.params.id } });
+    if (!conversation) return res.status(404).json({ error: 'Conversation not found' });
+    if (!(await userCanAccessConversation(conversation, req.user))) {
+      return res.status(403).json({ error: 'Forbidden' });
+    }
+    const messages = await listMessages(req.params.id, {
+      before: req.query.before,
+      limit: req.query.limit
+    });
+    res.json(messages);
+  } catch (err) {
+    console.error('[GET /api/conversations/:id/messages]', err);
+    res.status(500).json({ error: 'Failed to list messages' });
+  }
+});
+
+router.post('/:id/messages', requireAuth, requireAdminOrMember, async (req, res) => {
+  try {
+    const conversation = await prisma.conversation.findUnique({ where: { id: req.params.id } });
+    if (!conversation) return res.status(404).json({ error: 'Conversation not found' });
+    if (!(await userCanAccessConversation(conversation, req.user))) {
+      return res.status(403).json({ error: 'Forbidden' });
+    }
+    const message = await sendMessage({
+      conversationId: req.params.id,
+      sender: req.user,
+      body: req.body?.body
+    });
+    res.status(201).json(message);
+  } catch (err) {
+    if (err.status) return res.status(err.status).json({ error: err.message });
+    console.error('[POST /api/conversations/:id/messages]', err);
+    res.status(500).json({ error: 'Failed to send message' });
+  }
+});
+
+router.post('/:id/read', requireAuth, requireAdminOrMember, async (req, res) => {
+  try {
+    const conversation = await prisma.conversation.findUnique({ where: { id: req.params.id } });
+    if (!conversation) return res.status(404).json({ error: 'Conversation not found' });
+    if (!(await userCanAccessConversation(conversation, req.user))) {
+      return res.status(403).json({ error: 'Forbidden' });
+    }
+    await markRead(req.params.id, req.user.id);
+    res.json({ ok: true });
+  } catch (err) {
+    console.error('[POST /api/conversations/:id/read]', err);
+    res.status(500).json({ error: 'Failed to mark read' });
+  }
+});
+
+export default router;

--- a/server/src/services/messaging.js
+++ b/server/src/services/messaging.js
@@ -1,0 +1,236 @@
+import prisma from '../prismaClient.js';
+import { broadcastToConversation, channelNameFor } from './realtime.js';
+
+const MESSAGE_PAGE_SIZE = 50;
+
+const senderSelect = {
+  id: true,
+  fullName: true,
+  email: true,
+  profileImage: true,
+  role: true
+};
+
+function serializeMessage(msg) {
+  return {
+    id: msg.id,
+    conversationId: msg.conversationId,
+    body: msg.body,
+    createdAt: msg.createdAt,
+    editedAt: msg.editedAt,
+    deletedAt: msg.deletedAt,
+    sender: msg.sender
+  };
+}
+
+export async function getOrCreateInterviewConversation(interviewId) {
+  const interview = await prisma.interview.findUnique({
+    where: { id: interviewId },
+    select: { id: true, title: true, assignments: { select: { userId: true } } }
+  });
+  if (!interview) {
+    const err = new Error('Interview not found');
+    err.status = 404;
+    throw err;
+  }
+
+  const existing = await prisma.conversation.findUnique({
+    where: { contextType_contextId: { contextType: 'INTERVIEW', contextId: interviewId } }
+  });
+  if (existing) return existing;
+
+  const conversation = await prisma.conversation.create({
+    data: {
+      contextType: 'INTERVIEW',
+      contextId: interviewId,
+      title: interview.title || null
+    }
+  });
+
+  const userIds = [...new Set(interview.assignments.map((a) => a.userId))];
+  if (userIds.length > 0) {
+    await prisma.conversationParticipant.createMany({
+      data: userIds.map((userId) => ({ conversationId: conversation.id, userId })),
+      skipDuplicates: true
+    });
+  }
+
+  return conversation;
+}
+
+export async function syncInterviewParticipants(interviewId) {
+  const conversation = await prisma.conversation.findUnique({
+    where: { contextType_contextId: { contextType: 'INTERVIEW', contextId: interviewId } },
+    select: { id: true }
+  });
+  if (!conversation) return;
+
+  const assignments = await prisma.interviewAssignment.findMany({
+    where: { interviewId },
+    select: { userId: true }
+  });
+  const desired = new Set(assignments.map((a) => a.userId));
+
+  const current = await prisma.conversationParticipant.findMany({
+    where: { conversationId: conversation.id },
+    select: { userId: true }
+  });
+  const currentSet = new Set(current.map((p) => p.userId));
+
+  const toAdd = [...desired].filter((id) => !currentSet.has(id));
+  if (toAdd.length > 0) {
+    await prisma.conversationParticipant.createMany({
+      data: toAdd.map((userId) => ({ conversationId: conversation.id, userId })),
+      skipDuplicates: true
+    });
+  }
+}
+
+async function ensureParticipantRow(conversationId, userId) {
+  const existing = await prisma.conversationParticipant.findUnique({
+    where: { conversationId_userId: { conversationId, userId } },
+    select: { id: true }
+  });
+  if (existing) return;
+  try {
+    await prisma.conversationParticipant.create({
+      data: { conversationId, userId }
+    });
+  } catch (_) {
+    // ignore unique-constraint races
+  }
+}
+
+export async function userCanAccessConversation(conversation, user) {
+  if (!conversation || !user) return false;
+  if (user.role === 'ADMIN') return true;
+  const row = await prisma.conversationParticipant.findUnique({
+    where: { conversationId_userId: { conversationId: conversation.id, userId: user.id } }
+  });
+  return !!row;
+}
+
+export async function listMessages(conversationId, { before, limit = MESSAGE_PAGE_SIZE } = {}) {
+  const where = { conversationId };
+  if (before) where.createdAt = { lt: new Date(before) };
+  const rows = await prisma.message.findMany({
+    where,
+    orderBy: { createdAt: 'desc' },
+    take: Math.min(Math.max(parseInt(limit, 10) || MESSAGE_PAGE_SIZE, 1), 200),
+    include: { sender: { select: senderSelect } }
+  });
+  return rows.reverse().map(serializeMessage);
+}
+
+export async function sendMessage({ conversationId, sender, body }) {
+  const trimmed = (body || '').trim();
+  if (!trimmed) {
+    const err = new Error('Message body cannot be empty');
+    err.status = 400;
+    throw err;
+  }
+  if (trimmed.length > 5000) {
+    const err = new Error('Message body too long');
+    err.status = 400;
+    throw err;
+  }
+
+  const created = await prisma.message.create({
+    data: { conversationId, senderId: sender.id, body: trimmed },
+    include: { sender: { select: senderSelect } }
+  });
+
+  const payload = serializeMessage(created);
+  broadcastToConversation(conversationId, 'message:created', payload).catch(() => {});
+
+  // Tail writes — not on the response-path. Best-effort, fire-and-forget.
+  ensureParticipantRow(conversationId, sender.id).catch(() => {});
+  prisma.conversation.update({
+    where: { id: conversationId },
+    data: { updatedAt: created.createdAt }
+  }).catch(() => {});
+
+  return payload;
+}
+
+export async function markRead(conversationId, userId, at = new Date()) {
+  await ensureParticipantRow(conversationId, userId);
+  await prisma.conversationParticipant.update({
+    where: { conversationId_userId: { conversationId, userId } },
+    data: { lastReadAt: at }
+  });
+}
+
+export async function getConversationForUser(conversationId, user) {
+  const conversation = await prisma.conversation.findUnique({
+    where: { id: conversationId },
+    include: {
+      participants: {
+        include: { user: { select: senderSelect } }
+      }
+    }
+  });
+  if (!conversation) return null;
+  if (!(await userCanAccessConversation(conversation, user))) return null;
+  return {
+    id: conversation.id,
+    contextType: conversation.contextType,
+    contextId: conversation.contextId,
+    title: conversation.title,
+    createdAt: conversation.createdAt,
+    updatedAt: conversation.updatedAt,
+    channelName: channelNameFor(conversation.id),
+    participants: conversation.participants.map((p) => ({
+      userId: p.userId,
+      joinedAt: p.joinedAt,
+      lastReadAt: p.lastReadAt,
+      user: p.user
+    }))
+  };
+}
+
+export async function listConversationsForUser(user) {
+  const where = user.role === 'ADMIN'
+    ? {}
+    : { participants: { some: { userId: user.id } } };
+
+  const conversations = await prisma.conversation.findMany({
+    where,
+    orderBy: { updatedAt: 'desc' },
+    include: {
+      participants: {
+        where: { userId: user.id },
+        select: { lastReadAt: true }
+      },
+      messages: {
+        orderBy: { createdAt: 'desc' },
+        take: 1,
+        include: { sender: { select: senderSelect } }
+      }
+    }
+  });
+
+  const result = [];
+  for (const c of conversations) {
+    const lastReadAt = c.participants[0]?.lastReadAt || null;
+    const unreadCount = await prisma.message.count({
+      where: {
+        conversationId: c.id,
+        senderId: { not: user.id },
+        ...(lastReadAt ? { createdAt: { gt: lastReadAt } } : {})
+      }
+    });
+    result.push({
+      id: c.id,
+      contextType: c.contextType,
+      contextId: c.contextId,
+      title: c.title,
+      updatedAt: c.updatedAt,
+      lastMessage: c.messages[0] ? serializeMessage(c.messages[0]) : null,
+      unreadCount
+    });
+  }
+  return result;
+}
+
+export { channelNameFor };

--- a/server/src/services/realtime.js
+++ b/server/src/services/realtime.js
@@ -1,0 +1,17 @@
+import supabase, { isSupabaseAvailable } from '../supabaseClient.js';
+
+export async function broadcastToConversation(conversationId, event, payload) {
+  if (!isSupabaseAvailable()) return;
+  try {
+    const channel = supabase.channel(`conv:${conversationId}`);
+    if (typeof channel.httpSend === 'function') {
+      await channel.httpSend(event, payload);
+    } else {
+      await channel.send({ type: 'broadcast', event, payload });
+    }
+  } catch (err) {
+    console.error(`[realtime] broadcast failed for ${conversationId}/${event}:`, err);
+  }
+}
+
+export const channelNameFor = (conversationId) => `conv:${conversationId}`;


### PR DESCRIPTION
## Summary

Closes #33.

Introduces a generic **Conversation / ConversationParticipant / Message** data model with a `contextType` field (`INTERVIEW | APPLICATION | CYCLE | DIRECT_MESSAGE`) so the same plumbing can serve interview chat today and per-application threads / DMs later. The first consumer is a floating chat widget on the four interview pages — interviewers in the same interview see a Slack/Intercom-style chat scoped to that interview.

**Realtime** uses Supabase broadcast channels (`conv:<conversationId>`). The Express server stays the only authority — it authenticates the request, writes the message via Prisma, then broadcasts via the Supabase HTTP API. Clients subscribe with the anon key. This avoids re-doing auth around `postgres_changes` + RLS while still getting sub-second cross-tab delivery.

**Access:** assigned interviewers (via `InterviewAssignment`) + all admins. Until the assignment-management UI lands, MEMBER callers are lazily added as participants when they open an interview chat — admins always have implicit access.

**Send latency:** optimistic UI on the client (the bubble appears in the same render the user hits Enter), and the server response path is a single Prisma write — `conversation.updatedAt`, `lastReadAt`, and the participant-row check all moved off the critical path as fire-and-forget tail writes.

### What's in the diff
- **Schema:** new `conversations`, `conversation_participants`, `messages` tables + `ConversationContextType` enum (migration `20260507191433_add_messaging`).
- **Server:** `services/messaging.js` (get-or-create / send / list / mark-read / `syncInterviewParticipants`), `services/realtime.js` (Supabase broadcast wrapper using `httpSend`), `routes/conversations.js` registered at `/api/conversations` in `index.js`. Added `@supabase/supabase-js` to server deps.
- **Client:** `useConversation` hook (history fetch + WebSocket subscribe + optimistic send + unread tracking), `ChatWidget` (floating launcher + slide-out panel with unread badge, day dividers, sender avatars, mine/others bubble styling, pending/failed states), `InterviewChatWidget` wrapper. Mounted on `InterviewInterface.jsx`, `FirstRoundInterviewInterface.jsx`, `FinalRoundInterviewInterface.jsx`, `MemberInterviewInterface.jsx`. Made `supabaseClient.js` defensive so missing env vars no longer crash the app.

### Required env vars (new)
- `server/.env`: `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`
- `client/.env`: `VITE_SUPABASE_URL`, `VITE_SUPABASE_ANON_KEY`

Both `.env.example` files updated.

### Out of scope (deferred)
- Edit / delete UI (schema supports `editedAt` / `deletedAt`)
- File attachments
- Typing indicators (Supabase Presence would slot in cleanly)
- DM channels and per-application threads (data model supports them — just no UI yet)

## Test plan
- [ ] Run pending migration on the dev DB: `cd server && npx prisma migrate deploy` (or via Supabase if already applied)
- [ ] Set `SUPABASE_URL` + `SUPABASE_SERVICE_ROLE_KEY` in `server/.env` and restart the server
- [ ] Set `VITE_SUPABASE_URL` + `VITE_SUPABASE_ANON_KEY` in `client/.env` and restart Vite
- [ ] As ADMIN, navigate to any interview page — confirm the chat launcher appears bottom-right
- [ ] Click the launcher, send a message — bubble should appear instantly with "Sending…" then resolve to a timestamp
- [ ] Open the same interview in a second tab as a MEMBER — confirm history loads, send a reply
- [ ] Confirm both tabs receive each other's messages without refresh
- [ ] Close the chat panel on tab A; send from tab B; confirm the unread badge appears on tab A's launcher
- [ ] Reopen the panel on tab A; confirm badge clears (mark-read fires)
- [ ] Disconnect the network briefly and send a message; confirm the bubble shows "Failed to send" in red
- [ ] Confirm a USER (candidate) hitting `/api/conversations/...` is rejected (`requireAdminOrMember`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)