### PR TITLE
feat(cycles): per-audience active recruiting cycle

### DIFF
--- a/client/src/components/CycleScopeBanner.jsx
+++ b/client/src/components/CycleScopeBanner.jsx
@@ -1,0 +1,62 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import apiClient from '../utils/api';
+import { useAuth } from '../context/AuthContext';
+
+// Admins can be working in a different recruiting cycle than members and candidates
+// see. Nothing else on screen says which one they are in, and admin writes (events,
+// interviews, review teams) are stamped with the admin cycle — so a silent split is
+// how you build a round of interviews nobody can see.
+//
+// Renders nothing at all when the pointers agree, which is the normal case.
+export default function CycleScopeBanner() {
+  const { user } = useAuth();
+  const [scope, setScope] = useState(null);
+
+  const load = useCallback(async () => {
+    if (user?.role !== 'ADMIN') return;
+    try {
+      const cycle = await apiClient.get('/admin/cycles/active');
+      setScope(cycle?.audiencesSplit ? cycle : null);
+    } catch {
+      // A banner is never worth breaking the page over.
+      setScope(null);
+    }
+  }, [user?.role]);
+
+  useEffect(() => {
+    load();
+    window.addEventListener('cycleActivated', load);
+    return () => window.removeEventListener('cycleActivated', load);
+  }, [load]);
+
+  if (!scope) return null;
+
+  return (
+    <div
+      role="status"
+      style={{
+        display: 'flex',
+        flexWrap: 'wrap',
+        alignItems: 'center',
+        gap: '0.5rem',
+        padding: '0.625rem 0.875rem',
+        marginBottom: '1rem',
+        border: '1px solid #f0b429',
+        borderRadius: '0.375rem',
+        background: '#fff8e6',
+        color: '#5c4400',
+        fontSize: '0.875rem'
+      }}
+    >
+      <span>
+        You are working in <strong>{scope.name}</strong>. Members and candidates see{' '}
+        <strong>{scope.candidateCycle?.name}</strong>. Events, interviews and review teams you
+        create here will not be visible to them.
+      </span>
+      <Link to="/cycles" style={{ color: '#5c4400', fontWeight: 600 }}>
+        Manage cycles
+      </Link>
+    </div>
+  );
+}

