### PR TITLE
test: verify Render PR preview environments

### DIFF
--- a/docs/render-preview-test.md
+++ b/docs/render-preview-test.md
@@ -1,0 +1,5 @@
+# Render preview smoke test
+
+Disposable file used to verify that Render creates a preview
+environment for pull requests. Safe to delete along with this branch
+once the preview URL has been confirmed working.


### PR DESCRIPTION
Disposable PR to confirm Render creates a preview environment from `render.yaml`.

Cut from `main` because none of the 14 open PR branches contain `render.yaml` yet — they all branched off before it landed, so Render would not build a preview for them.

**Close and delete the branch once the preview URL is confirmed.**