--- a/client/src/components/Layout.jsx
+++ b/client/src/components/Layout.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
+import CycleScopeBanner from './CycleScopeBanner';
 import {
   HomeIcon, 
   DocumentTextIcon, 
@@ -209,6 +210,7 @@ const Layout = ({ children }) => {
         <div className="content-area">
           <main className="main-content">
             <div className="content-container">
+              <CycleScopeBanner />
               {children}
             </div>
           </main>

--- a/client/src/pages/CycleManagement.jsx
+++ b/client/src/pages/CycleManagement.jsx
@@ -17,8 +17,13 @@ import {
   DialogContent,
   DialogActions,
   Checkbox,
+  Chip,
   IconButton,
   Tooltip,
+  Radio,
+  RadioGroup,
+  FormControlLabel,
+  Alert,
 } from '@mui/material';
 import { Edit as EditIcon } from '@mui/icons-material';
 import apiClient from '../utils/api';
@@ -40,6 +45,14 @@ export default function CycleManagement() {
   const [offerLetterCycleId, setOfferLetterCycleId] = useState(null);
   const [form, setForm] = useState({ name: '', formUrl: '', startDate: '', endDate: '', isActive: false });
   const [submitting, setSubmitting] = useState(false);
+  // Which cycle the audience dialog is open for, and the audience chosen in it.
+  const [activating, setActivating] = useState(null);
+  const [activateAudiences, setActivateAudiences] = useState('BOTH');
+
+  const candidateCycle = cycles.find((c) => c.isActive) || null;
+  // No pinned admin cycle means admins are still following the candidate one.
+  const adminCycle = cycles.find((c) => c.isAdminActive) || candidateCycle;
+  const audiencesSplit = Boolean(candidateCycle && adminCycle && candidateCycle.id !== adminCycle.id);
 
   const fetchCycles = async () => {
     try {
@@ -135,12 +148,35 @@ export default function CycleManagement() {
     setError('');
   };
 
-  const activateCycle = async (id) => {
-    await apiClient.post(`/admin/cycles/${id}/activate`, {});
+  // 'BOTH' is the historical behaviour. The split options exist for a handover, where
+  // admins finish out the closing cycle while the next one opens to candidates.
+  const AUDIENCE_CHOICES = {
+    BOTH: ['CANDIDATE', 'ADMIN'],
+    CANDIDATE: ['CANDIDATE'],
+    ADMIN: ['ADMIN']
+  };
+
+  const activateCycle = async (id, choice = 'BOTH') => {
+    const audiences = AUDIENCE_CHOICES[choice];
+    await apiClient.post(`/admin/cycles/${id}/activate`, { audiences });
     await fetchCycles();
-    
-    // Dispatch event to notify other components (like EventManagement) that a cycle was activated
-    window.dispatchEvent(new CustomEvent('cycleActivated', { detail: { cycleId: id } }));
+
+    // Listeners refetch on this regardless of audience: an extra refetch is harmless,
+    // a skipped one leaves a stale screen. The audience is carried for those that care.
+    window.dispatchEvent(new CustomEvent('cycleActivated', { detail: { cycleId: id, audiences } }));
+  };
+
+  const submitActivation = async () => {
+    if (!activating) return;
+    try {
+      setSubmitting(true);
+      await activateCycle(activating.id, activateAudiences);
+      setActivating(null);
+    } catch (e) {
+      setError(e.message || 'Failed to activate cycle');
+    } finally {
+      setSubmitting(false);
+    }
   };
 
   const deleteCycle = async (id) => {
@@ -169,6 +205,17 @@ export default function CycleManagement() {
         <Paper sx={{ p: 2, mb: 2, color: 'error.main' }}>{error}</Paper>
       )}
 
+      <Paper sx={{ p: 1.5, mb: 2 }}>
+        <Stack direction={{ xs: 'column', sm: 'row' }} spacing={{ xs: 1, sm: 3 }} alignItems={{ sm: 'center' }}>
+          <Typography variant="body2" color="text.secondary">
+            Members &amp; candidates: <strong>{candidateCycle?.name || 'None'}</strong>
+          </Typography>
+          <Typography variant="body2" color={audiencesSplit ? 'warning.main' : 'text.secondary'}>
+            Admins: <strong>{adminCycle?.name || 'None'}</strong>
+          </Typography>
+        </Stack>
+      </Paper>
+
       <TableContainer component={Paper} className="responsive-table">
         <Table>
           <TableHead>
@@ -177,7 +224,8 @@ export default function CycleManagement() {
               <TableCell>Form URL</TableCell>
               <TableCell>Start</TableCell>
               <TableCell>End</TableCell>
-              <TableCell>Active</TableCell>
+              <TableCell>Members &amp; Candidates</TableCell>
+              <TableCell>Admins</TableCell>
               <TableCell align="right">Actions</TableCell>
             </TableRow>
           </TableHead>
@@ -188,7 +236,12 @@ export default function CycleManagement() {
                 <TableCell data-label="Form URL" sx={{ maxWidth: { xs: 'none', md: 320 }, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: { xs: 'normal', md: 'nowrap' }, wordBreak: 'break-all' }}>{c.formUrl || '-'}</TableCell>
                 <TableCell data-label="Start">{c.startDate ? new Date(c.startDate).toLocaleDateString() : '-'}</TableCell>
                 <TableCell data-label="End">{c.endDate ? new Date(c.endDate).toLocaleDateString() : '-'}</TableCell>
-                <TableCell data-label="Active">{c.isActive ? 'Yes' : 'No'}</TableCell>
+                <TableCell data-label="Members & Candidates">
+                  {c.isActive ? <Chip size="small" color="primary" label="Active" /> : '—'}
+                </TableCell>
+                <TableCell data-label="Admins">
+                  {c.isAdminActive ? <Chip size="small" color="warning" label="Active" /> : '—'}
+                </TableCell>
                 <TableCell data-label="Actions" align="right">
                   <Stack direction="row" spacing={1} justifyContent="flex-end">
                     <Tooltip title="Edit cycle">
@@ -199,8 +252,14 @@ export default function CycleManagement() {
                     <Button size="small" variant="outlined" onClick={() => setOfferLetterCycleId(c.id)}>
                       Offer Letters
                     </Button>
-                    {!c.isActive && (
-                      <Button size="small" variant="outlined" onClick={() => activateCycle(c.id)}>Activate</Button>
+                    {!(c.isActive && c.isAdminActive) && (
+                      <Button
+                        size="small"
+                        variant="outlined"
+                        onClick={() => { setActivateAudiences('BOTH'); setActivating(c); }}
+                      >
+                        Activate…
+                      </Button>
                     )}
                     <Button size="small" color="error" variant="outlined" onClick={() => deleteCycle(c.id)}>Delete</Button>
                   </Stack>
@@ -210,6 +269,49 @@ export default function CycleManagement() {
           </TableBody>
         </Table>
       </TableContainer>
+
+      {/* Activation Dialog: which audiences this cycle becomes active for */}
+      <Dialog open={Boolean(activating)} onClose={() => !submitting && setActivating(null)} fullWidth maxWidth="sm">
+        <DialogTitle>Activate {activating?.name}</DialogTitle>
+        <DialogContent>
+          <RadioGroup
+            value={activateAudiences}
+            onChange={(e) => setActivateAudiences(e.target.value)}
+          >
+            <FormControlLabel
+              value="BOTH"
+              control={<Radio />}
+              disabled={submitting}
+              label="Everyone — members, candidates and admins"
+            />
+            <FormControlLabel
+              value="CANDIDATE"
+              control={<Radio />}
+              disabled={submitting}
+              label={`Members & candidates only — admins stay on ${adminCycle?.name || 'their current cycle'}`}
+            />
+            <FormControlLabel
+              value="ADMIN"
+              control={<Radio />}
+              disabled={submitting}
+              label={`Admins only — members & candidates stay on ${candidateCycle?.name || 'their current cycle'}`}
+            />
+          </RadioGroup>
+          {activateAudiences !== 'BOTH' && (
+            <Alert severity="warning" sx={{ mt: 2 }}>
+              Admins and members will be working in different cycles. Events, interviews and
+              review teams an admin creates are stamped with the admin cycle, so members on the
+              other cycle will not see them.
+            </Alert>
+          )}
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setActivating(null)} disabled={submitting}>Cancel</Button>
+          <Button variant="contained" onClick={submitActivation} disabled={submitting}>
+            {submitting ? 'Activating…' : 'Activate'}
+          </Button>
+        </DialogActions>
+      </Dialog>
 
       {/* Create Dialog */}
       <Dialog open={createOpen} onClose={() => !submitting && setCreateOpen(false)} fullWidth maxWidth="sm">
@@ -256,7 +358,7 @@ export default function CycleManagement() {
                 onChange={(e) => setForm({ ...form, isActive: e.target.checked })} 
                 disabled={submitting}
               />
-              <Typography>Set as active</Typography>
+              <Typography>Set as active for everyone</Typography>
             </Stack>
           </Stack>
         </DialogContent>
@@ -313,7 +415,7 @@ export default function CycleManagement() {
                 onChange={(e) => setForm({ ...form, isActive: e.target.checked })} 
                 disabled={submitting}
               />
-              <Typography>Set as active</Typography>
+              <Typography>Set as active for everyone</Typography>
             </Stack>
           </Stack>
         </DialogContent>

--- a/server/prisma/migrations/20260825000000_cycle_admin_audience/migration.sql
+++ b/server/prisma/migrations/20260825000000_cycle_admin_audience/migration.sql
@@ -1,0 +1,36 @@
+-- Audience-scoped cycle activation.
+--
+-- `isActive` keeps its meaning: the cycle members, candidates and the public pages
+-- see. `isAdminActive` is the new, independent pointer for admins. They are normally
+-- the same row and differ only during a handover, where admins finish out the closing
+-- cycle while the next one opens to candidates.
+--
+-- Purely additive: one column and one index. No drops, renames, type changes or
+-- backfills. On PostgreSQL 11+ an ADD COLUMN with a non-volatile DEFAULT is
+-- metadata-only, so this does not rewrite the table.
+--
+-- Written to be re-runnable: `prisma db execute` has no transaction wrapper of its
+-- own (see CLAUDE.md), so a half-applied file has to be safe to run again.
+
+ALTER TABLE "recruiting_cycles"
+  ADD COLUMN IF NOT EXISTS "isAdminActive" BOOLEAN NOT NULL DEFAULT false;
+
+-- Fail loudly rather than letting CREATE UNIQUE INDEX report a bare duplicate-key
+-- error. Only reachable on a re-run after someone hand-set the column.
+DO $$
+DECLARE offenders TEXT;
+BEGIN
+  SELECT string_agg("name", ', ') INTO offenders
+    FROM "recruiting_cycles" WHERE "isAdminActive";
+  IF (SELECT COUNT(*) FROM "recruiting_cycles" WHERE "isAdminActive") > 1 THEN
+    RAISE EXCEPTION
+      'Cannot enforce a single admin-active cycle: clear isAdminActive on all but one of: %',
+      offenders;
+  END IF;
+END $$;
+
+-- Mirrors `recruiting_cycles_single_active` from the
+-- 20260808210000_cycle_bootstrap_identity_and_single_active migration.
+DROP INDEX IF EXISTS "recruiting_cycles_single_admin_active";
+CREATE UNIQUE INDEX "recruiting_cycles_single_admin_active"
+  ON "recruiting_cycles" (("isAdminActive")) WHERE "isAdminActive";

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -134,11 +134,21 @@ model RecruitingCycle {
   // Unique so an exact retry of a bootstrap commit recovers the cycle it
   // already created instead of making a second one.
   name                      String                           @unique
-  // At most one cycle may be active. Enforced by the partial unique index
-  // `recruiting_cycles_single_active`, which Prisma's schema cannot express, so it
-  // is created in SQL by the migration and must be re-added by hand if this table
-  // is ever recreated from scratch.
+  // Activation is audience-scoped. `isActive` is the cycle members, candidates and
+  // the public pages see; `isAdminActive` is the cycle admins see. They are normally
+  // the same row and differ only during a handover, where admins finish out the
+  // closing cycle while the next one opens to candidates.
+  //
+  // At most one cycle may carry each flag. Enforced by the partial unique indexes
+  // `recruiting_cycles_single_active` and `recruiting_cycles_single_admin_active`,
+  // which Prisma's schema cannot express, so they are created in SQL by the
+  // migrations and must be re-added by hand if this table is ever recreated.
+  //
+  // Never read either column directly: go through resolveCycle()/resolveCycleForRequest()
+  // in services/activeCycle.js, which maps the caller's role to the right pointer and
+  // falls back to `isActive` when no admin cycle is pinned.
   isActive                  Boolean                          @default(false)
+  isAdminActive             Boolean                          @default(false)
   startDate                 DateTime?
   endDate                   DateTime?
   createdAt                 DateTime                         @default(now())

--- a/server/src/routes/admin.js
+++ b/server/src/routes/admin.js
@@ -49,7 +49,12 @@ import { resolveFormStatus } from '../services/eventFormStatus.js';
 import {
   activateCycleExclusively,
   isActiveCycleConflict,
-  ActiveCycleConflictError
+  ActiveCycleConflictError,
+  ALL_AUDIENCES,
+  isValidAudience,
+  resolveCycleForRequest,
+  resolveAdminCycle,
+  resolveCandidateCycle
 } from '../services/activeCycle.js';
 
 const router = express.Router();
@@ -96,7 +101,7 @@ router.get('/stats', async (req, res) => {
     // Wrap all database calls in try-catch blocks to handle individual failures
     let active = null;
     try {
-      active = await prisma.recruitingCycle.findFirst({ where: { isActive: true } });
+      active = await resolveCycleForRequest(prisma, req);
     } catch (error) {
       console.error('Error fetching active cycle:', error);
     }
@@ -199,7 +204,7 @@ router.get('/candidates', async (req, res) => {
     const { year, gender, firstGen, transfer, status: statusFilter, eventAttendanceEventId, eventRsvpEventId } = req.query;
 
     // Scope to active cycle if present
-    const active = await prisma.recruitingCycle.findFirst({ where: { isActive: true } });
+    const active = await resolveCycleForRequest(prisma, req);
     if (!active) {
       return res.json([]);
     }
@@ -907,7 +912,7 @@ router.patch('/candidates/:id/approval', async (req, res) => {
 router.post('/advance-round', async (req, res) => {
   try {
     console.log('Starting bulk advance...');
-    const active = await prisma.recruitingCycle.findFirst({ where: { isActive: true } });
+    const active = await resolveCycleForRequest(prisma, req);
     if (!active) {
       return res.status(400).json({ error: 'No active recruiting cycle' });
     }
@@ -970,7 +975,7 @@ router.post('/process-decisions', async (req, res) => {
     const sendEmails = req.body.sendEmails !== false;
     console.log('Send emails:', sendEmails);
     
-    const active = await prisma.recruitingCycle.findFirst({ where: { isActive: true } });
+    const active = await resolveCycleForRequest(prisma, req);
     if (!active) {
       return res.status(400).json({ error: 'No active recruiting cycle' });
     }
@@ -1271,10 +1276,24 @@ router.get('/cycles', async (req, res) => {
   }
 });
 
-// Get active cycle
+// The admin console's own cycle. Additive extension: the body is still the admin
+// cycle row, so existing readers of .id/.name/deadlines are untouched, plus
+// `candidateCycle` and `audiencesSplit` so the UI can warn when admins are working in
+// a different cycle than members and candidates see.
 router.get('/cycles/active', async (req, res) => {
   try {
-    res.json(await loadActiveCycle(prisma));
+    const [adminCycle, candidateCycle] = await Promise.all([
+      resolveAdminCycle(prisma),
+      resolveCandidateCycle(prisma)
+    ]);
+    if (!adminCycle) return res.json(null);
+    res.json({
+      ...adminCycle,
+      candidateCycle: candidateCycle
+        ? { id: candidateCycle.id, name: candidateCycle.name }
+        : null,
+      audiencesSplit: Boolean(candidateCycle) && candidateCycle.id !== adminCycle.id
+    });
   } catch (error) {
     console.error('[GET /api/admin/cycles/active]', error);
     // Return null instead of error to prevent dashboard from breaking
@@ -1377,14 +1396,25 @@ router.post('/cycles/bootstrap-commit', async (req, res) => {
   }
 });
 
-// Set a cycle as active
+// Set a cycle as active, for one audience or both.
+//
+// `audiences` defaults to both, so an existing caller posting an empty body keeps
+// meaning "activate for everyone". Passing ['CANDIDATE'] alone is the handover case:
+// members and candidates move while admins stay on the closing cycle.
 router.post('/cycles/:id/activate', async (req, res) => {
   const { id } = req.params;
+  const { audiences = ALL_AUDIENCES } = req.body ?? {};
+
+  if (!Array.isArray(audiences) || audiences.length === 0 || !audiences.every(isValidAudience)) {
+    return res.status(400).json({
+      error: `audiences must be a non-empty array of ${ALL_AUDIENCES.join(' | ')}`
+    });
+  }
 
   try {
-    const updated = await prisma.$transaction((tx) => activateCycleExclusively(tx, id));
+    const updated = await prisma.$transaction((tx) => activateCycleExclusively(tx, id, audiences));
 
-    res.json({ message: 'Cycle activated', cycle: updated });
+    res.json({ message: 'Cycle activated', cycle: updated, audiences });
   } catch (error) {
     console.error('[POST /api/admin/cycles/:id/activate]', error);
     if (isActiveCycleConflict(error)) {
@@ -1474,7 +1504,7 @@ router.delete('/cycles/:id', async (req, res) => {
 router.post('/reset-all', async (req, res) => {
   try {
     console.log('Resetting candidates for active cycle...');
-    const active = await prisma.recruitingCycle.findFirst({ where: { isActive: true } });
+    const active = await resolveCycleForRequest(prisma, req);
     if (!active) {
       return res.status(400).json({ error: 'No active recruiting cycle' });
     }
@@ -1930,9 +1960,7 @@ router.post('/events/copy-commit', async (req, res) => {
 router.get('/interviews', async (req, res) => {
   try {
     // Get the active cycle first
-    const activeCycle = await prisma.recruitingCycle.findFirst({ 
-      where: { isActive: true } 
-    });
+    const activeCycle = await resolveCycleForRequest(prisma, req);
     
     if (!activeCycle) {
       return res.json([]);
@@ -2878,7 +2906,7 @@ router.post('/save-decision', async (req, res) => {
     }
 
     // Find the application for this candidate in the active cycle
-    const active = await prisma.recruitingCycle.findFirst({ where: { isActive: true } });
+    const active = await resolveCycleForRequest(prisma, req);
     if (!active) {
       return res.status(400).json({ error: 'No active recruiting cycle' });
     }
@@ -3613,7 +3641,7 @@ router.post('/process-coffee-decisions', async (req, res) => {
   try {
     console.log('Starting coffee chat decision processing...');
 
-    const active = await prisma.recruitingCycle.findFirst({ where: { isActive: true } });
+    const active = await resolveCycleForRequest(prisma, req);
     if (!active) {
       return res.status(400).json({ error: 'No active recruiting cycle' });
     }
@@ -3756,7 +3784,7 @@ router.post('/process-first-round-decisions', async (req, res) => {
     const sendEmails = req.body.sendEmails !== false;
     console.log('Send emails:', sendEmails);
 
-    const active = await prisma.recruitingCycle.findFirst({ where: { isActive: true } });
+    const active = await resolveCycleForRequest(prisma, req);
     if (!active) {
       return res.status(400).json({ error: 'No active recruiting cycle' });
     }
@@ -3936,7 +3964,7 @@ router.post('/process-final-decisions', async (req, res) => {
   try {
     console.log('Starting final round decision processing...');
 
-    const active = await prisma.recruitingCycle.findFirst({ where: { isActive: true } });
+    const active = await resolveCycleForRequest(prisma, req);
     if (!active) {
       return res.status(400).json({ error: 'No active recruiting cycle' });
     }
@@ -4552,9 +4580,7 @@ router.get('/flagged-documents', async (req, res) => {
     const { resolved } = req.query;
     
     // Get the active cycle first
-    const activeCycle = await prisma.recruitingCycle.findFirst({ 
-      where: { isActive: true } 
-    });
+    const activeCycle = await resolveCycleForRequest(prisma, req);
     
     if (!activeCycle) {
       return res.json([]);
@@ -5438,8 +5464,11 @@ router.post('/users/deactivate-preview', async (req, res) => {
       return res.status(400).json({ error: 'graduationClass is required' });
     }
 
+    // Union of both audience pointers on purpose: a member still staffed on the
+    // admin-facing cycle must not be deactivatable just because candidates have
+    // already moved on to the next one.
     const activeCycles = await prisma.recruitingCycle.findMany({
-      where: { isActive: true },
+      where: { OR: [{ isActive: true }, { isAdminActive: true }] },
       select: { id: true }
     });
     const activeCycleIds = new Set(activeCycles.map(c => c.id));
@@ -5484,8 +5513,11 @@ router.post('/users/deactivate', async (req, res) => {
       return res.status(400).json({ error: 'Could not determine a graduation year from the class value' });
     }
 
+    // Union of both audience pointers on purpose: a member still staffed on the
+    // admin-facing cycle must not be deactivatable just because candidates have
+    // already moved on to the next one.
     const activeCycles = await prisma.recruitingCycle.findMany({
-      where: { isActive: true },
+      where: { OR: [{ isActive: true }, { isAdminActive: true }] },
       select: { id: true }
     });
     const activeCycleIds = new Set(activeCycles.map(c => c.id));
@@ -5550,9 +5582,12 @@ router.post('/users/deactivate', async (req, res) => {
 router.get('/talent-pool/stats', async (req, res) => {
   try {
     const cycles = await prisma.recruitingCycle.findMany({
-      select: { id: true, name: true, isActive: true },
+      select: { id: true, name: true, isActive: true, isAdminActive: true },
       orderBy: { createdAt: 'desc' }
     });
+    // Omitted cycleId means "the cycle I am working in", which on an admin route is
+    // the admin pointer, not the one candidates see.
+    const defaultCycle = await resolveCycleForRequest(prisma, req);
 
     const requested = req.query.cycleId;
     let cycleFilter;
@@ -5564,7 +5599,7 @@ router.get('/talent-pool/stats', async (req, res) => {
     } else {
       const target = requested
         ? cycles.find((c) => c.id === requested)
-        : cycles.find((c) => c.isActive);
+        : cycles.find((c) => c.id === defaultCycle?.id);
       if (!target) {
         return res.status(404).json({ error: 'Recruiting cycle not found' });
       }

--- a/server/src/routes/applications.js
+++ b/server/src/routes/applications.js
@@ -4,6 +4,7 @@ import { requireAuth, requireAdmin, requireAdminOrMember } from '../middleware/a
 import { getFormQuestions, getResponses } from '../services/google/forms.js';
 import { getGroupMemberUsers, groupMemberUserInclude } from '../utils/groupMembers.js';
 import config from '../config.js';
+import { resolveCycleForRequest } from '../services/activeCycle.js';
 
 const router = express.Router();
 
@@ -173,9 +174,7 @@ router.post('/manual', requireAdmin, async (req, res) => {
     }
 
     // Get the active recruiting cycle
-    const activeCycle = await prisma.recruitingCycle.findFirst({ 
-      where: { isActive: true } 
-    });
+    const activeCycle = await resolveCycleForRequest(prisma, req);
 
     if (!activeCycle) {
       return res.status(400).json({ 
@@ -260,7 +259,7 @@ router.get('/', async (req, res) => {
     const { year, gender, firstGen, transfer, status: statusFilter, returning, eventAttendanceEventId } = req.query;
 
     // Optional: scope to active recruiting cycle if one exists
-    const activeCycle = await prisma.recruitingCycle.findFirst({ where: { isActive: true } });
+    const activeCycle = await resolveCycleForRequest(prisma, req);
     if (!activeCycle) {
       // When no active cycle, return empty list instead of all
       return res.json([]);

--- a/server/src/routes/candidate.js
+++ b/server/src/routes/candidate.js
@@ -8,6 +8,8 @@ import {
   sendMeetingCancellationToMember,
 } from '../services/emailNotifications.js';
 import { toCandidateCard } from '../utils/gtkucProfile.js';
+// Candidate-facing: always the candidate pointer, never the caller's role.
+import { resolveCandidateCycle } from '../services/activeCycle.js';
 
 const router = express.Router();
 
@@ -78,7 +80,7 @@ router.post('/my-meeting-signups', requireAuth, async (req, res) => {
     }
 
     // Enforce one signup per active recruiting cycle (mirrors public signup route).
-    const activeCycle = await prisma.recruitingCycle.findFirst({ where: { isActive: true } });
+    const activeCycle = await resolveCandidateCycle(prisma);
 
     if (activeCycle && (activeCycle.startDate || activeCycle.endDate)) {
       const cycleStartDate = activeCycle.startDate ? new Date(activeCycle.startDate) : null;

--- a/server/src/routes/cycleActivation.routes.test.js
+++ b/server/src/routes/cycleActivation.routes.test.js
@@ -47,6 +47,24 @@ const request = (path, method, body) =>
   });
 
 const activeIds = () => rows.filter((row) => row.isActive).map((row) => row.id);
+const adminActiveIds = () => rows.filter((row) => row.isAdminActive).map((row) => row.id);
+
+// The real `where` for a two-audience activation is
+// `{ id: { not }, OR: [{ isActive: true }, { isAdminActive: true }] }`. Interpreting OR
+// here rather than special-casing one flag is what keeps this fake honest: a guard written
+// against `where.isActive` alone silently stops matching once the shape changes, and the
+// fake would start writing to every row while these assertions still passed.
+const matchesWhere = (row, where) => {
+  if (where.id?.not === row.id) return false;
+  if (Array.isArray(where.OR)) {
+    return where.OR.some((clause) =>
+      Object.entries(clause).every(([field, value]) => row[field] === value)
+    );
+  }
+  return Object.entries(where)
+    .filter(([field]) => field !== 'id')
+    .every(([field, value]) => row[field] === value);
+};
 
 beforeAll(async () => {
   const app = express();
@@ -79,20 +97,26 @@ beforeEach(() => {
         rows.push(row);
         return row;
       }),
+      findFirst: vi.fn(async ({ where }) => {
+        calls.push('find');
+        return rows.find((row) => matchesWhere(row, where)) ?? null;
+      }),
       updateMany: vi.fn(async ({ where, data }) => {
         calls.push('deactivate-others');
         let count = 0;
         rows.forEach((row, index) => {
-          if (where.id?.not === row.id) return;
-          if (where.isActive === true && !row.isActive) return;
+          if (!matchesWhere(row, where)) return;
           rows[index] = { ...row, ...data };
           count += 1;
         });
         return { count };
       }),
       update: vi.fn(async ({ where, data }) => {
-        calls.push(data.isActive === true ? 'activate' : 'update');
-        if (data.isActive === true && indexRejects) throw singleActiveViolation();
+        const activating = data.isActive === true || data.isAdminActive === true;
+        // A lone `isAdminActive: true` is the pin-before-split write, not an activation.
+        const pinning = data.isAdminActive === true && data.isActive === undefined && !data.name;
+        calls.push(activating ? (pinning ? 'pin-admin' : 'activate') : 'update');
+        if (activating && !pinning && indexRejects) throw singleActiveViolation();
         const index = rows.findIndex((row) => row.id === where.id);
         rows[index] = { ...rows[index], ...data };
         return rows[index];
@@ -130,6 +154,42 @@ describe('POST /api/admin/cycles/:id/activate', () => {
     expect(res.status).toBe(409);
     expect((await res.json()).error).toMatch(/activated at the same time/i);
     expect(activeIds()).toEqual(['current']);
+  });
+
+  it('claims both audiences when the body omits them', async () => {
+    const res = await request('/cycles/next/activate', 'POST');
+
+    expect(res.status).toBe(200);
+    expect(activeIds()).toEqual(['next']);
+    expect(adminActiveIds()).toEqual(['next']);
+  });
+
+  // The handover: members and candidates move, admins stay on the closing cycle.
+  it('pins admins to the outgoing cycle when activating for candidates alone', async () => {
+    const res = await request('/cycles/next/activate', 'POST', { audiences: ['CANDIDATE'] });
+
+    expect(res.status).toBe(200);
+    expect(activeIds()).toEqual(['next']);
+    expect(adminActiveIds()).toEqual(['current']);
+    expect(calls).toEqual(['find', 'find', 'pin-admin', 'deactivate-others', 'activate']);
+  });
+
+  it('sets the admin cycle without disturbing candidates', async () => {
+    const res = await request('/cycles/next/activate', 'POST', { audiences: ['ADMIN'] });
+
+    expect(res.status).toBe(200);
+    expect(activeIds()).toEqual(['current']);
+    expect(adminActiveIds()).toEqual(['next']);
+  });
+
+  it('rejects an empty or unknown audience instead of silently activating both', async () => {
+    for (const audiences of [[], ['EVERYONE'], 'CANDIDATE']) {
+      const res = await request('/cycles/next/activate', 'POST', { audiences });
+      expect(res.status).toBe(400);
+      // Nothing moved.
+      expect(activeIds()).toEqual(['current']);
+      expect(adminActiveIds()).toEqual([]);
+    }
   });
 });
 

--- a/server/src/routes/member.js
+++ b/server/src/routes/member.js
@@ -5,6 +5,7 @@ import { sendSlackMessage } from '../services/slackService.js';
 import { sendMeetingCancellationEmail } from '../services/emailNotifications.js';
 import { sendAndLogMeetingCommunication, MEETING_COMM_SUBJECTS } from '../services/meetingComms.js';
 import { localInputToUTC } from '../utils/timezoneUtils.js';
+import { resolveCycleForRequest, resolveCandidateCycle } from '../services/activeCycle.js';
 import {
   getGroupMemberUsers,
   getGroupMemberIds,
@@ -32,8 +33,12 @@ router.get('/events', requireAuth, async (req, res) => {
   try {
     const userId = req.user.id;
 
-    // Fetch all events with cycle for ordering/filtering
+    // Scope in SQL rather than loading every event ever created and filtering in JS.
+    const activeCycle = await resolveCycleForRequest(prisma, req);
+    if (!activeCycle) return res.json([]);
+
     const events = await prisma.events.findMany({
+      where: { cycleId: activeCycle.id },
       include: {
         cycle: true
       },
@@ -42,11 +47,9 @@ router.get('/events', requireAuth, async (req, res) => {
       }
     });
 
-    // Only include events from active cycles
-    const activeEvents = events.filter(event => event.cycle?.isActive);
 
     // Build a Set of eventIds this member RSVP'd to
-    const eventIds = activeEvents.map(e => e.id);
+    const eventIds = events.map(e => e.id);
     let rsvpsByEventId = new Set();
     if (eventIds.length > 0) {
       const memberRsvps = await prisma.memberEventRsvp.findMany({
@@ -59,7 +62,7 @@ router.get('/events', requireAuth, async (req, res) => {
       rsvpsByEventId = new Set(memberRsvps.map(r => r.eventId));
     }
 
-    const eventsWithStatus = activeEvents.map(event => ({
+    const eventsWithStatus = events.map(event => ({
       ...event,
       memberRsvpUrl: event.memberRsvpUrl || null,
       hasMemberRsvpd: rsvpsByEventId.has(event.id)
@@ -78,9 +81,7 @@ router.get('/all-applications', requireAuth, async (req, res) => {
     console.log('Fetching all applications for member:', req.user.id);
     
     // Get the active cycle first
-    const activeCycle = await prisma.recruitingCycle.findFirst({ 
-      where: { isActive: true } 
-    });
+    const activeCycle = await resolveCycleForRequest(prisma, req);
     
     console.log('Active cycle found:', activeCycle?.id);
     
@@ -416,9 +417,7 @@ router.get('/my-team', requireAuth, async (req, res) => {
     const userId = req.user.id;
     
     // Get the active cycle first
-    const activeCycle = await prisma.recruitingCycle.findFirst({ 
-      where: { isActive: true } 
-    });
+    const activeCycle = await resolveCycleForRequest(prisma, req);
     
     if (!activeCycle) {
       return res.json(null);
@@ -584,9 +583,7 @@ router.get('/interviews', requireAuth, async (req, res) => {
     const userId = req.user.id;
     
     // Get the active cycle first
-    const activeCycle = await prisma.recruitingCycle.findFirst({ 
-      where: { isActive: true } 
-    });
+    const activeCycle = await resolveCycleForRequest(prisma, req);
     
     if (!activeCycle) {
       return res.json([]);
@@ -935,7 +932,9 @@ router.put('/gtkuc-profile', requireAuth, requireAdminOrMember, async (req, res)
       return res.status(400).json({ error: 'Enter a LinkedIn profile URL, e.g. linkedin.com/in/your-handle' });
     }
 
-    const activeCycle = await prisma.recruitingCycle.findFirst({ where: { isActive: true } });
+    // Candidate pointer even for admin callers: the confirmation this writes is keyed
+    // (profileId, cycleId) and must match the cycle the gate checks.
+    const activeCycle = await resolveCandidateCycle(prisma);
 
     // Members may clear an auto-filled LinkedIn link, so an empty submission
     // overwrites rather than falling back to what was stored.
@@ -1245,9 +1244,7 @@ router.patch('/meeting-signups/:id/attendance', requireAuth, async (req, res) =>
 
         if (candidate && candidate.applications.length > 0) {
           // Get the latest application for the active cycle
-          const activeCycle = await prisma.recruitingCycle.findFirst({
-            where: { isActive: true }
-          });
+          const activeCycle = await resolveCycleForRequest(prisma, req);
 
           if (activeCycle) {
             const latestApplication = candidate.applications
@@ -1701,9 +1698,7 @@ router.post('/flag-document', requireAuth, async (req, res) => {
     }
 
     // Get the active cycle first
-    const activeCycle = await prisma.recruitingCycle.findFirst({ 
-      where: { isActive: true } 
-    });
+    const activeCycle = await resolveCycleForRequest(prisma, req);
 
     if (!activeCycle) {
       return res.status(400).json({ error: 'No active recruitment cycle found' });

--- a/server/src/routes/public.js
+++ b/server/src/routes/public.js
@@ -4,6 +4,8 @@ import { requireAuth } from '../middleware/auth.js';
 import { sendMeetingSignupConfirmation, sendMeetingSignupNotification, sendMeetingCancellationToMember } from '../services/emailNotifications.js';
 import { sendAndLogMeetingCommunication, MEETING_COMM_SUBJECTS } from '../services/meetingComms.js';
 import { toCandidateCard } from '../utils/gtkucProfile.js';
+// Public routes are candidate-facing by definition: no token, so no role to key on.
+import { resolveCandidateCycle } from '../services/activeCycle.js';
 
 const router = express.Router();
 
@@ -71,9 +73,7 @@ router.post('/meeting-slots/:id/signup', requireAuth, async (req, res) => {
     }
 
     // Get the active recruiting cycle to check for cycle-specific signups
-    const activeCycle = await prisma.recruitingCycle.findFirst({ 
-      where: { isActive: true } 
-    });
+    const activeCycle = await resolveCandidateCycle(prisma);
 
     // Check if user has already signed up for a meeting slot in the current cycle
     if (activeCycle && (activeCycle.startDate || activeCycle.endDate)) {
@@ -283,8 +283,13 @@ router.get('/events', async (req, res) => {
   try {
     const userEmail = req.query.userEmail; // Get user email from query parameter
     
+    // Scope in SQL rather than loading every event ever created and filtering in JS.
+    const activeCycle = await resolveCandidateCycle(prisma);
+    if (!activeCycle) return res.json([]);
+
     const events = await prisma.events.findMany({
       where: {
+        cycleId: activeCycle.id,
         showToCandidates: true // Only show events that are meant to be visible to candidates
       },
       include: {
@@ -305,9 +310,6 @@ router.get('/events', async (req, res) => {
       }
     });
 
-    // Filter to only show events from active cycles
-    const activeEvents = events.filter(event => event.cycle?.isActive);
-
     // Find the user by email to get their studentId (if provided)
     let user = null;
     if (userEmail) {
@@ -317,7 +319,7 @@ router.get('/events', async (req, res) => {
     }
 
     // Add RSVP and attendance status for each event
-    const eventsWithStatus = activeEvents.map(event => {
+    const eventsWithStatus = events.map(event => {
       let hasRsvpd = false;
       let hasAttended = false;
       
@@ -353,7 +355,11 @@ router.get('/events', async (req, res) => {
 // Get all events from active cycle for member timeline (no candidate visibility filter)
 router.get('/member/events', async (req, res) => {
   try {
+    const activeCycle = await resolveCandidateCycle(prisma);
+    if (!activeCycle) return res.json([]);
+
     const events = await prisma.events.findMany({
+      where: { cycleId: activeCycle.id },
       include: {
         cycle: true
       },
@@ -362,11 +368,8 @@ router.get('/member/events', async (req, res) => {
       }
     });
 
-    // Filter to only show events from active cycles
-    const activeEvents = events.filter(event => event.cycle?.isActive);
-
     // Ensure memberRsvpUrl is included in the response
-    const eventsWithMemberRsvp = activeEvents.map(event => ({
+    const eventsWithMemberRsvp = events.map(event => ({
       ...event,
       memberRsvpUrl: event.memberRsvpUrl || null
     }));
@@ -381,9 +384,7 @@ router.get('/member/events', async (req, res) => {
 // Public: get active recruiting cycle (for filtering meeting slots by cycle)
 router.get('/active-cycle', async (req, res) => {
   try {
-    const active = await prisma.recruitingCycle.findFirst({ 
-      where: { isActive: true } 
-    });
+    const active = await resolveCandidateCycle(prisma);
     res.json(active || null);
   } catch (error) {
     console.error('[GET /api/active-cycle]', error);

--- a/server/src/routes/reviewTeams.js
+++ b/server/src/routes/reviewTeams.js
@@ -11,16 +11,14 @@ import {
   buildCreateGroupData,
   groupMemberUserInclude
 } from '../utils/groupMembers.js';
+import { resolveCycleForRequest } from '../services/activeCycle.js';
 
 const router = express.Router();
 
 // Admin audit of each reviewer's grading contribution within their assigned team.
 router.get('/contributions', requireAuth, requireAdmin, async (req, res) => {
   try {
-    const activeCycle = await prisma.recruitingCycle.findFirst({
-      where: { isActive: true },
-      select: { id: true }
-    });
+    const activeCycle = await resolveCycleForRequest(prisma, req);
 
     if (!activeCycle) {
       return res.json([]);
@@ -113,10 +111,7 @@ router.post('/:groupId/reviewers/:reviewerId/reminder', requireAuth, requireAdmi
   try {
     const { groupId, reviewerId } = req.params;
 
-    const activeCycle = await prisma.recruitingCycle.findFirst({
-      where: { isActive: true },
-      select: { id: true, name: true }
-    });
+    const activeCycle = await resolveCycleForRequest(prisma, req);
 
     if (!activeCycle) {
       return res.status(400).json({ error: 'No active recruiting cycle' });
@@ -234,9 +229,7 @@ router.get('/', requireAuth, async (req, res) => {
     console.log('Review teams endpoint called');
     
     // Get the active cycle first
-    const activeCycle = await prisma.recruitingCycle.findFirst({ 
-      where: { isActive: true } 
-    });
+    const activeCycle = await resolveCycleForRequest(prisma, req);
     
     console.log('Active cycle found:', activeCycle?.id);
     
@@ -891,9 +884,7 @@ router.delete('/:groupId/members/:memberId', requireAuth, async (req, res) => {
 router.get('/available-applications', requireAuth, async (req, res) => {
   try {
     // Get the active cycle
-    const activeCycle = await prisma.recruitingCycle.findFirst({ 
-      where: { isActive: true } 
-    });
+    const activeCycle = await resolveCycleForRequest(prisma, req);
     
     if (!activeCycle) {
       return res.json([]);
@@ -979,9 +970,7 @@ router.get('/member/:memberId/candidates', requireAuth, async (req, res) => {
     const { memberId } = req.params;
     
     // Get the active cycle first
-    const activeCycle = await prisma.recruitingCycle.findFirst({ 
-      where: { isActive: true } 
-    });
+    const activeCycle = await resolveCycleForRequest(prisma, req);
     
     if (!activeCycle) {
       return res.json([]);
@@ -1054,9 +1043,7 @@ router.get('/member/:memberId/candidates', requireAuth, async (req, res) => {
 router.post('/auto-distribute', requireAuth, async (req, res) => {
   try {
     // Get the active cycle
-    const activeCycle = await prisma.recruitingCycle.findFirst({ 
-      where: { isActive: true } 
-    });
+    const activeCycle = await resolveCycleForRequest(prisma, req);
     
     if (!activeCycle) {
       return res.status(400).json({ error: 'No active cycle found' });
@@ -1171,9 +1158,7 @@ router.get('/member-applications/:memberId', requireAuth, async (req, res) => {
     console.log('Fetching applications for member:', memberId);
     
     // Get the active cycle first
-    const activeCycle = await prisma.recruitingCycle.findFirst({ 
-      where: { isActive: true } 
-    });
+    const activeCycle = await resolveCycleForRequest(prisma, req);
     
     console.log('Active cycle:', activeCycle?.id);
     
@@ -1582,9 +1567,7 @@ router.get('/resume-score/:candidateId', requireAuth, async (req, res) => {
 
     // If no cycleId provided, get the active cycle
     if (!cycleId) {
-      const activeCycle = await prisma.recruitingCycle.findFirst({
-        where: { isActive: true }
-      });
+      const activeCycle = await resolveCycleForRequest(prisma, req);
       if (activeCycle) {
         cycleId = activeCycle.id;
       }
@@ -1731,9 +1714,7 @@ router.get('/cover-letter-score/:candidateId', requireAuth, async (req, res) => 
 
     // If no cycleId provided, get the active cycle
     if (!cycleId) {
-      const activeCycle = await prisma.recruitingCycle.findFirst({
-        where: { isActive: true }
-      });
+      const activeCycle = await resolveCycleForRequest(prisma, req);
       if (activeCycle) {
         cycleId = activeCycle.id;
       }
@@ -1888,9 +1869,7 @@ router.get('/video-score/:candidateId', requireAuth, async (req, res) => {
 
     // If no cycleId provided, get the active cycle
     if (!cycleId) {
-      const activeCycle = await prisma.recruitingCycle.findFirst({
-        where: { isActive: true }
-      });
+      const activeCycle = await resolveCycleForRequest(prisma, req);
       if (activeCycle) {
         cycleId = activeCycle.id;
       }

--- a/server/src/services/activeCycle.js
+++ b/server/src/services/activeCycle.js
@@ -1,34 +1,132 @@
-// "At most one active recruiting cycle" is a database invariant, enforced by the
-// partial unique index `recruiting_cycles_single_active` on (isActive) WHERE
-// isActive. Application-level "deactivate everything, then activate this one"
-// cannot hold on its own: two concurrent requests each read a snapshot without
-// the other's row, so both would end up active.
+// Which recruiting cycle is "current" is audience-scoped: members, candidates and the
+// public pages follow `isActive`, while admins follow `isAdminActive`. They are normally
+// the same row and differ only during a handover, where admins finish out the closing
+// cycle while the next one opens to candidates.
 //
-// Every write that activates a cycle must go through this helper so the ordering
-// is the same everywhere (deactivate others first, activate last — the reverse
-// order trips the index within a single request), and must run inside a
-// transaction so a losing request leaves nothing behind.
+// "At most one active cycle per audience" is a database invariant, enforced by the partial
+// unique indexes `recruiting_cycles_single_active` on (isActive) WHERE isActive and
+// `recruiting_cycles_single_admin_active` on (isAdminActive) WHERE isAdminActive.
+// Application-level "deactivate everything, then activate this one" cannot hold on its own:
+// two concurrent requests each read a snapshot without the other's row, so both would end
+// up active.
+//
+// Every write that activates a cycle must go through activateCycleExclusively so the
+// ordering is the same everywhere (deactivate others first, activate last — the reverse
+// order trips the index within a single request), and must run inside a transaction so a
+// losing request leaves nothing behind.
+//
+// Every *read* must go through resolveCycle/resolveCycleForRequest rather than querying
+// either flag directly, so the audience rule lives in exactly one place.
+
+export const CYCLE_AUDIENCE = Object.freeze({
+  // Members, candidates, and unauthenticated public pages share one pointer. They are
+  // all looking at the cycle that is currently open to applicants.
+  CANDIDATE: 'CANDIDATE',
+  ADMIN: 'ADMIN'
+});
+
+const AUDIENCE_FLAG = Object.freeze({
+  [CYCLE_AUDIENCE.CANDIDATE]: 'isActive',
+  [CYCLE_AUDIENCE.ADMIN]: 'isAdminActive'
+});
+
+export const ALL_AUDIENCES = Object.freeze([CYCLE_AUDIENCE.CANDIDATE, CYCLE_AUDIENCE.ADMIN]);
 
 export const SINGLE_ACTIVE_CYCLE_INDEX = 'recruiting_cycles_single_active';
+export const SINGLE_ADMIN_ACTIVE_CYCLE_INDEX = 'recruiting_cycles_single_admin_active';
 
-export async function activateCycleExclusively(tx, cycleId) {
+export const isValidAudience = (value) => Object.hasOwn(AUDIENCE_FLAG, value);
+
+// MEMBER and USER both resolve to the candidate pointer. Keyed on the role rather than on
+// which router the request reached, because most /api/member/* routes carry only
+// requireAuth and reviewTeams has no router-level guard at all — a candidate's token can
+// land on a member route, and must still see the candidate cycle.
+export const audienceForRole = (role) =>
+  role === 'ADMIN' ? CYCLE_AUDIENCE.ADMIN : CYCLE_AUDIENCE.CANDIDATE;
+
+// `client` is always explicit and never defaults to the module-level prisma: callers inside
+// a $transaction must resolve against that transaction, not around it.
+export async function resolveCycle(client, audience = CYCLE_AUDIENCE.CANDIDATE) {
+  if (audience === CYCLE_AUDIENCE.ADMIN) {
+    const pinned = await client.recruitingCycle.findFirst({ where: { isAdminActive: true } });
+    // Unpinned means admins have not been split off yet, so they follow the candidate
+    // pointer. This fallback is what lets every part of this change deploy as a no-op.
+    if (pinned) return pinned;
+  }
+  return (await client.recruitingCycle.findFirst({ where: { isActive: true } })) || null;
+}
+
+export const resolveCandidateCycle = (client) => resolveCycle(client, CYCLE_AUDIENCE.CANDIDATE);
+export const resolveAdminCycle = (client) => resolveCycle(client, CYCLE_AUDIENCE.ADMIN);
+
+// Memoised per request (the promise, so concurrent callers share one query) because a
+// single handler often needs the cycle several times.
+const REQUEST_CYCLE_CACHE = Symbol('resolvedCycleByAudience');
+
+export function resolveCycleForRequest(client, req) {
+  const audience = audienceForRole(req?.user?.role);
+  if (!req) return resolveCycle(client, audience);
+
+  const cache = (req[REQUEST_CYCLE_CACHE] ??= {});
+  cache[audience] ??= resolveCycle(client, audience);
+  return cache[audience];
+}
+
+export async function activateCycleExclusively(tx, cycleId, audiences = ALL_AUDIENCES) {
+  const targets = [...new Set(audiences)];
+  if (!targets.length || !targets.every(isValidAudience)) {
+    throw new Error(`activateCycleExclusively: invalid audiences ${JSON.stringify(audiences)}`);
+  }
+
+  // Splitting the audiences for the first time. While nothing carries isAdminActive,
+  // admins are implicitly following isActive (see resolveCycle), so moving isActive below
+  // would silently drag them onto the new cycle — the exact opposite of "candidates only".
+  // Freeze them onto the cycle they are on now, in this same transaction.
+  //
+  // Only when nothing is pinned: once an admin cycle exists it is an explicit choice and
+  // must never be silently repointed.
+  if (targets.includes(CYCLE_AUDIENCE.CANDIDATE) && !targets.includes(CYCLE_AUDIENCE.ADMIN)) {
+    const pinned = await tx.recruitingCycle.findFirst({
+      where: { isAdminActive: true },
+      select: { id: true }
+    });
+    if (!pinned) {
+      const current = await tx.recruitingCycle.findFirst({
+        where: { isActive: true },
+        select: { id: true }
+      });
+      if (current && current.id !== cycleId) {
+        await tx.recruitingCycle.update({
+          where: { id: current.id },
+          data: { isAdminActive: true }
+        });
+      }
+    }
+  }
+
+  const flags = targets.map((audience) => AUDIENCE_FLAG[audience]);
+
   await tx.recruitingCycle.updateMany({
-    where: { id: { not: cycleId }, isActive: true },
-    data: { isActive: false }
+    where: { id: { not: cycleId }, OR: flags.map((flag) => ({ [flag]: true })) },
+    data: Object.fromEntries(flags.map((flag) => [flag, false]))
   });
   return tx.recruitingCycle.update({
     where: { id: cycleId },
-    data: { isActive: true }
+    data: Object.fromEntries(flags.map((flag) => [flag, true]))
   });
 }
 
-// A concurrent activation that would have produced a second active cycle fails
-// on the index rather than silently winning; callers surface that as a conflict.
+// A concurrent activation that would have produced a second active cycle fails on the
+// index rather than silently winning; callers surface that as a conflict.
 export const isActiveCycleConflict = (error) => {
   if (error?.code !== 'P2002') return false;
   const target = error.meta?.target;
   const targets = Array.isArray(target) ? target.join(',') : String(target ?? '');
-  return `${targets} ${error.message ?? ''}`.includes(SINGLE_ACTIVE_CYCLE_INDEX);
+  const haystack = `${targets} ${error.message ?? ''}`;
+  return (
+    haystack.includes(SINGLE_ACTIVE_CYCLE_INDEX) ||
+    haystack.includes(SINGLE_ADMIN_ACTIVE_CYCLE_INDEX)
+  );
 };
 
 export class ActiveCycleConflictError extends Error {

--- a/server/src/services/activeCycle.test.js
+++ b/server/src/services/activeCycle.test.js
@@ -1,16 +1,48 @@
 import { describe, it, expect } from 'vitest';
-import { activateCycleExclusively, isActiveCycleConflict, SINGLE_ACTIVE_CYCLE_INDEX } from './activeCycle.js';
+import {
+  activateCycleExclusively,
+  audienceForRole,
+  CYCLE_AUDIENCE,
+  isActiveCycleConflict,
+  resolveCycle,
+  resolveCycleForRequest,
+  SINGLE_ACTIVE_CYCLE_INDEX,
+  SINGLE_ADMIN_ACTIVE_CYCLE_INDEX
+} from './activeCycle.js';
 
-// Postgres stand-in with the two properties this invariant depends on:
+// Postgres stand-in with the properties this invariant depends on:
 //   * a statement never sees another transaction's uncommitted writes, so two
 //     concurrent activations both "deactivate everything" against the same
 //     committed state and neither clears the other's row;
-//   * the partial unique index the migration creates is checked on commit, so the
+//   * the partial unique indexes the migrations create are checked on commit, so the
 //     second transaction fails instead of producing a second active cycle.
 // Interleaving is explicit (both transactions run their statements before either
 // commits), which is what makes the regression deterministic.
+const FLAG_INDEX = {
+  isActive: SINGLE_ACTIVE_CYCLE_INDEX,
+  isAdminActive: SINGLE_ADMIN_ACTIVE_CYCLE_INDEX
+};
+
+// The real `where` is `{ id: { not }, OR: [{ isActive: true }, ...] }`. Interpreting OR
+// here rather than special-casing one flag is what keeps this fake honest: a guard written
+// against `where.isActive` alone silently stops matching and the fake starts writing to
+// every row while the assertions still pass.
+const matches = (row, where) => {
+  if (where.id?.not === row.id) return false;
+  if (Array.isArray(where.OR)) {
+    return where.OR.some((clause) =>
+      Object.entries(clause).every(([field, value]) => row[field] === value)
+    );
+  }
+  return Object.entries(where)
+    .filter(([field]) => field !== 'id')
+    .every(([field, value]) => row[field] === value);
+};
+
 const makeStore = (rows) => {
-  const committed = new Map(rows.map((row) => [row.id, { ...row }]));
+  const committed = new Map(
+    rows.map((row) => [row.id, { isActive: false, isAdminActive: false, ...row }])
+  );
 
   const begin = () => {
     const staged = new Map();
@@ -18,11 +50,17 @@ const makeStore = (rows) => {
 
     return {
       recruitingCycle: {
+        findFirst: async ({ where }) => {
+          for (const id of committed.keys()) {
+            const row = view(id);
+            if (matches(row, where)) return { ...row };
+          }
+          return null;
+        },
         updateMany: async ({ where, data }) => {
           let count = 0;
           for (const id of committed.keys()) {
-            if (where.id?.not === id) continue;
-            if (where.isActive === true && !committed.get(id).isActive) continue;
+            if (!matches(view(id), where)) continue;
             staged.set(id, { ...view(id), ...data });
             count += 1;
           }
@@ -38,19 +76,37 @@ const makeStore = (rows) => {
         const snapshot = new Map([...committed].map(([id, row]) => [id, { ...row }]));
         for (const [id, row] of staged) committed.set(id, row);
 
-        if ([...committed.values()].filter((row) => row.isActive).length > 1) {
-          committed.clear();
-          for (const [id, row] of snapshot) committed.set(id, row);
-          throw Object.assign(new Error(`Unique constraint failed on the fields: (\`${SINGLE_ACTIVE_CYCLE_INDEX}\`)`), {
-            code: 'P2002',
-            meta: { target: [SINGLE_ACTIVE_CYCLE_INDEX] }
-          });
+        for (const [flag, index] of Object.entries(FLAG_INDEX)) {
+          if ([...committed.values()].filter((row) => row[flag]).length > 1) {
+            committed.clear();
+            for (const [id, row] of snapshot) committed.set(id, row);
+            throw Object.assign(
+              new Error(`Unique constraint failed on the fields: (\`${index}\`)`),
+              { code: 'P2002', meta: { target: [index] } }
+            );
+          }
         }
       }
     };
   };
 
-  return { begin, activeIds: () => [...committed.values()].filter((row) => row.isActive).map((row) => row.id) };
+  const idsWith = (flag) =>
+    [...committed.values()].filter((row) => row[flag]).map((row) => row.id);
+
+  return {
+    begin,
+    activeIds: () => idsWith('isActive'),
+    adminActiveIds: () => idsWith('isAdminActive'),
+    // A read-only client, for driving resolveCycle against committed state.
+    client: {
+      recruitingCycle: {
+        findFirst: async ({ where }) => {
+          for (const row of committed.values()) if (matches(row, where)) return { ...row };
+          return null;
+        }
+      }
+    }
+  };
 };
 
 describe('activateCycleExclusively', () => {
@@ -63,6 +119,17 @@ describe('activateCycleExclusively', () => {
 
     expect(activated.isActive).toBe(true);
     expect(store.activeIds()).toEqual(['b']);
+  });
+
+  it('activates for both audiences by default', async () => {
+    const store = makeStore([{ id: 'a', isActive: true }, { id: 'b' }]);
+
+    const tx = store.begin();
+    await activateCycleExclusively(tx, 'b');
+    tx.commit();
+
+    expect(store.activeIds()).toEqual(['b']);
+    expect(store.adminActiveIds()).toEqual(['b']);
   });
 
   it('fails the loser of two concurrent activations instead of activating both', async () => {
@@ -91,10 +158,164 @@ describe('activateCycleExclusively', () => {
     expect(isActiveCycleConflict(conflict)).toBe(true);
     expect(store.activeIds()).toEqual(['b']);
   });
+
+  // The regression guard for the whole feature. If this breaks, "activate for members and
+  // candidates only" silently drags admins along, because an unpinned admin audience falls
+  // back to isActive.
+  it('pins admins to the outgoing cycle when candidates are activated alone', async () => {
+    const store = makeStore([
+      { id: 'winter', isActive: true },
+      { id: 'fall', isActive: false }
+    ]);
+
+    const tx = store.begin();
+    await activateCycleExclusively(tx, 'fall', [CYCLE_AUDIENCE.CANDIDATE]);
+    tx.commit();
+
+    expect(store.activeIds()).toEqual(['fall']);
+    expect(store.adminActiveIds()).toEqual(['winter']);
+    // And admins genuinely resolve to the outgoing cycle, not just carry a flag.
+    await expect(resolveCycle(store.client, CYCLE_AUDIENCE.ADMIN)).resolves.toMatchObject({
+      id: 'winter'
+    });
+  });
+
+  it('does not repoint an admin cycle that was already chosen explicitly', async () => {
+    const store = makeStore([
+      { id: 'winter', isActive: true, isAdminActive: false },
+      { id: 'fall2025', isAdminActive: true },
+      { id: 'fall', isActive: false }
+    ]);
+
+    const tx = store.begin();
+    await activateCycleExclusively(tx, 'fall', [CYCLE_AUDIENCE.CANDIDATE]);
+    tx.commit();
+
+    expect(store.activeIds()).toEqual(['fall']);
+    expect(store.adminActiveIds()).toEqual(['fall2025']);
+  });
+
+  it('leaves the candidate pointer untouched when activating for admins alone', async () => {
+    const store = makeStore([
+      { id: 'fall', isActive: true },
+      { id: 'winter', isActive: false }
+    ]);
+
+    const tx = store.begin();
+    await activateCycleExclusively(tx, 'winter', [CYCLE_AUDIENCE.ADMIN]);
+    tx.commit();
+
+    expect(store.activeIds()).toEqual(['fall']);
+    expect(store.adminActiveIds()).toEqual(['winter']);
+  });
+
+  it('rejects an empty or unknown audience rather than writing nothing', async () => {
+    const store = makeStore([{ id: 'a', isActive: true }]);
+
+    await expect(activateCycleExclusively(store.begin(), 'a', [])).rejects.toThrow(/invalid audiences/);
+    await expect(activateCycleExclusively(store.begin(), 'a', ['EVERYONE'])).rejects.toThrow(
+      /invalid audiences/
+    );
+  });
+});
+
+describe('resolveCycle', () => {
+  it('prefers the pinned admin cycle for the admin audience', async () => {
+    const store = makeStore([
+      { id: 'fall', isActive: true },
+      { id: 'winter', isAdminActive: true }
+    ]);
+
+    await expect(resolveCycle(store.client, CYCLE_AUDIENCE.ADMIN)).resolves.toMatchObject({ id: 'winter' });
+    await expect(resolveCycle(store.client, CYCLE_AUDIENCE.CANDIDATE)).resolves.toMatchObject({ id: 'fall' });
+  });
+
+  it('falls back to the candidate cycle when no admin cycle is pinned', async () => {
+    const store = makeStore([{ id: 'winter', isActive: true }]);
+
+    await expect(resolveCycle(store.client, CYCLE_AUDIENCE.ADMIN)).resolves.toMatchObject({ id: 'winter' });
+  });
+
+  it('returns null rather than throwing when nothing is active', async () => {
+    const store = makeStore([{ id: 'winter' }]);
+
+    await expect(resolveCycle(store.client, CYCLE_AUDIENCE.ADMIN)).resolves.toBeNull();
+    await expect(resolveCycle(store.client, CYCLE_AUDIENCE.CANDIDATE)).resolves.toBeNull();
+  });
+
+  it('defaults to the candidate audience', async () => {
+    const store = makeStore([
+      { id: 'fall', isActive: true },
+      { id: 'winter', isAdminActive: true }
+    ]);
+
+    await expect(resolveCycle(store.client)).resolves.toMatchObject({ id: 'fall' });
+  });
+});
+
+describe('audienceForRole', () => {
+  it('sends only ADMIN to the admin pointer', () => {
+    expect(audienceForRole('ADMIN')).toBe(CYCLE_AUDIENCE.ADMIN);
+    expect(audienceForRole('MEMBER')).toBe(CYCLE_AUDIENCE.CANDIDATE);
+    expect(audienceForRole('USER')).toBe(CYCLE_AUDIENCE.CANDIDATE);
+    expect(audienceForRole(undefined)).toBe(CYCLE_AUDIENCE.CANDIDATE);
+  });
+});
+
+describe('resolveCycleForRequest', () => {
+  const store = () =>
+    makeStore([
+      { id: 'fall', isActive: true },
+      { id: 'winter', isAdminActive: true }
+    ]);
+
+  it('keys on the role, not on which router the request reached', async () => {
+    const s = store();
+    await expect(resolveCycleForRequest(s.client, { user: { role: 'ADMIN' } })).resolves.toMatchObject({ id: 'winter' });
+    await expect(resolveCycleForRequest(s.client, { user: { role: 'MEMBER' } })).resolves.toMatchObject({ id: 'fall' });
+    await expect(resolveCycleForRequest(s.client, { user: { role: 'USER' } })).resolves.toMatchObject({ id: 'fall' });
+    // Unauthenticated public routes are candidate-facing.
+    await expect(resolveCycleForRequest(s.client, {})).resolves.toMatchObject({ id: 'fall' });
+  });
+
+  it('resolves once per request even when a handler asks repeatedly', async () => {
+    const s = store();
+    let calls = 0;
+    const counting = {
+      recruitingCycle: {
+        findFirst: async (args) => {
+          calls += 1;
+          return s.client.recruitingCycle.findFirst(args);
+        }
+      }
+    };
+    const req = { user: { role: 'MEMBER' } };
+
+    await Promise.all([
+      resolveCycleForRequest(counting, req),
+      resolveCycleForRequest(counting, req),
+      resolveCycleForRequest(counting, req)
+    ]);
+
+    expect(calls).toBe(1);
+  });
 });
 
 describe('isActiveCycleConflict', () => {
-  it('only claims the single-active index, not other unique violations', () => {
+  it('claims both single-active indexes', () => {
+    for (const index of [SINGLE_ACTIVE_CYCLE_INDEX, SINGLE_ADMIN_ACTIVE_CYCLE_INDEX]) {
+      expect(
+        isActiveCycleConflict(
+          Object.assign(new Error('Unique constraint failed'), {
+            code: 'P2002',
+            meta: { target: [index] }
+          })
+        )
+      ).toBe(true);
+    }
+  });
+
+  it('only claims the single-active indexes, not other unique violations', () => {
     expect(
       isActiveCycleConflict(
         Object.assign(new Error('Unique constraint failed'), {

--- a/server/src/services/cycleBootstrap.js
+++ b/server/src/services/cycleBootstrap.js
@@ -364,8 +364,11 @@ export async function commitCycleBootstrap({
       data: {
         name: name.trim(),
         // Activation is a separate, ordered step below; creating the row already
-        // active would trip the single-active index before others are cleared.
+        // active would trip the single-active indexes before others are cleared.
+        // A bootstrapped cycle is the new season for everyone, so it activates for
+        // both audiences — that is activateCycleExclusively's default.
         isActive: false,
+        isAdminActive: false,
         startDate: stages.applications_open ? stages.applications_open.start : null,
         endDate: stages.offers_released
           ? stages.offers_released.start

--- a/server/src/services/cycleBootstrap.test.js
+++ b/server/src/services/cycleBootstrap.test.js
@@ -179,13 +179,19 @@ describe('commitCycleBootstrap', () => {
     });
 
     expect(result.cycle.isActive).toBe(true);
+    // A bootstrapped cycle is the new season for everyone, so it clears and claims
+    // both audience pointers rather than only the candidate-facing one.
     expect(prisma.tx.recruitingCycle.updateMany).toHaveBeenCalledWith({
-      where: { id: { not: 'cycle-1' }, isActive: true },
-      data: { isActive: false }
+      where: {
+        id: { not: 'cycle-1' },
+        OR: [{ isActive: true }, { isAdminActive: true }]
+      },
+      data: { isActive: false, isAdminActive: false }
     });
     // The row is created inactive and activated last: the reverse order would
-    // trip the single-active index against the cycle still marked active.
+    // trip the single-active indexes against the cycle still marked active.
     expect(prisma.tx.recruitingCycle.create.mock.calls[0][0].data.isActive).toBe(false);
+    expect(prisma.tx.recruitingCycle.create.mock.calls[0][0].data.isAdminActive).toBe(false);
     expect(prisma.tx.recruitingCycle.updateMany.mock.invocationCallOrder[0]).toBeLessThan(
       prisma.tx.recruitingCycle.update.mock.invocationCallOrder[0]
     );

--- a/server/src/services/stagingSnapshot.js
+++ b/server/src/services/stagingSnapshot.js
@@ -1,6 +1,8 @@
 import prisma from '../prismaClient.js';
 import { getGroupMemberUsers } from '../utils/groupMembers.js';
 import { readSnapshotVersion } from '../utils/snapshotVersion.js';
+// Staging is an admin console surface, so it follows the admin cycle pointer.
+import { resolveAdminCycle } from './activeCycle.js';
 
 // The Staging console renders six resources as a single screen, so each of them has
 // to be readable through the same database transaction: that is what makes one
@@ -15,15 +17,11 @@ const SNAPSHOT_MAX_WAIT_MS = 10 * 1000;
 const SNAPSHOT_TIMEOUT_MS = 30 * 1000;
 
 export async function loadActiveCycle(client) {
-  return (await client.recruitingCycle.findFirst({ where: { isActive: true } })) || null;
+  return resolveAdminCycle(client);
 }
 
-export async function loadEvents(client) {
-  // Get the active cycle to filter events
-  const activeCycle = await client.recruitingCycle.findFirst({
-    where: { isActive: true },
-    select: { id: true }
-  });
+export async function loadEvents(client, cycle) {
+  const activeCycle = cycle ?? (await resolveAdminCycle(client));
 
   // Only return events from the active cycle (or empty if no active cycle)
   return client.events.findMany({
@@ -37,8 +35,8 @@ export async function loadEvents(client) {
   });
 }
 
-export async function loadReviewTeams(client) {
-  const active = await client.recruitingCycle.findFirst({ where: { isActive: true } });
+export async function loadReviewTeams(client, cycle) {
+  const active = cycle ?? (await resolveAdminCycle(client));
   if (!active) return [];
 
   const reviewTeams = await client.groups.findMany({
@@ -77,8 +75,8 @@ export async function loadReviewTeams(client) {
   });
 }
 
-export async function loadExistingDecisions(client) {
-  const active = await client.recruitingCycle.findFirst({ where: { isActive: true } });
+export async function loadExistingDecisions(client, cycle) {
+  const active = cycle ?? (await resolveAdminCycle(client));
   if (!active) {
     return { decisions: {}, perRoundDecisions: { resume: {}, coffee: {}, firstRound: {}, final: {} } };
   }
@@ -129,14 +127,11 @@ export async function loadExistingDecisions(client) {
   return { decisions, perRoundDecisions };
 }
 
-export async function loadStagingCandidates(client, { page, limit } = {}) {
+export async function loadStagingCandidates(client, { page, limit, cycle } = {}) {
   const usePagination = Boolean(page && limit);
   const skip = usePagination ? (page - 1) * limit : 0;
 
-  const active = await client.recruitingCycle.findFirst({
-    where: { isActive: true },
-    select: { id: true, startDate: true, endDate: true }
-  });
+  const active = cycle ?? (await resolveAdminCycle(client));
   console.log('Active cycle:', active ? active.id : 'No active cycle found');
   if (!active) {
     return { candidates: [], total: 0, page: usePagination ? page : 1, totalPages: 0, hasNextPage: false, hasPrevPage: false };
@@ -458,13 +453,11 @@ export async function loadStagingCandidates(client, { page, limit } = {}) {
   };
 }
 
-export async function loadAdminApplications(client, { page, limit } = {}) {
+export async function loadAdminApplications(client, { page, limit, cycle } = {}) {
   const usePagination = Boolean(page && limit);
   const skip = usePagination ? (page - 1) * limit : 0;
 
-  const activeCycle = await client.recruitingCycle.findFirst({
-    where: { isActive: true }
-  });
+  const activeCycle = cycle ?? (await resolveAdminCycle(client));
 
   if (!activeCycle) {
     return { applications: [], total: 0, page: usePagination ? page : 1, totalPages: 0, hasNextPage: false, hasPrevPage: false };
@@ -732,12 +725,15 @@ export async function loadStagingSnapshot(client = prisma) {
       // the point in time the reads below are consistent as of.
       const snapshotVersion = await readSnapshotVersion(tx);
 
-      const candidates = await loadStagingCandidates(tx);
+      // Resolve the cycle once and thread it through: six independent lookups inside
+      // one transaction could not disagree, but they were six round trips for one answer.
       const activeCycle = await loadActiveCycle(tx);
-      const applications = await loadAdminApplications(tx);
-      const events = await loadEvents(tx);
-      const reviewTeams = await loadReviewTeams(tx);
-      const existingDecisions = await loadExistingDecisions(tx);
+
+      const candidates = await loadStagingCandidates(tx, { cycle: activeCycle });
+      const applications = await loadAdminApplications(tx, { cycle: activeCycle });
+      const events = await loadEvents(tx, activeCycle);
+      const reviewTeams = await loadReviewTeams(tx, activeCycle);
+      const existingDecisions = await loadExistingDecisions(tx, activeCycle);
 
       return {
         snapshotVersion,

--- a/server/src/services/syncResponses.js
+++ b/server/src/services/syncResponses.js
@@ -3,13 +3,16 @@ import config from '../config.js';
 import { getResponses } from './google/forms.js'
 import { transformFormResponse } from '../utils/dataMapper.js'
 import { extractFormIdFromUrl } from '../utils/formUtils.js'
+import { resolveCandidateCycle } from './activeCycle.js'
 
 export default async function syncFormResponses() {
   try {
     console.log('Fetching new responses from Google Forms...');
 
-    // Require an active cycle and use its form URL exclusively
-    const activeCycle = await prisma.recruitingCycle.findFirst({ where: { isActive: true } });
+    // Require an active cycle and use its form URL exclusively.
+    // Always the candidate pointer: applications belong to the cycle candidates are
+    // applying to, and this cron has no request or role to key on.
+    const activeCycle = await resolveCandidateCycle(prisma);
     if (!activeCycle) {
       console.warn('No active recruiting cycle. Skipping sync.');
       return;

--- a/server/src/utils/gtkucProfileState.js
+++ b/server/src/utils/gtkucProfileState.js
@@ -3,6 +3,7 @@
 // admin console open timeslots and must apply the same per-cycle gate.
 import prisma from '../prismaClient.js';
 import { needsCycleConfirmation } from './gtkucProfile.js';
+import { resolveCandidateCycle } from '../services/activeCycle.js';
 
 export const loadGtkucProfileState = async (userId) => {
   const [user, activeCycle] = await Promise.all([
@@ -10,7 +11,10 @@ export const loadGtkucProfileState = async (userId) => {
       where: { id: userId },
       select: { id: true, fullName: true, profileImage: true, graduationClass: true }
     }),
-    prisma.recruitingCycle.findFirst({ where: { isActive: true } })
+    // Candidate pointer even for admin callers: GTKUC is a candidate-facing
+    // obligation, and MemberGtkucProfileConfirmation is unique per (profile, cycle),
+    // so a confirmation written against the admin cycle would never clear the gate.
+    resolveCandidateCycle(prisma)
   ]);
 
   const profile = await prisma.memberGtkucProfile.findUnique({


### PR DESCRIPTION
## What and why

Today there is exactly one active recruiting cycle, shared by every role, and the database enforces it with a partial unique index on `isActive`. That single pointer is now a problem: the admin team needs to keep working in **Winter 2026** (294 applications, 12 events, 13 groups, 6 interviews) while members and candidates move onto the new **Fall 2026** cycle.

> When we set a cycle as an "active" cycle in the admin UI, I should be able to control whether that cycle is "active" for members, users, and admin, or just active for members and users.

This is a permanent capability, not a one-off migration — every future handover has the same shape.

## Approach

`RecruitingCycle` gains `isAdminActive` alongside `isActive`, each guarded by its own partial unique index. `isActive` keeps its name and meaning (members, candidates, public pages); `isAdminActive` is the admin pointer.

**Renaming `isActive` was considered and rejected.** Prisma serializes field names straight into JSON, so a rename breaks the public `/api/active-cycle` contract and every client reader, forcing a synchronized server+client big-bang for no behavioural gain.

Reads now go through one resolver in `services/activeCycle.js` instead of the **40** inlined `findFirst({ where: { isActive: true } })` lookups. It keys on the caller's **role**, not on which router the request reached — most `/api/member/*` routes carry only `requireAuth` and `reviewTeams.js` has no router-level guard, so a candidate's token can land on a member route and must still resolve to the candidate cycle.

Pinned to the candidate pointer regardless of caller:
- unauthenticated public routes
- the Google Forms sync cron (applications belong to the cycle candidates apply to)
- GTKUC confirmation — it is keyed `(profileId, cycleId)`, so an admin's confirmation landing in the admin cycle would never clear the gate that checks the candidate one

## The ordering rule this depends on

Activating for candidates alone **first pins the outgoing cycle as admin-active, in the same transaction**. Without that, an unpinned admin audience falls back to `isActive` and gets dragged along by the very move meant to leave it behind — the exact opposite of "members only". It only pins when nothing is pinned; an explicit admin cycle is never silently repointed.

There is a dedicated regression test for this, and it was verified to fail (`expected [] to deeply equal ['winter']`) when the guard is disabled.

## Two regressions this avoids

Both are sites where silently narrowing to the candidate pointer would have been a *new* bug introduced by this change:

- **User deactivation** now checks the union of both pointers. Otherwise you could retire a member still staffed on the admin cycle's review teams.
- **`talent-pool/stats`** defaulted admins to the cycle candidates see.

## Ships as a no-op

Nothing carries `isAdminActive`, and the admin branch falls back to `isActive`, so every audience resolves exactly as before until someone splits them deliberately. Verified against the live database: both audiences currently resolve to Winter 2026.

The migration is purely additive — one column, one index, no drops, renames, type changes or backfills. On PostgreSQL 11+ (this DB is 17.4) `ADD COLUMN` with a non-volatile default is metadata-only, so no table rewrite.

**Note:** the migration has already been applied to the shared Supabase database, so branches without this code will report drift until it merges. It is benign — additive column, default false, nothing reads it.

## UI

- **Cycle Management**: a summary strip (`Members & candidates: … · Admins: …`), two audience columns replacing the single Active column, and an `Activate…` dialog with three choices — everyone / members & candidates only / admins only — warning when a split is selected.
- **`CycleScopeBanner`**: persistent amber banner on admin pages, rendered only when the pointers differ, because admin-created events, interviews and review teams are stamped with the admin cycle and would otherwise be invisible to members.

## Testing

- Server: **248 passing** (2 pre-existing `offerLetter` failures, confirmed on a clean tree)
- Client: **230/230 passing, 28/28 files**
- Resolver verified against the live database for both audiences and all three roles

To exercise the split: activate Winter 2026 for *Admins only*, then Fall 2026 for *Members & candidates only*. Expect `Winter | f | t` and `Fall | t | f`.

Because Fall 2026 is empty and has no `formUrl`, after the flip member/candidate surfaces go empty and the sync cron logs `Active cycle has no valid Google Form URL. Skipping sync.` That gap is known and accepted; it is recoverable, since `existingResponseIds` dedupes globally across all applications.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TqvMV3C4c95EswTF7tz3py
