### PR TITLE
Talent Partner Network: client resume portal

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { Route, Routes, Navigate } from 'react-router-dom';
+import { Route, Routes, Navigate, useLocation } from 'react-router-dom';
 import ApplicationList from './pages/ApplicationList';
 import ApplicationDetail from './pages/ApplicationDetail';
 import Login from './pages/Login';
@@ -7,6 +7,7 @@ import SignUp from './pages/SignUp';
 import MemberSignUp from './pages/MemberSignUp';
 import Layout from './components/Layout';
 import CandidateLayout from './components/CandidateLayout';
+import ClientLayout from './components/ClientLayout';
 import { AuthProvider, useAuth } from './context/AuthContext';
 import { DataProvider } from './context/DataContext';
 import { CelebrationProvider } from './context/CelebrationContext';
@@ -47,13 +48,15 @@ import CandidateList from './pages/CandidateList';
 import CandidateDetail from './pages/CandidateDetail';
 import MasterCommunications from './pages/MasterCommunications';
 import Profile from './pages/Profile';
+import ClientResumeLibrary from './pages/ClientResumeLibrary';
 import NotFound from './pages/NotFound';
 import PausedLanding from './pages/PausedLanding';
 import './styles/variables.css';
 // Protected Route wrapper for admin/member users
 const ProtectedRoute = ({ children }) => {
   const { user, loading } = useAuth();
-  
+  const location = useLocation();
+
   if (loading) {
     return <div>Loading...</div>;
   }
@@ -62,11 +65,21 @@ const ProtectedRoute = ({ children }) => {
     return <Navigate to="/login" />;
   }
   
+  // Talent Partner Network clients have exactly one page. Without this they
+  // fall through to the admin Layout below - not a data leak, since every API
+  // call 403s for them, but it would show them a sidebar full of staff tooling.
+  if (user.role === 'CLIENT') {
+    if (location.pathname !== '/partner/resumes') {
+      return <Navigate to="/partner/resumes" replace />;
+    }
+    return <ClientLayout>{children}</ClientLayout>;
+  }
+
   // Use different layouts based on user role
   if (user.role === 'USER') {
     return <CandidateLayout>{children}</CandidateLayout>;
   }
-  
+
   return <Layout>{children}</Layout>;
 };
 
@@ -76,6 +89,10 @@ const HomeRoute = () => {
 
   if (loading) {
     return <div>Loading...</div>;
+  }
+
+  if (user?.role === 'CLIENT') {
+    return <Navigate to="/partner/resumes" replace />;
   }
 
   if (user?.role === 'ADMIN' || user?.role === 'MEMBER') {
@@ -358,6 +375,16 @@ const AppRoutes = () => {
         }
       />
       
+      {/* Talent Partner Network client portal - one page, its own shell */}
+      <Route
+        path="/partner/resumes"
+        element={
+          <ProtectedRoute>
+            <ClientResumeLibrary />
+          </ProtectedRoute>
+        }
+      />
+
       <Route path="/forgot-password" element={<ForgotPassword />} />
       <Route path="/reset-password" element={<ResetPassword />} />
       {/* Public meeting signup page */}

--- a/client/src/components/ClientAssignBuilder.jsx
+++ b/client/src/components/ClientAssignBuilder.jsx
@@ -1,0 +1,423 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  Alert,
+  AlertTitle,
+  Autocomplete,
+  Box,
+  Button,
+  Checkbox,
+  Chip,
+  CircularProgress,
+  FormControl,
+  IconButton,
+  InputLabel,
+  MenuItem,
+  Paper,
+  Select,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  TextField,
+  Typography,
+} from '@mui/material';
+import AddIcon from '@mui/icons-material/Add';
+import DeleteIcon from '@mui/icons-material/Delete';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import apiClient from '../utils/api';
+
+// Filter builder for assigning resumes to one partner client.
+//
+// Rows AND together; values within a row OR. That is the whole grammar, and it
+// covers "class of 2030 AND female" without a nested boolean editor that is
+// easy to misread and therefore easy to over-share with.
+//
+// Preview is an explicit button rather than live-per-keystroke: the codebase's
+// own convention (ApplicationList's pending-vs-applied filters), and running a
+// `contains` sweep over free-text major columns on every keystroke is a bad
+// idea on a table this size.
+
+const POOLS = [
+  { value: 'APPLICANTS', label: 'Applicants' },
+  { value: 'MEMBERS', label: 'Members' },
+  { value: 'BOTH', label: 'Applicants and members' },
+];
+
+const NUMBER_OPS = [
+  { value: 'gte', label: 'at least' },
+  { value: 'lte', label: 'at most' },
+];
+
+const emptyRow = () => ({ field: '', values: [], op: 'gte', value: '', boolValue: true });
+
+const ClientAssignBuilder = ({ client, onDone }) => {
+  const [fields, setFields] = useState([]);
+  const [options, setOptions] = useState({});
+  const [pool, setPool] = useState('APPLICANTS');
+  const [rows, setRows] = useState([emptyRow()]);
+  const [preview, setPreview] = useState(null);
+  const [checked, setChecked] = useState(() => new Set());
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [note, setNote] = useState('');
+
+  useEffect(() => {
+    apiClient
+      .get('/admin/talent-pool/filter-fields')
+      .then((data) => {
+        setFields(data.fields || []);
+        setOptions(data.options || {});
+      })
+      .catch((err) => setError(err.message || 'Failed to load filter options'));
+  }, []);
+
+  const fieldByKey = useMemo(() => new Map(fields.map((f) => [f.key, f])), [fields]);
+
+  const buildFilter = useCallback(
+    () => ({
+      pool,
+      rows: rows
+        .filter((r) => r.field)
+        .map((r) => {
+          const field = fieldByKey.get(r.field);
+          if (!field) return null;
+          if (field.type === 'number') return { field: r.field, op: r.op, value: r.value };
+          if (field.type === 'bool') return { field: r.field, value: r.boolValue };
+          return { field: r.field, values: r.values };
+        })
+        .filter(Boolean),
+    }),
+    [pool, rows, fieldByKey]
+  );
+
+  const runPreview = async () => {
+    setLoading(true);
+    setError('');
+    try {
+      const data = await apiClient.post(`/admin/talent-pool/clients/${client.id}/preview`, {
+        filter: buildFilter(),
+      });
+      setPreview(data);
+      // Everything eligible starts checked; the admin trims down rather than up.
+      setChecked(new Set((data.rows || []).filter((r) => !r.alreadyAssigned).map((r) => r.key)));
+    } catch (err) {
+      setError(err.message || 'Failed to preview matches');
+      setPreview(null);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const commit = async () => {
+    setLoading(true);
+    setError('');
+    try {
+      // Only the keys still checked are sent. The server never re-runs the
+      // filter, so this trim is what actually gets assigned.
+      const data = await apiClient.post(`/admin/talent-pool/clients/${client.id}/assign`, {
+        keys: [...checked],
+        filter: buildFilter(),
+        note: note || null,
+      });
+      const skippedNote = data.skipped?.length ? ` ${data.skipped.length} skipped.` : '';
+      window.alert(`Assigned ${data.created} resume(s) to ${client.organization}.${skippedNote}`);
+      onDone();
+    } catch (err) {
+      setError(err.message || 'Failed to assign resumes');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const updateRow = (index, patch) =>
+    setRows(rows.map((r, i) => (i === index ? { ...r, ...patch } : r)));
+
+  const usedFields = new Set(rows.map((r) => r.field).filter(Boolean));
+
+  const toggle = (key) => {
+    const next = new Set(checked);
+    if (next.has(key)) next.delete(key);
+    else next.add(key);
+    setChecked(next);
+  };
+
+  const eligibleRows = (preview?.rows || []).filter((r) => !r.alreadyAssigned);
+  const allChecked = eligibleRows.length > 0 && eligibleRows.every((r) => checked.has(r.key));
+
+  return (
+    <Box>
+      <Stack direction="row" alignItems="center" spacing={1} sx={{ mb: 2 }}>
+        <IconButton onClick={onDone} size="small">
+          <ArrowBackIcon />
+        </IconButton>
+        <Box>
+          <Typography variant="h6">Assign resumes to {client.organization}</Typography>
+          <Typography variant="body2" color="text.secondary">
+            Visibility: {client.visibility}. Only applicants who opted in to the Talent Partner
+            Network can be assigned.
+          </Typography>
+        </Box>
+      </Stack>
+
+      {error && (
+        <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError('')}>
+          {error}
+        </Alert>
+      )}
+
+      <Paper sx={{ p: 2, mb: 3 }}>
+        <Stack spacing={2}>
+          <FormControl size="small" sx={{ maxWidth: 280 }}>
+            <InputLabel id="assign-pool-label">Pool</InputLabel>
+            <Select
+              labelId="assign-pool-label"
+              value={pool}
+              label="Pool"
+              onChange={(e) => setPool(e.target.value)}
+            >
+              {POOLS.map((p) => (
+                <MenuItem key={p.value} value={p.value}>
+                  {p.label}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+
+          {rows.map((row, index) => {
+            const field = fieldByKey.get(row.field);
+            return (
+              <Stack key={index} direction={{ xs: 'column', md: 'row' }} spacing={1} alignItems="center">
+                <FormControl size="small" sx={{ minWidth: 200 }}>
+                  <InputLabel id={`assign-field-label-${index}`}>Field</InputLabel>
+                  <Select
+                    labelId={`assign-field-label-${index}`}
+                    value={row.field}
+                    label="Field"
+                    onChange={(e) => updateRow(index, { field: e.target.value, values: [], value: '' })}
+                  >
+                    {fields.map((f) => (
+                      <MenuItem key={f.key} value={f.key} disabled={usedFields.has(f.key) && f.key !== row.field}>
+                        {f.label}
+                        {f.pool === 'applicants' ? ' (applicants only)' : ''}
+                      </MenuItem>
+                    ))}
+                  </Select>
+                </FormControl>
+
+                {field && (field.type === 'multiText' || field.type === 'multiId') && (
+                  <Autocomplete
+                    multiple
+                    size="small"
+                    sx={{ flex: 1, minWidth: 260 }}
+                    options={(options[field.key] || []).map((o) =>
+                      typeof o === 'string' ? o : o.value
+                    )}
+                    getOptionLabel={(opt) => {
+                      const list = options[field.key] || [];
+                      const match = list.find((o) => typeof o !== 'string' && o.value === opt);
+                      return match ? match.label : String(opt);
+                    }}
+                    value={row.values}
+                    onChange={(_, v) => updateRow(index, { values: v })}
+                    renderInput={(params) => (
+                      <TextField {...params} label="Any of" placeholder="Select one or more" />
+                    )}
+                  />
+                )}
+
+                {field && field.type === 'number' && (
+                  <>
+                    <FormControl size="small" sx={{ minWidth: 140 }}>
+                      <InputLabel id={`assign-op-label-${index}`}>Comparison</InputLabel>
+                      <Select
+                        labelId={`assign-op-label-${index}`}
+                        value={row.op}
+                        label="Comparison"
+                        onChange={(e) => updateRow(index, { op: e.target.value })}
+                      >
+                        {NUMBER_OPS.map((o) => (
+                          <MenuItem key={o.value} value={o.value}>
+                            {o.label}
+                          </MenuItem>
+                        ))}
+                      </Select>
+                    </FormControl>
+                    <TextField
+                      size="small"
+                      label="Value"
+                      placeholder="3.50"
+                      value={row.value}
+                      onChange={(e) => updateRow(index, { value: e.target.value })}
+                    />
+                  </>
+                )}
+
+                {field && field.type === 'bool' && (
+                  <FormControl size="small" sx={{ minWidth: 140 }}>
+                    <InputLabel id={`assign-bool-label-${index}`}>Is</InputLabel>
+                    <Select
+                      labelId={`assign-bool-label-${index}`}
+                      value={row.boolValue ? 'yes' : 'no'}
+                      label="Is"
+                      onChange={(e) => updateRow(index, { boolValue: e.target.value === 'yes' })}
+                    >
+                      <MenuItem value="yes">Yes</MenuItem>
+                      <MenuItem value="no">No</MenuItem>
+                    </Select>
+                  </FormControl>
+                )}
+
+                <IconButton
+                  onClick={() => setRows(rows.length === 1 ? [emptyRow()] : rows.filter((_, i) => i !== index))}
+                  size="small"
+                  aria-label="Remove filter row"
+                >
+                  <DeleteIcon fontSize="small" />
+                </IconButton>
+              </Stack>
+            );
+          })}
+
+          <Stack direction="row" spacing={1}>
+            <Button size="small" startIcon={<AddIcon />} onClick={() => setRows([...rows, emptyRow()])}>
+              Add filter
+            </Button>
+            <Button variant="contained" onClick={runPreview} disabled={loading}>
+              Preview matches
+            </Button>
+          </Stack>
+
+          <Typography variant="caption" color="text.secondary">
+            Filters combine with AND. Multiple values in one filter combine with OR.
+          </Typography>
+        </Stack>
+      </Paper>
+
+      {loading && (
+        <Box sx={{ display: 'flex', justifyContent: 'center', p: 4 }}>
+          <CircularProgress />
+        </Box>
+      )}
+
+      {preview && !loading && (
+        <Paper sx={{ p: 2 }}>
+          <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mb: 1 }}>
+            <Typography variant="subtitle1">
+              {preview.total} match{preview.total === 1 ? '' : 'es'}
+              {preview.truncated ? ` (showing the first ${preview.rows.length})` : ''}
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              {checked.size} selected
+            </Typography>
+          </Stack>
+
+          {(preview.excluded?.noOptIn > 0 ||
+            preview.excluded?.noBlindResume > 0 ||
+            preview.excluded?.memberNoConsent > 0) && (
+            <Alert severity="info" sx={{ mb: 2 }}>
+              <AlertTitle>Excluded from these matches</AlertTitle>
+              <Stack spacing={0.5}>
+                {preview.excluded.noOptIn > 0 && (
+                  <Typography variant="body2">
+                    {preview.excluded.noOptIn} did not opt in to the Talent Partner Network.
+                  </Typography>
+                )}
+                {preview.excluded.noBlindResume > 0 && (
+                  <Typography variant="body2">
+                    {preview.excluded.noBlindResume} have no redacted resume, and this client is
+                    blind-visibility.
+                  </Typography>
+                )}
+                {preview.excluded.memberNoConsent > 0 && (
+                  <Typography variant="body2">
+                    {preview.excluded.memberNoConsent} member(s) have not consented to sharing.
+                  </Typography>
+                )}
+              </Stack>
+            </Alert>
+          )}
+
+          {preview.notes?.length > 0 && (
+            <Alert severity="warning" sx={{ mb: 2 }}>
+              <Stack spacing={0.5}>
+                {preview.notes.map((n, i) => (
+                  <Typography variant="body2" key={i}>
+                    {n}
+                  </Typography>
+                ))}
+              </Stack>
+            </Alert>
+          )}
+
+          <TableContainer sx={{ maxHeight: 460 }}>
+            <Table size="small" stickyHeader>
+              <TableHead>
+                <TableRow>
+                  <TableCell padding="checkbox">
+                    <Checkbox
+                      checked={allChecked}
+                      indeterminate={checked.size > 0 && !allChecked}
+                      onChange={() =>
+                        setChecked(allChecked ? new Set() : new Set(eligibleRows.map((r) => r.key)))
+                      }
+                      inputProps={{ 'aria-label': 'Select all matches' }}
+                    />
+                  </TableCell>
+                  <TableCell>Name</TableCell>
+                  <TableCell>Type</TableCell>
+                  <TableCell>Class</TableCell>
+                  <TableCell>Major</TableCell>
+                  <TableCell>Gender</TableCell>
+                  <TableCell>GPA</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {preview.rows.map((row) => (
+                  <TableRow key={row.key} hover selected={checked.has(row.key)}>
+                    <TableCell padding="checkbox">
+                      <Checkbox
+                        checked={checked.has(row.key)}
+                        disabled={row.alreadyAssigned}
+                        onChange={() => toggle(row.key)}
+                        inputProps={{ 'aria-label': `Select ${row.name}` }}
+                      />
+                    </TableCell>
+                    <TableCell>
+                      {row.name}
+                      {row.alreadyAssigned && (
+                        <Chip size="small" label="Already shared" sx={{ ml: 1 }} variant="outlined" />
+                      )}
+                    </TableCell>
+                    <TableCell>{row.kind === 'MEMBER' ? 'Member' : 'Applicant'}</TableCell>
+                    <TableCell>{row.graduationYear || '—'}</TableCell>
+                    <TableCell>{[row.major1, row.major2].filter(Boolean).join(', ') || '—'}</TableCell>
+                    <TableCell>{row.gender || '—'}</TableCell>
+                    <TableCell>{row.cumulativeGpa || '—'}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </TableContainer>
+
+          <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2} alignItems="center" sx={{ mt: 2 }}>
+            <TextField
+              size="small"
+              label="Batch note (internal)"
+              value={note}
+              onChange={(e) => setNote(e.target.value)}
+              sx={{ flex: 1 }}
+            />
+            <Button variant="contained" disabled={checked.size === 0 || loading} onClick={commit}>
+              Assign {checked.size} resume{checked.size === 1 ? '' : 's'}
+            </Button>
+          </Stack>
+        </Paper>
+      )}
+    </Box>
+  );
+};
+
+export default ClientAssignBuilder;

--- a/client/src/components/ClientAssignBuilder.test.jsx
+++ b/client/src/components/ClientAssignBuilder.test.jsx
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ClientAssignBuilder from './ClientAssignBuilder';
+import apiClient from '../utils/api';
+
+const client = { id: 'partner-1', organization: 'Acme Recruiting', visibility: 'BASIC' };
+
+const FIELDS = [
+  { key: 'graduationYear', label: 'Graduation year', pool: 'both', type: 'multiText' },
+  { key: 'gender', label: 'Gender', pool: 'both', type: 'multiText' },
+  { key: 'cumulativeGpa', label: 'Cumulative GPA', pool: 'applicants', type: 'number' },
+];
+
+const OPTIONS = {
+  graduationYear: ['2029', '2030'],
+  gender: ['Female', 'Male', 'Other'],
+};
+
+const previewRows = [
+  { key: 'APPLICATION:app-1', kind: 'APPLICANT', name: 'Jane Doe', graduationYear: '2030', major1: 'Econ', gender: 'Female', alreadyAssigned: false },
+  { key: 'APPLICATION:app-2', kind: 'APPLICANT', name: 'Ada Lovelace', graduationYear: '2030', major1: 'CS', gender: 'Female', alreadyAssigned: false },
+  { key: 'APPLICATION:app-3', kind: 'APPLICANT', name: 'Grace Hopper', graduationYear: '2030', major1: 'Math', gender: 'Female', alreadyAssigned: true },
+];
+
+const mockApi = (previewOverrides = {}) => {
+  apiClient.get = vi.fn(() => Promise.resolve({ fields: FIELDS, options: OPTIONS }));
+  apiClient.post = vi.fn((url) => {
+    if (url.includes('/preview')) {
+      return Promise.resolve({
+        rows: previewRows,
+        total: previewRows.length,
+        truncated: false,
+        excluded: { noOptIn: 4, noBlindResume: 0, memberNoConsent: 0 },
+        notes: [],
+        visibility: 'BASIC',
+        ...previewOverrides,
+      });
+    }
+    return Promise.resolve({ batchId: 'batch-1', created: 2, skipped: [] });
+  });
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  apiClient.token = 'test-token';
+  vi.spyOn(window, 'alert').mockImplementation(() => {});
+});
+
+const setUpPreview = async () => {
+  const user = userEvent.setup();
+  render(<ClientAssignBuilder client={client} onDone={vi.fn()} />);
+
+  await waitFor(() => expect(apiClient.get).toHaveBeenCalled());
+
+  await user.click(screen.getByLabelText('Field'));
+  await user.click(await screen.findByRole('option', { name: /Graduation year/ }));
+
+  await user.click(screen.getByRole('button', { name: /preview matches/i }));
+  await screen.findByText(/3 matches/i);
+  return user;
+};
+
+describe('ClientAssignBuilder', () => {
+  it('posts the filter rows to preview', async () => {
+    mockApi();
+    const user = userEvent.setup();
+    render(<ClientAssignBuilder client={client} onDone={vi.fn()} />);
+
+    await waitFor(() => expect(apiClient.get).toHaveBeenCalled());
+    await user.click(screen.getByLabelText('Field'));
+    await user.click(await screen.findByRole('option', { name: /Gender/ }));
+    await user.click(screen.getByRole('button', { name: /preview matches/i }));
+
+    await waitFor(() => {
+      const call = apiClient.post.mock.calls.find(([url]) => url.includes('/preview'));
+      expect(call[1].filter.rows[0].field).toBe('gender');
+    });
+  });
+
+  it('surfaces how many rows the opt-in gate excluded', async () => {
+    mockApi();
+    await setUpPreview();
+    expect(
+      screen.getByText(/4 did not opt in to the Talent Partner Network/i)
+    ).toBeInTheDocument();
+  });
+
+  it('pre-selects eligible rows but not ones already shared', async () => {
+    mockApi();
+    await setUpPreview();
+    expect(screen.getByText('2 selected')).toBeInTheDocument();
+    expect(screen.getByText(/Already shared/i)).toBeInTheDocument();
+  });
+
+  it('sends only the rows left checked, so the trim is what gets assigned', async () => {
+    mockApi();
+    const user = await setUpPreview();
+
+    // Untick Jane Doe.
+    const janeRow = screen.getByText('Jane Doe').closest('tr');
+    await user.click(within(janeRow).getByRole('checkbox'));
+
+    await user.click(screen.getByRole('button', { name: /assign 1 resume/i }));
+
+    await waitFor(() => {
+      const call = apiClient.post.mock.calls.find(([url]) => url.includes('/assign'));
+      expect(call[1].keys).toEqual(['APPLICATION:app-2']);
+    });
+  });
+
+  it('cannot select a row that is already shared with this client', async () => {
+    mockApi();
+    await setUpPreview();
+    const graceRow = screen.getByText('Grace Hopper').closest('tr');
+    expect(within(graceRow).getByRole('checkbox')).toBeDisabled();
+  });
+
+  it('shows server notes, such as an applicant-only field against the member pool', async () => {
+    mockApi({ notes: ['Member resumes do not record Cumulative GPA, so no member resume can match this filter.'] });
+    await setUpPreview();
+    expect(screen.getByText(/do not record Cumulative GPA/i)).toBeInTheDocument();
+  });
+});

--- a/client/src/components/ClientLayout.jsx
+++ b/client/src/components/ClientLayout.jsx
@@ -1,0 +1,115 @@
+import React, { useState } from 'react';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
+import {
+  FolderOpenIcon,
+  ArrowRightOnRectangleIcon,
+  Bars3Icon,
+  XMarkIcon,
+} from '@heroicons/react/24/outline';
+import UConsultingLogo from './UConsultingLogo';
+import ThemeToggle from './ThemeToggle';
+import '../styles/ClientLayout.css';
+
+// Shell for Talent Partner Network clients. Mirrors CandidateLayout, minus the
+// feature-request modal: it POSTs /api/feature-requests, which the containment
+// middleware 403s for this role, so the button would only ever fail.
+//
+// One nav item on purpose. A client has exactly one page.
+const ClientLayout = ({ children }) => {
+  const { user, logout } = useAuth();
+  const location = useLocation();
+  const navigate = useNavigate();
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+
+  const handleLogout = () => {
+    logout();
+    navigate('/login');
+  };
+
+  const navigation = [
+    { name: 'Resume Library', href: '/partner/resumes', icon: FolderOpenIcon },
+  ];
+
+  const isCurrentPath = (path) => location.pathname === path;
+
+  return (
+    <div className="client-layout-container">
+      <nav className="client-top-nav">
+        <div className="nav-container">
+          <div className="nav-content">
+            <div className="nav-left">
+              <button
+                type="button"
+                className="mobile-menu-btn"
+                onClick={() => setSidebarOpen(!sidebarOpen)}
+              >
+                {sidebarOpen ? (
+                  <XMarkIcon style={{ width: '1.5rem', height: '1.5rem' }} />
+                ) : (
+                  <Bars3Icon style={{ width: '1.5rem', height: '1.5rem' }} />
+                )}
+              </button>
+
+              <div className="logo-section">
+                <UConsultingLogo size="medium" />
+                <div className="logo-subtitle">
+                  <p>Talent Partner Network</p>
+                </div>
+              </div>
+            </div>
+
+            <div className="nav-right">
+              <div className="user-info">
+                <p className="user-name">{user?.fullName}</p>
+                <p className="user-role">PARTNER</p>
+              </div>
+              <ThemeToggle />
+              <button onClick={handleLogout} className="logout-btn">
+                <ArrowRightOnRectangleIcon className="logout-icon" />
+                Logout
+              </button>
+            </div>
+          </div>
+        </div>
+      </nav>
+
+      <div className="main-layout">
+        <div className={`client-sidebar ${sidebarOpen ? 'open' : ''}`}>
+          <div className="sidebar-content">
+            <nav className="sidebar-nav">
+              {navigation.map((item) => {
+                const Icon = item.icon;
+                const current = isCurrentPath(item.href);
+
+                return (
+                  <Link
+                    key={item.name}
+                    to={item.href}
+                    className={`nav-item ${current ? 'active' : ''}`}
+                    onClick={() => setSidebarOpen(false)}
+                  >
+                    <Icon className="nav-icon" />
+                    {item.name}
+                  </Link>
+                );
+              })}
+            </nav>
+          </div>
+        </div>
+
+        {sidebarOpen && (
+          <div className="sidebar-overlay" onClick={() => setSidebarOpen(false)} />
+        )}
+
+        <div className="content-area">
+          <main className="main-content">
+            <div className="content-container">{children}</div>
+          </main>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ClientLayout;

--- a/client/src/components/ClientLayout.test.jsx
+++ b/client/src/components/ClientLayout.test.jsx
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import ClientLayout from './ClientLayout';
+
+vi.mock('../context/AuthContext', () => ({
+  useAuth: () => ({
+    user: { id: 'client-1', role: 'CLIENT', fullName: 'Acme Recruiting' },
+    logout: vi.fn(),
+  }),
+}));
+vi.mock('./ThemeToggle', () => ({ default: () => <div /> }));
+vi.mock('./UConsultingLogo', () => ({ default: () => <div /> }));
+
+const renderLayout = () =>
+  render(
+    <MemoryRouter>
+      <ClientLayout>
+        <div>portal content</div>
+      </ClientLayout>
+    </MemoryRouter>
+  );
+
+describe('ClientLayout', () => {
+  it('exposes exactly one destination', () => {
+    const { container } = renderLayout();
+    const links = [...container.querySelectorAll('a[href]')];
+    expect(links).toHaveLength(1);
+    expect(links[0].getAttribute('href')).toBe('/partner/resumes');
+  });
+
+  it('links to nothing in the staff console', () => {
+    const { container } = renderLayout();
+    const hrefs = [...container.querySelectorAll('a[href]')].map((a) => a.getAttribute('href'));
+
+    for (const href of hrefs) {
+      expect(href).not.toMatch(
+        /staging|application-list|user-management|review-teams|talent-pool|cases|events/
+      );
+    }
+  });
+
+  it('does not offer the feature-request modal, which the API blocks for this role', () => {
+    renderLayout();
+    expect(screen.queryByText(/request a feature/i)).not.toBeInTheDocument();
+  });
+
+  it('renders its children and labels the role', () => {
+    renderLayout();
+    expect(screen.getByText('portal content')).toBeInTheDocument();
+    expect(screen.getByText('PARTNER')).toBeInTheDocument();
+  });
+});

--- a/client/src/components/MemberResumeCard.jsx
+++ b/client/src/components/MemberResumeCard.jsx
@@ -1,0 +1,262 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  Alert,
+  Button,
+  Card,
+  CardContent,
+  Checkbox,
+  Chip,
+  Divider,
+  FormControl,
+  FormControlLabel,
+  Grid,
+  InputLabel,
+  MenuItem,
+  Select,
+  Stack,
+  TextField,
+  Typography,
+} from '@mui/material';
+import apiClient from '../utils/api';
+import DocumentPreviewModal from './DocumentPreviewModal';
+
+// A member's own resume for the Talent Partner Network, plus the consent that
+// makes it shareable. Sharing is strictly opt-in, and withdrawing pulls the
+// resume back from every partner immediately.
+
+const emptyForm = { major1: '', major2: '', graduationYear: '', gender: '' };
+
+const MemberResumeCard = () => {
+  const [resume, setResume] = useState(null);
+  const [genders, setGenders] = useState([]);
+  const [form, setForm] = useState(emptyForm);
+  const [file, setFile] = useState(null);
+  const [consent, setConsent] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState('');
+  const [success, setSuccess] = useState('');
+  const [previewOpen, setPreviewOpen] = useState(false);
+
+  const load = useCallback(async () => {
+    try {
+      const data = await apiClient.get('/member/resume');
+      setResume(data.resume);
+      setGenders(data.genders || []);
+      if (data.resume) {
+        setForm({
+          major1: data.resume.major1 || '',
+          major2: data.resume.major2 || '',
+          graduationYear: data.resume.graduationYear || '',
+          gender: data.resume.gender || '',
+        });
+      }
+    } catch (err) {
+      setError(err.message || 'Failed to load your resume');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const upload = async () => {
+    if (!file) return;
+    setSaving(true);
+    setError('');
+    try {
+      const body = new FormData();
+      body.append('resume', file);
+      body.append('major1', form.major1);
+      body.append('major2', form.major2);
+      body.append('graduationYear', form.graduationYear);
+      body.append('gender', form.gender);
+      body.append('shareConsent', String(consent));
+
+      await apiClient.post('/member/resume', body);
+      setFile(null);
+      setSuccess('Resume uploaded.');
+      await load();
+    } catch (err) {
+      setError(err.message || 'Failed to upload your resume');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const setSharing = async (shareConsent) => {
+    if (!shareConsent && resume?.assignedCount > 0) {
+      const ok = window.confirm(
+        `Stop sharing? Your resume will be withdrawn from ${resume.assignedCount} partner organization(s) immediately.`
+      );
+      if (!ok) return;
+    }
+    setSaving(true);
+    try {
+      const data = await apiClient.patch('/member/resume/consent', { shareConsent });
+      setResume(data.resume);
+      setSuccess(shareConsent ? 'Sharing enabled.' : 'Sharing stopped and existing shares withdrawn.');
+    } catch (err) {
+      setError(err.message || 'Failed to update your sharing preference');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading) return null;
+
+  return (
+    <Card variant="outlined" sx={{ mb: 3 }}>
+      <CardContent>
+        <Typography variant="h6" gutterBottom>
+          Talent Partner Network resume
+        </Typography>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+          Optional. UConsulting shares resumes with partner organizations looking for interns and
+          early-career hires. Nothing is shared unless you tick the box below, and you can withdraw
+          at any time.
+        </Typography>
+
+        {error && (
+          <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError('')}>
+            {error}
+          </Alert>
+        )}
+        {success && (
+          <Alert severity="success" sx={{ mb: 2 }} onClose={() => setSuccess('')}>
+            {success}
+          </Alert>
+        )}
+
+        {resume && (
+          <>
+            <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap" useFlexGap>
+              <Chip label={resume.originalName} onClick={() => setPreviewOpen(true)} />
+              <Chip
+                size="small"
+                color={resume.shareConsent ? 'success' : 'default'}
+                label={resume.shareConsent ? 'Shared with partners' : 'Not shared'}
+              />
+              {resume.shareConsent && (
+                <Chip
+                  size="small"
+                  variant="outlined"
+                  label={`${resume.assignedCount} organization(s) can see it`}
+                />
+              )}
+            </Stack>
+
+            <Stack direction="row" spacing={1} sx={{ mt: 2 }}>
+              {resume.shareConsent ? (
+                <Button size="small" color="error" disabled={saving} onClick={() => setSharing(false)}>
+                  Stop sharing
+                </Button>
+              ) : (
+                <Button size="small" variant="contained" disabled={saving} onClick={() => setSharing(true)}>
+                  Share with partners
+                </Button>
+              )}
+              <Button size="small" onClick={() => setPreviewOpen(true)}>
+                Preview
+              </Button>
+            </Stack>
+
+            <Divider sx={{ my: 3 }} />
+            <Typography variant="subtitle2" gutterBottom>
+              Replace your resume
+            </Typography>
+          </>
+        )}
+
+        <Grid container spacing={2} sx={{ mt: 0 }}>
+          <Grid item xs={12} sm={6}>
+            <TextField
+              fullWidth
+              size="small"
+              required
+              label="Major"
+              value={form.major1}
+              onChange={(e) => setForm({ ...form, major1: e.target.value })}
+            />
+          </Grid>
+          <Grid item xs={12} sm={6}>
+            <TextField
+              fullWidth
+              size="small"
+              label="Second major (optional)"
+              value={form.major2}
+              onChange={(e) => setForm({ ...form, major2: e.target.value })}
+            />
+          </Grid>
+          <Grid item xs={12} sm={6}>
+            <TextField
+              fullWidth
+              size="small"
+              required
+              label="Graduation year"
+              placeholder="2027"
+              value={form.graduationYear}
+              onChange={(e) => setForm({ ...form, graduationYear: e.target.value })}
+            />
+          </Grid>
+          <Grid item xs={12} sm={6}>
+            <FormControl fullWidth size="small">
+              <InputLabel>Gender (optional)</InputLabel>
+              <Select
+                value={form.gender}
+                label="Gender (optional)"
+                onChange={(e) => setForm({ ...form, gender: e.target.value })}
+              >
+                <MenuItem value="">Prefer not to say</MenuItem>
+                {genders.map((g) => (
+                  <MenuItem key={g} value={g}>
+                    {g}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          </Grid>
+        </Grid>
+
+        <Stack spacing={1} sx={{ mt: 2 }}>
+          <Button variant="outlined" component="label" size="small" sx={{ alignSelf: 'flex-start' }}>
+            {file ? file.name : 'Choose PDF'}
+            <input
+              hidden
+              type="file"
+              accept="application/pdf"
+              onChange={(e) => setFile(e.target.files?.[0] || null)}
+            />
+          </Button>
+
+          <FormControlLabel
+            control={<Checkbox checked={consent} onChange={(e) => setConsent(e.target.checked)} />}
+            label="My resume may be shared with UConsulting's partner organizations"
+          />
+
+          <Button
+            variant="contained"
+            sx={{ alignSelf: 'flex-start' }}
+            disabled={!file || saving}
+            onClick={upload}
+          >
+            {resume ? 'Replace resume' : 'Upload resume'}
+          </Button>
+        </Stack>
+      </CardContent>
+
+      {previewOpen && (
+        <DocumentPreviewModal
+          src="/api/member/resume/pdf"
+          kind="pdf"
+          title="Your resume"
+          onClose={() => setPreviewOpen(false)}
+        />
+      )}
+    </Card>
+  );
+};
+
+export default MemberResumeCard;

--- a/client/src/components/TalentPoolClients.jsx
+++ b/client/src/components/TalentPoolClients.jsx
@@ -1,0 +1,327 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  Card,
+  CardActions,
+  CardContent,
+  Chip,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Divider,
+  FormControl,
+  Grid,
+  InputLabel,
+  MenuItem,
+  Paper,
+  Select,
+  Stack,
+  TextField,
+  Typography,
+} from '@mui/material';
+import AddIcon from '@mui/icons-material/Add';
+import apiClient from '../utils/api';
+import ClientAssignBuilder from './ClientAssignBuilder';
+
+// Client accounts for the Talent Partner Network, rendered as a tab on the TPN
+// page. Deliberately not a separate nav entry - a second "partner" concept next
+// to the existing one would be confusing.
+
+const VISIBILITY_HELP = {
+  BLIND: 'Redacted resume only. No name, gender, contact details, or GPA. Applicants with no redacted resume on file cannot be shared with this client.',
+  BASIC: 'Real resume, plus name, gender, major and graduation year. No contact details or GPA.',
+  FULL: 'Everything: real resume, name, contact details, and GPA.',
+};
+
+const VISIBILITY_COLOR = { BLIND: 'default', BASIC: 'primary', FULL: 'warning' };
+
+const emptyForm = {
+  organization: '',
+  fullName: '',
+  email: '',
+  password: '',
+  visibility: 'BLIND',
+  notes: '',
+};
+
+const TalentPoolClients = () => {
+  const [clients, setClients] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [success, setSuccess] = useState('');
+  const [createOpen, setCreateOpen] = useState(false);
+  const [form, setForm] = useState(emptyForm);
+  const [saving, setSaving] = useState(false);
+  const [assignFor, setAssignFor] = useState(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      setClients(await apiClient.get('/admin/talent-pool/clients'));
+      setError('');
+    } catch (err) {
+      setError(err.message || 'Failed to load partner clients');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  useEffect(() => {
+    if (!success) return undefined;
+    const t = setTimeout(() => setSuccess(''), 4000);
+    return () => clearTimeout(t);
+  }, [success]);
+
+  const handleCreate = async (e) => {
+    e.preventDefault();
+    setSaving(true);
+    try {
+      await apiClient.post('/admin/talent-pool/clients', form);
+      setCreateOpen(false);
+      setForm(emptyForm);
+      setSuccess('Partner client created. Send them the email and password you just set.');
+      await load();
+    } catch (err) {
+      setError(err.message || 'Failed to create partner client');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleVisibilityChange = async (client, visibility) => {
+    try {
+      const { warnings } = await apiClient.patch(`/admin/talent-pool/clients/${client.id}`, {
+        visibility,
+      });
+      if (warnings?.blindUnavailable > 0) {
+        setSuccess(
+          `Visibility updated. ${warnings.blindUnavailable} already-shared resume(s) have no redacted version and will show as unavailable to this client.`
+        );
+      } else {
+        setSuccess('Visibility updated.');
+      }
+      await load();
+    } catch (err) {
+      setError(err.message || 'Failed to update visibility');
+    }
+  };
+
+  const handleDeactivate = async (client) => {
+    const isActive = client.user?.isActive !== false;
+    const message = isActive
+      ? `Deactivate ${client.organization}? They will no longer be able to sign in. Their assignments are kept.`
+      : `Reactivate ${client.organization}? They will be able to sign in again.`;
+    if (!window.confirm(message)) return;
+
+    try {
+      await apiClient.patch(`/users/${client.user.id}/${isActive ? 'deactivate' : 'reactivate'}`, {});
+      setSuccess(isActive ? 'Client deactivated.' : 'Client reactivated.');
+      await load();
+    } catch (err) {
+      setError(err.message || 'Failed to update the account');
+    }
+  };
+
+  if (assignFor) {
+    return (
+      <ClientAssignBuilder
+        client={assignFor}
+        onDone={() => {
+          setAssignFor(null);
+          load();
+        }}
+      />
+    );
+  }
+
+  return (
+    <Box>
+      <Stack
+        direction={{ xs: 'column', md: 'row' }}
+        justifyContent="space-between"
+        alignItems={{ md: 'center' }}
+        spacing={1}
+        sx={{ mb: 2 }}
+      >
+        <Typography variant="body2" color="text.secondary">
+          Outside organizations with portal access. Only resumes you explicitly assign are visible
+          to them, and only from applicants who opted in.
+        </Typography>
+        <Button variant="contained" startIcon={<AddIcon />} onClick={() => setCreateOpen(true)}>
+          Add Client
+        </Button>
+      </Stack>
+
+      {error && (
+        <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError('')}>
+          {error}
+        </Alert>
+      )}
+      {success && (
+        <Alert severity="success" sx={{ mb: 2 }} onClose={() => setSuccess('')}>
+          {success}
+        </Alert>
+      )}
+
+      {loading && (
+        <Box sx={{ display: 'flex', justifyContent: 'center', p: 4 }}>
+          <CircularProgress />
+        </Box>
+      )}
+
+      {!loading && clients.length === 0 && (
+        <Paper sx={{ p: 4, textAlign: 'center' }}>
+          <Typography variant="h6" gutterBottom>
+            No partner clients yet
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            Add one to give an outside organization access to a set of resumes.
+          </Typography>
+        </Paper>
+      )}
+
+      <Grid container spacing={2}>
+        {clients.map((client) => {
+          const inactive = client.user?.isActive === false;
+          return (
+            <Grid item xs={12} sm={6} lg={4} key={client.id}>
+              <Card variant="outlined" sx={{ height: '100%', opacity: inactive ? 0.6 : 1 }}>
+                <CardContent>
+                  <Stack direction="row" justifyContent="space-between" alignItems="flex-start">
+                    <Typography variant="h6">{client.organization}</Typography>
+                    {inactive && <Chip size="small" label="Deactivated" color="error" />}
+                  </Stack>
+                  <Typography variant="body2" color="text.secondary">
+                    {client.user?.fullName}
+                  </Typography>
+                  <Typography variant="body2" color="text.secondary">
+                    {client.user?.email}
+                  </Typography>
+
+                  <Stack direction="row" spacing={1} sx={{ mt: 2 }}>
+                    <Chip
+                      size="small"
+                      label={client.visibility}
+                      color={VISIBILITY_COLOR[client.visibility] || 'default'}
+                    />
+                    <Chip size="small" variant="outlined" label={`${client.assignmentCount} resumes`} />
+                  </Stack>
+
+                  <Divider sx={{ my: 2 }} />
+
+                  <FormControl fullWidth size="small">
+                    <InputLabel id={`visibility-label-${client.id}`}>Visibility</InputLabel>
+                    <Select
+                      labelId={`visibility-label-${client.id}`}
+                      value={client.visibility}
+                      label="Visibility"
+                      onChange={(e) => handleVisibilityChange(client, e.target.value)}
+                    >
+                      {Object.keys(VISIBILITY_HELP).map((v) => (
+                        <MenuItem key={v} value={v}>
+                          {v}
+                        </MenuItem>
+                      ))}
+                    </Select>
+                  </FormControl>
+                  <Typography variant="caption" color="text.secondary" sx={{ mt: 1, display: 'block' }}>
+                    {VISIBILITY_HELP[client.visibility]}
+                  </Typography>
+                </CardContent>
+
+                <CardActions>
+                  <Button size="small" variant="contained" onClick={() => setAssignFor(client)}>
+                    Assign resumes
+                  </Button>
+                  <Button size="small" color={inactive ? 'success' : 'error'} onClick={() => handleDeactivate(client)}>
+                    {inactive ? 'Reactivate' : 'Deactivate'}
+                  </Button>
+                </CardActions>
+              </Card>
+            </Grid>
+          );
+        })}
+      </Grid>
+
+      <Dialog open={createOpen} onClose={() => setCreateOpen(false)} maxWidth="sm" fullWidth>
+        <DialogTitle>Add Partner Client</DialogTitle>
+        <form onSubmit={handleCreate}>
+          <DialogContent>
+            <Stack spacing={2}>
+              <TextField
+                fullWidth
+                required
+                label="Organization"
+                value={form.organization}
+                onChange={(e) => setForm({ ...form, organization: e.target.value })}
+              />
+              <TextField
+                fullWidth
+                required
+                label="Contact name"
+                value={form.fullName}
+                onChange={(e) => setForm({ ...form, fullName: e.target.value })}
+              />
+              <TextField
+                fullWidth
+                required
+                type="email"
+                label="Login email"
+                value={form.email}
+                onChange={(e) => setForm({ ...form, email: e.target.value })}
+              />
+              <TextField
+                fullWidth
+                required
+                label="Password"
+                value={form.password}
+                onChange={(e) => setForm({ ...form, password: e.target.value })}
+                helperText="At least 12 characters. There is no self-service reset for these accounts, so send it to them securely."
+              />
+              <FormControl fullWidth>
+                <InputLabel id="new-client-visibility-label">Visibility</InputLabel>
+                <Select
+                  labelId="new-client-visibility-label"
+                  value={form.visibility}
+                  label="Visibility"
+                  onChange={(e) => setForm({ ...form, visibility: e.target.value })}
+                >
+                  {Object.keys(VISIBILITY_HELP).map((v) => (
+                    <MenuItem key={v} value={v}>
+                      {v}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+              <Alert severity="info">{VISIBILITY_HELP[form.visibility]}</Alert>
+              <TextField
+                fullWidth
+                multiline
+                minRows={2}
+                label="Notes (internal)"
+                value={form.notes}
+                onChange={(e) => setForm({ ...form, notes: e.target.value })}
+              />
+            </Stack>
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={() => setCreateOpen(false)}>Cancel</Button>
+            <Button type="submit" variant="contained" disabled={saving}>
+              Create Client
+            </Button>
+          </DialogActions>
+        </form>
+      </Dialog>
+    </Box>
+  );
+};
+
+export default TalentPoolClients;

--- a/client/src/components/TalentPoolClients.test.jsx
+++ b/client/src/components/TalentPoolClients.test.jsx
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import TalentPoolClients from './TalentPoolClients';
+import apiClient from '../utils/api';
+
+vi.mock('./ClientAssignBuilder', () => ({
+  default: ({ client }) => <div data-testid="assign-builder">{client.organization}</div>,
+}));
+
+const clients = [
+  {
+    id: 'partner-1',
+    organization: 'Acme Recruiting',
+    visibility: 'BLIND',
+    assignmentCount: 12,
+    user: { id: 'u1', fullName: 'Buyer Contact', email: 'buyer@acme.com', isActive: true },
+  },
+];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  apiClient.token = 'test-token';
+  apiClient.get = vi.fn(() => Promise.resolve(clients));
+  apiClient.post = vi.fn(() => Promise.resolve({ client: clients[0] }));
+  apiClient.patch = vi.fn(() => Promise.resolve({ client: clients[0], warnings: {} }));
+});
+
+describe('TalentPoolClients', () => {
+  it('lists clients with their visibility and share count', async () => {
+    render(<TalentPoolClients />);
+    await waitFor(() => expect(screen.getByText('Acme Recruiting')).toBeInTheDocument());
+    // Appears twice: once as the summary chip, once as the Select's value.
+    expect(screen.getAllByText('BLIND').length).toBeGreaterThan(0);
+    expect(screen.getByText('12 resumes')).toBeInTheDocument();
+  });
+
+  it('creates a client with the details the admin entered', async () => {
+    const user = userEvent.setup();
+    render(<TalentPoolClients />);
+    await waitFor(() => expect(screen.getByText('Acme Recruiting')).toBeInTheDocument());
+
+    await user.click(screen.getByRole('button', { name: /add client/i }));
+    await user.type(screen.getByLabelText(/organization/i), 'Globex');
+    await user.type(screen.getByLabelText(/contact name/i), 'Jane Buyer');
+    await user.type(screen.getByLabelText(/login email/i), 'jane@globex.com');
+    await user.type(screen.getByLabelText(/^password/i), 'a-very-long-password');
+    await user.click(screen.getByRole('button', { name: /create client/i }));
+
+    await waitFor(() =>
+      expect(apiClient.post).toHaveBeenCalledWith(
+        '/admin/talent-pool/clients',
+        expect.objectContaining({
+          organization: 'Globex',
+          email: 'jane@globex.com',
+          visibility: 'BLIND',
+        })
+      )
+    );
+  });
+
+  it('explains what each visibility level exposes', async () => {
+    render(<TalentPoolClients />);
+    await waitFor(() => expect(screen.getByText('Acme Recruiting')).toBeInTheDocument());
+    expect(screen.getByText(/Redacted resume only/i)).toBeInTheDocument();
+  });
+
+  it('opens the assign builder for a client', async () => {
+    const user = userEvent.setup();
+    render(<TalentPoolClients />);
+    await waitFor(() => expect(screen.getByText('Acme Recruiting')).toBeInTheDocument());
+
+    await user.click(screen.getByRole('button', { name: /assign resumes/i }));
+    expect(await screen.findByTestId('assign-builder')).toHaveTextContent('Acme Recruiting');
+  });
+
+  it('warns when tightening to BLIND strands already-shared resumes', async () => {
+    apiClient.patch = vi.fn(() =>
+      Promise.resolve({ client: clients[0], warnings: { blindUnavailable: 3 } })
+    );
+    const user = userEvent.setup();
+    render(<TalentPoolClients />);
+    await waitFor(() => expect(screen.getByText('Acme Recruiting')).toBeInTheDocument());
+
+    await user.click(screen.getByLabelText('Visibility'));
+    await user.click(await screen.findByRole('option', { name: 'FULL' }));
+
+    await waitFor(() =>
+      expect(screen.getByText(/3 already-shared resume\(s\) have no redacted version/i)).toBeInTheDocument()
+    );
+  });
+});

--- a/client/src/context/AuthContext.jsx
+++ b/client/src/context/AuthContext.jsx
@@ -48,7 +48,9 @@ export const AuthProvider = ({ children }) => {
       localStorage.setItem('token', data.token);
       setToken(data.token);
       setUser(data.user);
-      return { success: true };
+      // data.user is returned so the caller can route by role without waiting
+      // for context state to settle. Login.jsx is the only caller.
+      return { success: true, user: data.user };
 
     } catch (error) {
       return { success: false, error: error.message };

--- a/client/src/pages/ClientResumeLibrary.jsx
+++ b/client/src/pages/ClientResumeLibrary.jsx
@@ -1,35 +1,94 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   Alert,
+  Autocomplete,
   Box,
   Button,
-  Card,
-  CardActionArea,
-  CardContent,
+  Checkbox,
   Chip,
   CircularProgress,
-  Grid,
+  Divider,
+  FormControl,
+  FormControlLabel,
+  FormGroup,
+  FormLabel,
   Paper,
   Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TablePagination,
+  TableRow,
+  TableSortLabel,
   TextField,
+  Tooltip,
   Typography,
 } from '@mui/material';
 import SearchIcon from '@mui/icons-material/Search';
+import FileDownloadOutlinedIcon from '@mui/icons-material/FileDownloadOutlined';
 import AccessControl from '../components/AccessControl';
 import DocumentPreviewModal from '../components/DocumentPreviewModal';
+import { useAuth } from '../context/AuthContext';
 import apiClient from '../utils/api';
+import '../styles/ClientResumeLibrary.css';
 
-// The only page a Talent Partner Network client sees.
+// The only page a Talent Partner Network client sees: their assigned resumes as
+// a spreadsheet-style table they can filter, sort, select and export.
 //
-// There is deliberately no download control anywhere in here. The PDF is shown
-// through DocumentPreviewModal, which fetches a blob and renders it in an
+// There is deliberately no download control for the PDFs themselves. The file is
+// shown through DocumentPreviewModal, which fetches a blob and renders it in an
 // iframe with the viewer toolbar suppressed. That is deterrence plus an audit
 // trail, not prevention - see the note in the branch README/plan.
+//
+// Export is the deliberate exception, and it is metadata only: the CSV carries
+// exactly the columns this client's visibility already puts on screen, and the
+// server records one access-log row per exported resume. What a client cannot
+// export is a resume file.
+//
+// Column and control visibility is driven entirely by `account.filterableFields`
+// / `account.sortableFields`, which the server derives from the same visibility
+// level its projection uses. A BLIND client does not get a greyed-out Gender
+// column - the column does not exist, matching the server's omit-don't-null rule.
 
-const PAGE_SIZE = 24;
+const ROWS_PER_PAGE_OPTIONS = [25, 50, 100];
 
-// Under BLIND the server omits identity keys entirely rather than nulling them,
-// so presence is the signal.
+// Below this the columns stop shrinking and the table scrolls sideways inside
+// its own container. Squeezing twelve columns into a phone-width viewport is
+// what made cells collide in the first place.
+const MIN_TABLE_WIDTH = 1080;
+
+// Applied to the header cell and the body cell of each column so the two can
+// never disagree about width or wrapping.
+//
+// Short columns are `nowrap`: a wrapped "2029" or "Applicant" costs a row of
+// height and reads worse. Free text wraps inside its own cell instead.
+// `anywhere` on email and phone is the load-bearing one - an address has no
+// space to break at, so a long one overflows its cell and prints on top of the
+// next column, which is exactly the overlap this fixes.
+const COLUMNS = {
+  // Wide enough for the checkbox plus its ripple target. Left at MUI's default
+  // the box sat flush against the cell edge and clipped.
+  select: { width: 52, minWidth: 52 },
+  ref: { width: 120, whiteSpace: 'nowrap' },
+  name: { minWidth: 160, whiteSpace: 'nowrap' },
+  kind: { width: 110, whiteSpace: 'nowrap' },
+  graduationYear: { width: 90, whiteSpace: 'nowrap' },
+  major: { minWidth: 180 },
+  major2: { minWidth: 180 },
+  gender: { minWidth: 110, whiteSpace: 'nowrap' },
+  // minWidth, not width: "Major GPA" plus its sort arrow is wider than the
+  // numbers under it, and the header is what has to fit.
+  gpa: { minWidth: 112, whiteSpace: 'nowrap' },
+  phone: { minWidth: 140, overflowWrap: 'anywhere' },
+  assignedAt: { minWidth: 120, whiteSpace: 'nowrap' },
+  // Last column on purpose: an address is the longest value in the row and the
+  // only one with no natural break point, so it gets the leftover width and
+  // nothing sits to its right to be printed over.
+  email: { minWidth: 220, overflowWrap: 'anywhere' },
+};
+
 const displayName = (item) => {
   if (item.firstName || item.lastName) {
     return [item.firstName, item.lastName].filter(Boolean).join(' ');
@@ -37,77 +96,71 @@ const displayName = (item) => {
   return null;
 };
 
-const ResumeCard = ({ item, onOpen }) => {
-  const name = displayName(item);
-  const majors = [item.major1, item.major2].filter(Boolean).join(' · ');
+// Mirrors referenceFor() on the server so the on-screen handle and the CSV cell
+// are the same string.
+const referenceFor = (assignmentId) =>
+  String(assignmentId || '').replace(/-/g, '').slice(0, 8).toUpperCase();
 
-  return (
-    <Card variant="outlined" sx={{ height: '100%' }}>
-      <CardActionArea
-        onClick={() => onOpen(item)}
-        disabled={!item.available}
-        sx={{ height: '100%', alignItems: 'flex-start' }}
-      >
-        <CardContent sx={{ width: '100%' }}>
-          <Stack direction="row" justifyContent="space-between" alignItems="flex-start" spacing={1}>
-            <Typography variant="subtitle1" sx={{ fontWeight: 500 }}>
-              {name || 'Candidate'}
-            </Typography>
-            <Chip
-              size="small"
-              label={item.kind === 'MEMBER' ? 'Member' : 'Applicant'}
-              variant="outlined"
-            />
-          </Stack>
+const filenameFromDisposition = (header) => {
+  const match = /filename="?([^"]+)"?/.exec(header || '');
+  return match ? match[1] : null;
+};
 
-          <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
-            {majors || 'Major not recorded'}
-          </Typography>
+// Both pools are included by default: a client's library is everything shared
+// with them, and an unchecked box would hide rows they were never told about.
+// Unchecking one is how you narrow to the other.
+const DEFAULT_KINDS = { MEMBER: true, APPLICANT: true };
 
-          <Stack direction="row" spacing={1} sx={{ mt: 1.5 }} flexWrap="wrap" useFlexGap>
-            {item.graduationYear && (
-              <Chip size="small" label={`Class of ${item.graduationYear}`} />
-            )}
-            {item.gender && <Chip size="small" label={item.gender} variant="outlined" />}
-            {item.cumulativeGpa && (
-              <Chip size="small" label={`GPA ${item.cumulativeGpa}`} variant="outlined" />
-            )}
-          </Stack>
-
-          {item.email && (
-            <Typography variant="body2" color="text.secondary" sx={{ mt: 1.5 }}>
-              {item.email}
-            </Typography>
-          )}
-
-          {!item.available && (
-            <Typography variant="caption" color="text.secondary" sx={{ mt: 1.5, display: 'block' }}>
-              Resume not available
-            </Typography>
-          )}
-        </CardContent>
-      </CardActionArea>
-    </Card>
-  );
+const EMPTY_FILTERS = {
+  kinds: DEFAULT_KINDS,
+  graduationYear: [],
+  major: [],
+  gender: [],
+  gpaMin: '',
+  gpaMax: '',
 };
 
 const ClientResumeLibrary = () => {
+  const { token } = useAuth();
+
   const [account, setAccount] = useState(null);
+  const [facets, setFacets] = useState({});
   const [items, setItems] = useState([]);
   const [total, setTotal] = useState(0);
-  const [offset, setOffset] = useState(0);
+  const [notes, setNotes] = useState([]);
+
   const [pendingSearch, setPendingSearch] = useState('');
-  const [appliedSearch, setAppliedSearch] = useState('');
+  const [search, setSearch] = useState('');
+  const [filters, setFilters] = useState(EMPTY_FILTERS);
+  const [sort, setSort] = useState({ field: 'assignedAt', dir: 'desc' });
+  const [page, setPage] = useState(0);
+  const [rowsPerPage, setRowsPerPage] = useState(ROWS_PER_PAGE_OPTIONS[0]);
+
+  const [selected, setSelected] = useState(() => new Set());
   const [loading, setLoading] = useState(true);
+  const [exporting, setExporting] = useState(false);
   const [error, setError] = useState('');
   const [preview, setPreview] = useState(null);
 
+  const canFilter = useCallback(
+    (field) => account?.filterableFields?.includes(field) ?? false,
+    [account]
+  );
+  const canSort = useCallback(
+    (field) => account?.sortableFields?.includes(field) ?? false,
+    [account]
+  );
+
+  const showsIdentity = account?.visibility === 'BASIC' || account?.visibility === 'FULL';
+  const showsContact = account?.visibility === 'FULL';
+
   useEffect(() => {
     let cancelled = false;
-    apiClient
-      .get('/client/me')
-      .then((data) => {
-        if (!cancelled) setAccount(data);
+    Promise.all([apiClient.get('/client/me'), apiClient.get('/client/facets')])
+      .then(([me, facetValues]) => {
+        if (cancelled) return;
+        setAccount(me);
+        setFacets(facetValues || {});
       })
       .catch((err) => {
         if (!cancelled) setError(err.message || 'Failed to load your account');
@@ -117,44 +170,233 @@ const ClientResumeLibrary = () => {
     };
   }, []);
 
-  const fetchResumes = useCallback(async (nextOffset, search) => {
-    setLoading(true);
-    setError('');
-    try {
-      const params = new URLSearchParams({ limit: String(PAGE_SIZE), offset: String(nextOffset) });
-      if (search) params.set('q', search);
-      const data = await apiClient.get(`/client/resumes?${params.toString()}`);
-      setItems(data.items || []);
-      setTotal(data.total || 0);
-      setOffset(nextOffset);
-    } catch (err) {
-      setError(err.message || 'Failed to load your resume library');
-    } finally {
-      setLoading(false);
+  // Both boxes ticked is the same set as no kind filter at all, so it sends no
+  // `kind` param rather than an impossible "APPLICANT and MEMBER".
+  const selectedKinds = useMemo(
+    () => Object.keys(filters.kinds).filter((kind) => filters.kinds[kind]),
+    [filters.kinds]
+  );
+  const noKindSelected = selectedKinds.length === 0;
+
+  const queryString = useMemo(() => {
+    const params = new URLSearchParams();
+    params.set('limit', String(rowsPerPage));
+    params.set('offset', String(page * rowsPerPage));
+    params.set('sort', sort.field);
+    params.set('dir', sort.dir);
+    if (search) params.set('q', search);
+    if (selectedKinds.length === 1) params.set('kind', selectedKinds[0]);
+    for (const field of ['graduationYear', 'major', 'gender']) {
+      if (filters[field]?.length) params.set(field, filters[field].join(','));
     }
-  }, []);
+    if (filters.gpaMin) params.set('gpaMin', filters.gpaMin);
+    if (filters.gpaMax) params.set('gpaMax', filters.gpaMax);
+    return params.toString();
+  }, [rowsPerPage, page, sort, search, filters, selectedKinds]);
+
+  // Only fetch once the account is known: the server drops filters and sorts the
+  // client's visibility disallows, and firing before then would render one page
+  // under the default sort and then immediately replace it.
+  const ready = Boolean(account);
 
   useEffect(() => {
-    fetchResumes(0, '');
-  }, [fetchResumes]);
+    if (!ready) return undefined;
+
+    // Neither type ticked matches nothing. Answering that locally rather than
+    // asking the server keeps it from coming back as an unfiltered 500-row page,
+    // which is what an empty `kind` param means to /client/resumes.
+    if (noKindSelected) {
+      setItems([]);
+      setTotal(0);
+      setNotes([]);
+      setLoading(false);
+      return undefined;
+    }
+
+    let cancelled = false;
+    setLoading(true);
+    setError('');
+    apiClient
+      .get(`/client/resumes?${queryString}`)
+      .then((data) => {
+        if (cancelled) return;
+        setItems(data.items || []);
+        setTotal(data.total || 0);
+        setNotes(data.notes || []);
+      })
+      .catch((err) => {
+        if (!cancelled) setError(err.message || 'Failed to load your resume library');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [ready, queryString, noKindSelected]);
+
+  // Any change to what is being matched resets to the first page. Without this,
+  // narrowing a filter while on page 4 lands on an empty page that reads as "no
+  // results" when there are plenty.
+  const resetPage = () => setPage(0);
 
   const applySearch = () => {
-    setAppliedSearch(pendingSearch.trim());
-    fetchResumes(0, pendingSearch.trim());
+    setSearch(pendingSearch.trim());
+    resetPage();
   };
 
-  const clearSearch = () => {
+  const updateFilter = (field, value) => {
+    setFilters((prev) => ({ ...prev, [field]: value }));
+    resetPage();
+  };
+
+  const clearAll = () => {
     setPendingSearch('');
-    setAppliedSearch('');
-    fetchResumes(0, '');
+    setSearch('');
+    setFilters(EMPTY_FILTERS);
+    resetPage();
   };
 
-  const page = Math.floor(offset / PAGE_SIZE) + 1;
-  const pageCount = Math.max(Math.ceil(total / PAGE_SIZE), 1);
+  const toggleKind = (kind) => {
+    setFilters((prev) => ({
+      ...prev,
+      kinds: { ...prev.kinds, [kind]: !prev.kinds[kind] },
+    }));
+    resetPage();
+  };
+
+  const activeFilterCount =
+    // Only a narrowed type counts: both boxes ticked is the unfiltered set.
+    (selectedKinds.length === Object.keys(filters.kinds).length ? 0 : 1) +
+    filters.graduationYear.length +
+    filters.major.length +
+    filters.gender.length +
+    (filters.gpaMin ? 1 : 0) +
+    (filters.gpaMax ? 1 : 0);
+
+  const toggleSort = (field) => {
+    setSort((prev) =>
+      prev.field === field
+        ? { field, dir: prev.dir === 'asc' ? 'desc' : 'asc' }
+        : { field, dir: 'asc' }
+    );
+    resetPage();
+  };
+
+  const toggleRow = (assignmentId) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(assignmentId)) next.delete(assignmentId);
+      else next.add(assignmentId);
+      return next;
+    });
+  };
+
+  const pageIds = items.map((item) => item.assignmentId);
+  const pageSelectedCount = pageIds.filter((id) => selected.has(id)).length;
+  const allPageSelected = pageIds.length > 0 && pageSelectedCount === pageIds.length;
+
+  // Selection spans pages, so the header checkbox acts on the current page only
+  // and the toolbar reports the running total. A header box that silently
+  // cleared selections made on other pages would lose work without saying so.
+  const togglePage = () => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (allPageSelected) pageIds.forEach((id) => next.delete(id));
+      else pageIds.forEach((id) => next.add(id));
+      return next;
+    });
+  };
+
+  const exportSelected = async () => {
+    if (selected.size === 0) return;
+    setExporting(true);
+    setError('');
+    try {
+      // Raw fetch rather than apiClient: the response is a CSV body, and
+      // apiClient always parses JSON.
+      const response = await fetch('/api/client/resumes/export', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ assignmentIds: [...selected] }),
+      });
+
+      if (!response.ok) {
+        let message = `Export failed (${response.status})`;
+        try {
+          const body = await response.json();
+          if (body?.error) message = body.error;
+        } catch {
+          // A non-JSON error body tells us nothing more than the status did.
+        }
+        throw new Error(message);
+      }
+
+      const blob = await response.blob();
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      link.download =
+        filenameFromDisposition(response.headers.get('content-disposition')) || 'resumes.csv';
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      setError(err.message || 'Failed to export your selection');
+    } finally {
+      setExporting(false);
+    }
+  };
+
+  const sortLabel = (field, label, extraProps = {}) => (
+    <TableCell {...extraProps}>
+      {canSort(field) ? (
+        <TableSortLabel
+          active={sort.field === field}
+          direction={sort.field === field ? sort.dir : 'asc'}
+          onClick={() => toggleSort(field)}
+        >
+          {label}
+        </TableSortLabel>
+      ) : (
+        label
+      )}
+    </TableCell>
+  );
+
+  const multiSelectFilter = (field, label) => (
+    <Autocomplete
+      multiple
+      size="small"
+      options={facets[field] || []}
+      value={filters[field]}
+      onChange={(_, value) => updateFilter(field, value)}
+      disableCloseOnSelect
+      sx={{ minWidth: 220, flex: 1 }}
+      renderInput={(params) => <TextField {...params} label={label} placeholder="Any of" />}
+      renderTags={(value, getTagProps) =>
+        value.map((option, index) => (
+          <Chip size="small" label={option} {...getTagProps({ index })} key={option} />
+        ))
+      }
+    />
+  );
+
+  const columnCount =
+    2 + // checkbox + reference
+    (showsIdentity ? 2 : 0) + // name, gender
+    4 + // type, class, major, second major
+    (showsContact ? 4 : 0) + // cumulative gpa, major gpa, phone, email
+    1; // shared on
 
   return (
     <AccessControl allowedRoles={['CLIENT']}>
-      <Box sx={{ p: 3 }}>
+      {/* The class is load-bearing, not cosmetic - see ClientResumeLibrary.css. */}
+      <Box className="client-resume-library" sx={{ p: 3 }}>
         <Stack
           direction={{ xs: 'column', md: 'row' }}
           justifyContent="space-between"
@@ -166,10 +408,36 @@ const ClientResumeLibrary = () => {
             <Typography variant="h4">Resume Library</Typography>
             <Typography variant="body2" color="text.secondary">
               {account?.organization
-                ? `${account.organization} — ${total} resume${total === 1 ? '' : 's'} shared with you`
+                ? `${account.organization} — ${total} resume${total === 1 ? '' : 's'}${
+                    activeFilterCount > 0 || search ? ' matching your filters' : ' shared with you'
+                  }`
                 : 'Loading your account…'}
             </Typography>
           </Box>
+
+          <Stack direction="row" spacing={1} alignItems="center">
+            <Typography variant="body2" color="text.secondary">
+              {selected.size} selected
+            </Typography>
+            <Tooltip
+              title={
+                selected.size === 0
+                  ? 'Select one or more rows to export'
+                  : 'Downloads a spreadsheet of the columns shown here. Resume files are not included.'
+              }
+            >
+              <span>
+                <Button
+                  variant="contained"
+                  startIcon={<FileDownloadOutlinedIcon />}
+                  disabled={selected.size === 0 || exporting}
+                  onClick={exportSelected}
+                >
+                  {exporting ? 'Preparing…' : 'Export CSV'}
+                </Button>
+              </span>
+            </Tooltip>
+          </Stack>
         </Stack>
 
         {error && (
@@ -178,90 +446,261 @@ const ClientResumeLibrary = () => {
           </Alert>
         )}
 
-        <Paper sx={{ p: 1.5, mb: 3 }}>
-          <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1} alignItems="center">
-            <TextField
-              size="small"
-              fullWidth
-              placeholder={
-                account?.visibility === 'BLIND'
-                  ? 'Search by major or graduation year'
-                  : 'Search by name, major, or graduation year'
-              }
-              value={pendingSearch}
-              onChange={(e) => setPendingSearch(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter') applySearch();
-              }}
-              InputProps={{ startAdornment: <SearchIcon fontSize="small" sx={{ mr: 1 }} /> }}
-            />
-            <Button variant="contained" onClick={applySearch} disabled={loading}>
-              Search
-            </Button>
-            {appliedSearch && (
-              <Button onClick={clearSearch} disabled={loading}>
-                Clear
+        {notes.map((note) => (
+          <Alert severity="info" sx={{ mb: 2 }} key={note}>
+            {note}
+          </Alert>
+        ))}
+
+        <Paper sx={{ p: 2, mb: 3 }}>
+          <Stack spacing={2}>
+            <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1} alignItems="center">
+              <TextField
+                size="small"
+                fullWidth
+                placeholder={
+                  showsIdentity
+                    ? 'Search by name, major, or graduation year'
+                    : 'Search by major or graduation year'
+                }
+                value={pendingSearch}
+                onChange={(e) => setPendingSearch(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') applySearch();
+                }}
+                InputProps={{ startAdornment: <SearchIcon fontSize="small" sx={{ mr: 1 }} /> }}
+              />
+              <Button variant="outlined" onClick={applySearch} disabled={loading}>
+                Search
               </Button>
-            )}
+              {(search || activeFilterCount > 0) && (
+                <Button onClick={clearAll} disabled={loading}>
+                  Clear all
+                </Button>
+              )}
+            </Stack>
+
+            <Divider flexItem />
+
+            <Stack
+              direction={{ xs: 'column', md: 'row' }}
+              spacing={2}
+              alignItems={{ md: 'center' }}
+              useFlexGap
+              flexWrap="wrap"
+            >
+              {multiSelectFilter('graduationYear', 'Graduation year')}
+              {multiSelectFilter('major', 'Major')}
+              {canFilter('gender') && multiSelectFilter('gender', 'Gender')}
+
+              <FormControl component="fieldset" sx={{ minWidth: 210 }}>
+                <FormLabel component="legend" sx={{ fontSize: 12 }}>
+                  Type
+                </FormLabel>
+                <FormGroup row>
+                  <FormControlLabel
+                    control={
+                      <Checkbox
+                        size="small"
+                        checked={filters.kinds.MEMBER}
+                        onChange={() => toggleKind('MEMBER')}
+                      />
+                    }
+                    label="Members"
+                  />
+                  <FormControlLabel
+                    control={
+                      <Checkbox
+                        size="small"
+                        checked={filters.kinds.APPLICANT}
+                        onChange={() => toggleKind('APPLICANT')}
+                      />
+                    }
+                    label="Applicants"
+                  />
+                </FormGroup>
+              </FormControl>
+
+              {canFilter('gpa') && (
+                <Stack direction="row" spacing={1}>
+                  <TextField
+                    size="small"
+                    label="Min GPA"
+                    placeholder="3.50"
+                    value={filters.gpaMin}
+                    onChange={(e) => updateFilter('gpaMin', e.target.value)}
+                    sx={{ width: 110 }}
+                  />
+                  <TextField
+                    size="small"
+                    label="Max GPA"
+                    placeholder="4.00"
+                    value={filters.gpaMax}
+                    onChange={(e) => updateFilter('gpaMax', e.target.value)}
+                    sx={{ width: 110 }}
+                  />
+                </Stack>
+              )}
+            </Stack>
           </Stack>
         </Paper>
 
-        {loading && (
-          <Box sx={{ display: 'flex', justifyContent: 'center', py: 6 }}>
-            <CircularProgress />
-          </Box>
-        )}
+        <Paper>
+          <TableContainer sx={{ maxHeight: '65vh', overflowX: 'auto' }}>
+            <Table size="small" stickyHeader sx={{ minWidth: MIN_TABLE_WIDTH }}>
+              <TableHead>
+                <TableRow>
+                  <TableCell padding="checkbox" sx={COLUMNS.select}>
+                    <Checkbox
+                      checked={allPageSelected}
+                      indeterminate={pageSelectedCount > 0 && !allPageSelected}
+                      onChange={togglePage}
+                      inputProps={{ 'aria-label': 'Select all rows on this page' }}
+                    />
+                  </TableCell>
+                  <TableCell sx={COLUMNS.ref}>Ref</TableCell>
+                  {showsIdentity && sortLabel('name', 'Name', { sx: COLUMNS.name })}
+                  {sortLabel('kind', 'Type', { sx: COLUMNS.kind })}
+                  {sortLabel('graduationYear', 'Class', { sx: COLUMNS.graduationYear })}
+                  {sortLabel('major', 'Major', { sx: COLUMNS.major })}
+                  <TableCell sx={COLUMNS.major2}>Second Major</TableCell>
+                  {showsIdentity && sortLabel('gender', 'Gender', { sx: COLUMNS.gender })}
+                  {showsContact &&
+                    sortLabel('cumulativeGpa', 'GPA', { align: 'right', sx: COLUMNS.gpa })}
+                  {showsContact &&
+                    sortLabel('majorGpa', 'Major GPA', { align: 'right', sx: COLUMNS.gpa })}
+                  {showsContact && <TableCell sx={COLUMNS.phone}>Phone</TableCell>}
+                  {sortLabel('assignedAt', 'Shared', { sx: COLUMNS.assignedAt })}
+                  {showsContact && <TableCell sx={COLUMNS.email}>Email</TableCell>}
+                </TableRow>
+              </TableHead>
 
-        {!loading && items.length === 0 && (
-          <Paper sx={{ p: 4, textAlign: 'center' }}>
-            <Typography variant="h6" gutterBottom>
-              {appliedSearch ? 'No resumes match that search' : 'No resumes have been shared yet'}
-            </Typography>
-            <Typography variant="body2" color="text.secondary">
-              {appliedSearch
-                ? 'Try a different major or graduation year.'
-                : 'UConsulting will add resumes to your library. Check back shortly.'}
-            </Typography>
-          </Paper>
-        )}
+              <TableBody>
+                {loading && (
+                  <TableRow>
+                    <TableCell colSpan={columnCount} align="center" sx={{ py: 6 }}>
+                      <CircularProgress size={28} />
+                    </TableCell>
+                  </TableRow>
+                )}
 
-        {!loading && items.length > 0 && (
-          <>
-            <Grid container spacing={2}>
-              {items.map((item) => (
-                <Grid item xs={12} sm={6} lg={4} key={item.assignmentId}>
-                  <ResumeCard item={item} onOpen={setPreview} />
-                </Grid>
-              ))}
-            </Grid>
+                {!loading && items.length === 0 && (
+                  <TableRow>
+                    <TableCell colSpan={columnCount} align="center" sx={{ py: 6 }}>
+                      <Typography variant="subtitle1" gutterBottom>
+                        {noKindSelected
+                          ? 'No type selected'
+                          : search || activeFilterCount > 0
+                            ? 'No resumes match those filters'
+                            : 'No resumes have been shared yet'}
+                      </Typography>
+                      <Typography variant="body2" color="text.secondary">
+                        {noKindSelected
+                          ? 'Tick Members or Applicants to see resumes.'
+                          : search || activeFilterCount > 0
+                            ? 'Try widening the graduation year or major.'
+                            : 'UConsulting will add resumes to your library. Check back shortly.'}
+                      </Typography>
+                    </TableCell>
+                  </TableRow>
+                )}
 
-            {total > PAGE_SIZE && (
-              <Stack direction="row" spacing={2} justifyContent="center" alignItems="center" sx={{ mt: 3 }}>
-                <Button
-                  disabled={offset === 0}
-                  onClick={() => fetchResumes(Math.max(offset - PAGE_SIZE, 0), appliedSearch)}
-                >
-                  Previous
-                </Button>
-                <Typography variant="body2" color="text.secondary">
-                  Page {page} of {pageCount}
-                </Typography>
-                <Button
-                  disabled={offset + PAGE_SIZE >= total}
-                  onClick={() => fetchResumes(offset + PAGE_SIZE, appliedSearch)}
-                >
-                  Next
-                </Button>
-              </Stack>
-            )}
-          </>
-        )}
+                {!loading &&
+                  items.map((item) => {
+                    const isSelected = selected.has(item.assignmentId);
+                    const name = displayName(item);
+                    return (
+                      <TableRow
+                        key={item.assignmentId}
+                        hover
+                        selected={isSelected}
+                        sx={{ cursor: item.available ? 'pointer' : 'default' }}
+                        onClick={() => item.available && setPreview(item)}
+                      >
+                        <TableCell
+                          padding="checkbox"
+                          sx={COLUMNS.select}
+                          onClick={(e) => e.stopPropagation()}
+                        >
+                          <Checkbox
+                            checked={isSelected}
+                            onChange={() => toggleRow(item.assignmentId)}
+                            inputProps={{
+                              'aria-label': `Select ${name || referenceFor(item.assignmentId)}`,
+                            }}
+                          />
+                        </TableCell>
+
+                        <TableCell sx={COLUMNS.ref}>
+                          <Stack direction="row" spacing={1} alignItems="center">
+                            <Typography variant="body2" sx={{ fontFamily: 'monospace' }}>
+                              {referenceFor(item.assignmentId)}
+                            </Typography>
+                            {!item.available && (
+                              <Tooltip title="No resume file is available for this entry">
+                                <Chip size="small" variant="outlined" label="No file" />
+                              </Tooltip>
+                            )}
+                          </Stack>
+                        </TableCell>
+
+                        {showsIdentity && <TableCell sx={COLUMNS.name}>{name || '—'}</TableCell>}
+                        <TableCell sx={COLUMNS.kind}>
+                          {item.kind === 'MEMBER' ? 'Member' : 'Applicant'}
+                        </TableCell>
+                        <TableCell sx={COLUMNS.graduationYear}>
+                          {item.graduationYear || '—'}
+                        </TableCell>
+                        <TableCell sx={COLUMNS.major}>{item.major1 || '—'}</TableCell>
+                        <TableCell sx={COLUMNS.major2}>{item.major2 || '—'}</TableCell>
+                        {showsIdentity && (
+                          <TableCell sx={COLUMNS.gender}>{item.gender || '—'}</TableCell>
+                        )}
+                        {showsContact && (
+                          <TableCell align="right" sx={COLUMNS.gpa}>
+                            {item.cumulativeGpa || '—'}
+                          </TableCell>
+                        )}
+                        {showsContact && (
+                          <TableCell align="right" sx={COLUMNS.gpa}>
+                            {item.majorGpa || '—'}
+                          </TableCell>
+                        )}
+                        {showsContact && (
+                          <TableCell sx={COLUMNS.phone}>{item.phoneNumber || '—'}</TableCell>
+                        )}
+                        <TableCell sx={COLUMNS.assignedAt}>
+                          {item.assignedAt ? item.assignedAt.slice(0, 10) : '—'}
+                        </TableCell>
+                        {showsContact && (
+                          <TableCell sx={COLUMNS.email}>{item.email || '—'}</TableCell>
+                        )}
+                      </TableRow>
+                    );
+                  })}
+              </TableBody>
+            </Table>
+          </TableContainer>
+
+          <TablePagination
+            component="div"
+            count={total}
+            page={page}
+            onPageChange={(_, next) => setPage(next)}
+            rowsPerPage={rowsPerPage}
+            rowsPerPageOptions={ROWS_PER_PAGE_OPTIONS}
+            onRowsPerPageChange={(e) => {
+              setRowsPerPage(parseInt(e.target.value, 10));
+              resetPage();
+            }}
+          />
+        </Paper>
 
         {preview && (
           <DocumentPreviewModal
             src={preview.pdfUrl}
             kind="pdf"
-            title={displayName(preview) || 'Resume'}
+            title={displayName(preview) || `Resume ${referenceFor(preview.assignmentId)}`}
             onClose={() => setPreview(null)}
           />
         )}

--- a/client/src/pages/ClientResumeLibrary.jsx
+++ b/client/src/pages/ClientResumeLibrary.jsx
@@ -1,0 +1,273 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  Card,
+  CardActionArea,
+  CardContent,
+  Chip,
+  CircularProgress,
+  Grid,
+  Paper,
+  Stack,
+  TextField,
+  Typography,
+} from '@mui/material';
+import SearchIcon from '@mui/icons-material/Search';
+import AccessControl from '../components/AccessControl';
+import DocumentPreviewModal from '../components/DocumentPreviewModal';
+import apiClient from '../utils/api';
+
+// The only page a Talent Partner Network client sees.
+//
+// There is deliberately no download control anywhere in here. The PDF is shown
+// through DocumentPreviewModal, which fetches a blob and renders it in an
+// iframe with the viewer toolbar suppressed. That is deterrence plus an audit
+// trail, not prevention - see the note in the branch README/plan.
+
+const PAGE_SIZE = 24;
+
+// Under BLIND the server omits identity keys entirely rather than nulling them,
+// so presence is the signal.
+const displayName = (item) => {
+  if (item.firstName || item.lastName) {
+    return [item.firstName, item.lastName].filter(Boolean).join(' ');
+  }
+  return null;
+};
+
+const ResumeCard = ({ item, onOpen }) => {
+  const name = displayName(item);
+  const majors = [item.major1, item.major2].filter(Boolean).join(' · ');
+
+  return (
+    <Card variant="outlined" sx={{ height: '100%' }}>
+      <CardActionArea
+        onClick={() => onOpen(item)}
+        disabled={!item.available}
+        sx={{ height: '100%', alignItems: 'flex-start' }}
+      >
+        <CardContent sx={{ width: '100%' }}>
+          <Stack direction="row" justifyContent="space-between" alignItems="flex-start" spacing={1}>
+            <Typography variant="subtitle1" sx={{ fontWeight: 500 }}>
+              {name || 'Candidate'}
+            </Typography>
+            <Chip
+              size="small"
+              label={item.kind === 'MEMBER' ? 'Member' : 'Applicant'}
+              variant="outlined"
+            />
+          </Stack>
+
+          <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
+            {majors || 'Major not recorded'}
+          </Typography>
+
+          <Stack direction="row" spacing={1} sx={{ mt: 1.5 }} flexWrap="wrap" useFlexGap>
+            {item.graduationYear && (
+              <Chip size="small" label={`Class of ${item.graduationYear}`} />
+            )}
+            {item.gender && <Chip size="small" label={item.gender} variant="outlined" />}
+            {item.cumulativeGpa && (
+              <Chip size="small" label={`GPA ${item.cumulativeGpa}`} variant="outlined" />
+            )}
+          </Stack>
+
+          {item.email && (
+            <Typography variant="body2" color="text.secondary" sx={{ mt: 1.5 }}>
+              {item.email}
+            </Typography>
+          )}
+
+          {!item.available && (
+            <Typography variant="caption" color="text.secondary" sx={{ mt: 1.5, display: 'block' }}>
+              Resume not available
+            </Typography>
+          )}
+        </CardContent>
+      </CardActionArea>
+    </Card>
+  );
+};
+
+const ClientResumeLibrary = () => {
+  const [account, setAccount] = useState(null);
+  const [items, setItems] = useState([]);
+  const [total, setTotal] = useState(0);
+  const [offset, setOffset] = useState(0);
+  const [pendingSearch, setPendingSearch] = useState('');
+  const [appliedSearch, setAppliedSearch] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [preview, setPreview] = useState(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    apiClient
+      .get('/client/me')
+      .then((data) => {
+        if (!cancelled) setAccount(data);
+      })
+      .catch((err) => {
+        if (!cancelled) setError(err.message || 'Failed to load your account');
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const fetchResumes = useCallback(async (nextOffset, search) => {
+    setLoading(true);
+    setError('');
+    try {
+      const params = new URLSearchParams({ limit: String(PAGE_SIZE), offset: String(nextOffset) });
+      if (search) params.set('q', search);
+      const data = await apiClient.get(`/client/resumes?${params.toString()}`);
+      setItems(data.items || []);
+      setTotal(data.total || 0);
+      setOffset(nextOffset);
+    } catch (err) {
+      setError(err.message || 'Failed to load your resume library');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchResumes(0, '');
+  }, [fetchResumes]);
+
+  const applySearch = () => {
+    setAppliedSearch(pendingSearch.trim());
+    fetchResumes(0, pendingSearch.trim());
+  };
+
+  const clearSearch = () => {
+    setPendingSearch('');
+    setAppliedSearch('');
+    fetchResumes(0, '');
+  };
+
+  const page = Math.floor(offset / PAGE_SIZE) + 1;
+  const pageCount = Math.max(Math.ceil(total / PAGE_SIZE), 1);
+
+  return (
+    <AccessControl allowedRoles={['CLIENT']}>
+      <Box sx={{ p: 3 }}>
+        <Stack
+          direction={{ xs: 'column', md: 'row' }}
+          justifyContent="space-between"
+          alignItems={{ md: 'center' }}
+          spacing={1}
+          sx={{ mb: 3 }}
+        >
+          <Box>
+            <Typography variant="h4">Resume Library</Typography>
+            <Typography variant="body2" color="text.secondary">
+              {account?.organization
+                ? `${account.organization} — ${total} resume${total === 1 ? '' : 's'} shared with you`
+                : 'Loading your account…'}
+            </Typography>
+          </Box>
+        </Stack>
+
+        {error && (
+          <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError('')}>
+            {error}
+          </Alert>
+        )}
+
+        <Paper sx={{ p: 1.5, mb: 3 }}>
+          <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1} alignItems="center">
+            <TextField
+              size="small"
+              fullWidth
+              placeholder={
+                account?.visibility === 'BLIND'
+                  ? 'Search by major or graduation year'
+                  : 'Search by name, major, or graduation year'
+              }
+              value={pendingSearch}
+              onChange={(e) => setPendingSearch(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') applySearch();
+              }}
+              InputProps={{ startAdornment: <SearchIcon fontSize="small" sx={{ mr: 1 }} /> }}
+            />
+            <Button variant="contained" onClick={applySearch} disabled={loading}>
+              Search
+            </Button>
+            {appliedSearch && (
+              <Button onClick={clearSearch} disabled={loading}>
+                Clear
+              </Button>
+            )}
+          </Stack>
+        </Paper>
+
+        {loading && (
+          <Box sx={{ display: 'flex', justifyContent: 'center', py: 6 }}>
+            <CircularProgress />
+          </Box>
+        )}
+
+        {!loading && items.length === 0 && (
+          <Paper sx={{ p: 4, textAlign: 'center' }}>
+            <Typography variant="h6" gutterBottom>
+              {appliedSearch ? 'No resumes match that search' : 'No resumes have been shared yet'}
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              {appliedSearch
+                ? 'Try a different major or graduation year.'
+                : 'UConsulting will add resumes to your library. Check back shortly.'}
+            </Typography>
+          </Paper>
+        )}
+
+        {!loading && items.length > 0 && (
+          <>
+            <Grid container spacing={2}>
+              {items.map((item) => (
+                <Grid item xs={12} sm={6} lg={4} key={item.assignmentId}>
+                  <ResumeCard item={item} onOpen={setPreview} />
+                </Grid>
+              ))}
+            </Grid>
+
+            {total > PAGE_SIZE && (
+              <Stack direction="row" spacing={2} justifyContent="center" alignItems="center" sx={{ mt: 3 }}>
+                <Button
+                  disabled={offset === 0}
+                  onClick={() => fetchResumes(Math.max(offset - PAGE_SIZE, 0), appliedSearch)}
+                >
+                  Previous
+                </Button>
+                <Typography variant="body2" color="text.secondary">
+                  Page {page} of {pageCount}
+                </Typography>
+                <Button
+                  disabled={offset + PAGE_SIZE >= total}
+                  onClick={() => fetchResumes(offset + PAGE_SIZE, appliedSearch)}
+                >
+                  Next
+                </Button>
+              </Stack>
+            )}
+          </>
+        )}
+
+        {preview && (
+          <DocumentPreviewModal
+            src={preview.pdfUrl}
+            kind="pdf"
+            title={displayName(preview) || 'Resume'}
+            onClose={() => setPreview(null)}
+          />
+        )}
+      </Box>
+    </AccessControl>
+  );
+};
+
+export default ClientResumeLibrary;

--- a/client/src/pages/ClientResumeLibrary.test.jsx
+++ b/client/src/pages/ClientResumeLibrary.test.jsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import ClientResumeLibrary from './ClientResumeLibrary';
@@ -18,10 +18,11 @@ vi.mock('../components/DocumentPreviewModal', () => ({
 }));
 
 const blindItem = {
-  assignmentId: 'assign-1',
+  assignmentId: 'assign-1aaa-bbbb',
   kind: 'APPLICANT',
-  pdfUrl: '/api/client/resumes/assign-1/pdf',
+  pdfUrl: '/api/client/resumes/assign-1aaa-bbbb/pdf',
   available: true,
+  assignedAt: '2026-08-01T00:00:00.000Z',
   graduationYear: '2030',
   major1: 'Business Economics',
   major2: null,
@@ -29,22 +30,67 @@ const blindItem = {
 
 const fullItem = {
   ...blindItem,
-  assignmentId: 'assign-2',
-  pdfUrl: '/api/client/resumes/assign-2/pdf',
+  assignmentId: 'assign-2ccc-dddd',
+  pdfUrl: '/api/client/resumes/assign-2ccc-dddd/pdf',
   firstName: 'Jane',
   lastName: 'Doe',
   gender: 'Female',
   email: 'jane@ucla.edu',
+  phoneNumber: '310-555-0100',
   cumulativeGpa: '3.85',
+  majorGpa: '3.92',
 };
 
-const mockApi = ({ visibility = 'BASIC', items = [], total = items.length } = {}) => {
+// Matches what GET /api/client/me actually returns: the field lists are derived
+// server-side from the same visibility the projection uses, and the page renders
+// its controls from them.
+const FIELDS_BY_VISIBILITY = {
+  BLIND: {
+    filterableFields: ['kind', 'graduationYear', 'major'],
+    sortableFields: ['graduationYear', 'major', 'kind', 'assignedAt'],
+  },
+  BASIC: {
+    filterableFields: ['kind', 'graduationYear', 'major', 'gender'],
+    sortableFields: ['graduationYear', 'major', 'kind', 'assignedAt', 'name', 'gender'],
+  },
+  FULL: {
+    filterableFields: ['kind', 'graduationYear', 'major', 'gender', 'gpa'],
+    sortableFields: [
+      'graduationYear',
+      'major',
+      'kind',
+      'assignedAt',
+      'name',
+      'gender',
+      'cumulativeGpa',
+      'majorGpa',
+    ],
+  },
+};
+
+const mockApi = ({ visibility = 'BASIC', items = [], total = items.length, facets } = {}) => {
   apiClient.get = vi.fn((url) => {
     if (url.startsWith('/client/me')) {
-      return Promise.resolve({ organization: 'Acme Recruiting', visibility, resumeCount: total });
+      return Promise.resolve({
+        organization: 'Acme Recruiting',
+        visibility,
+        resumeCount: total,
+        maxExport: 1000,
+        ...FIELDS_BY_VISIBILITY[visibility],
+      });
+    }
+    if (url.startsWith('/client/facets')) {
+      return Promise.resolve(
+        facets || {
+          graduationYear: ['2029', '2030'],
+          major: ['Business Economics', 'Statistics'],
+          gender: ['Female', 'Male'],
+          kind: ['APPLICANT'],
+        }
+      );
     }
     if (url.startsWith('/client/resumes')) {
-      return Promise.resolve({ items, total, limit: 24, offset: 0 });
+      return Promise.resolve({ items, total, limit: 25, offset: 0, notes: [] });
     }
     return Promise.resolve({});
   });
@@ -57,9 +103,16 @@ const renderPage = () =>
     </MemoryRouter>
   );
 
+const lastResumesCall = () =>
+  apiClient.get.mock.calls.map(([url]) => url).filter((url) => url.startsWith('/client/resumes')).pop();
+
 beforeEach(() => {
   vi.clearAllMocks();
   apiClient.token = 'test-token';
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
 });
 
 describe('ClientResumeLibrary', () => {
@@ -72,23 +125,61 @@ describe('ClientResumeLibrary', () => {
     expect(screen.getByText(/Business Economics/)).toBeInTheDocument();
   });
 
-  it('renders a blind row without a name', async () => {
+  it('renders a blind row with an opaque reference instead of a name', async () => {
     mockApi({ visibility: 'BLIND', items: [blindItem] });
     renderPage();
 
-    await waitFor(() => expect(screen.getByText('Candidate')).toBeInTheDocument());
+    // Under BLIND there is no name to show, so the row is identified by a
+    // prefix of the assignment id the client already holds.
+    await waitFor(() => expect(screen.getByText('ASSIGN1A')).toBeInTheDocument());
     expect(screen.queryByText('Jane Doe')).not.toBeInTheDocument();
   });
 
-  it('offers no way to download a resume', async () => {
+  it('omits the columns a visibility level hides rather than blanking them', async () => {
+    mockApi({ visibility: 'BLIND', items: [blindItem] });
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText('ASSIGN1A')).toBeInTheDocument());
+
+    const headers = screen.getAllByRole('columnheader').map((h) => h.textContent);
+    expect(headers).not.toContain('Name');
+    expect(headers).not.toContain('Gender');
+    expect(headers).not.toContain('GPA');
+    expect(headers).not.toContain('Email');
+    expect(headers).toContain('Class');
+  });
+
+  it('shows the identity and contact columns at FULL', async () => {
+    mockApi({ visibility: 'FULL', items: [fullItem] });
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText('Jane Doe')).toBeInTheDocument());
+
+    const headers = screen.getAllByRole('columnheader').map((h) => h.textContent);
+    expect(headers).toEqual(expect.arrayContaining(['Name', 'Gender', 'GPA', 'Email', 'Phone']));
+    expect(screen.getByText('jane@ucla.edu')).toBeInTheDocument();
+    expect(screen.getByText('3.85')).toBeInTheDocument();
+    expect(screen.getByText('3.92')).toBeInTheDocument();
+  });
+
+  it('puts email last, where a long address has no column to spill into', async () => {
+    mockApi({ visibility: 'FULL', items: [fullItem] });
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText('Jane Doe')).toBeInTheDocument());
+
+    const headers = screen.getAllByRole('columnheader').map((h) => h.textContent);
+    expect(headers[headers.length - 1]).toBe('Email');
+  });
+
+  it('offers no way to download a resume file', async () => {
     mockApi({ items: [fullItem] });
     const { container } = renderPage();
 
     await waitFor(() => expect(screen.getByText('Jane Doe')).toBeInTheDocument());
 
-    // View-only is the whole point: no download control, and nothing that
-    // hands the browser a file directly.
-    expect(screen.queryByText(/download/i)).not.toBeInTheDocument();
+    // View-only is still the point for the PDFs themselves. The CSV export is
+    // metadata, and it goes through a POST, not a download link.
     expect(container.querySelector('a[download]')).toBeNull();
     expect(container.querySelector('a[href^="https://drive.google.com"]')).toBeNull();
   });
@@ -101,7 +192,7 @@ describe('ClientResumeLibrary', () => {
     await userEvent.click(screen.getByText('Jane Doe'));
 
     const preview = await screen.findByTestId('preview');
-    expect(preview.getAttribute('data-src')).toBe('/api/client/resumes/assign-2/pdf');
+    expect(preview.getAttribute('data-src')).toBe('/api/client/resumes/assign-2ccc-dddd/pdf');
   });
 
   it('shows an empty state when nothing has been shared yet', async () => {
@@ -117,7 +208,10 @@ describe('ClientResumeLibrary', () => {
     mockApi({ visibility: 'BLIND', items: [{ ...blindItem, available: false }] });
     renderPage();
 
-    await waitFor(() => expect(screen.getByText(/Resume not available/i)).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText('No file')).toBeInTheDocument());
+
+    await userEvent.click(screen.getByText('ASSIGN1A'));
+    expect(screen.queryByTestId('preview')).not.toBeInTheDocument();
   });
 
   it('tells a blind client the search does not cover names', async () => {
@@ -137,8 +231,263 @@ describe('ClientResumeLibrary', () => {
     await userEvent.type(screen.getByPlaceholderText(/Search by name/i), 'econ');
     await userEvent.click(screen.getByRole('button', { name: /^search$/i }));
 
+    await waitFor(() => expect(lastResumesCall()).toContain('q=econ'));
+  });
+});
+
+describe('filtering', () => {
+  it('sends a selected graduation year to the server', async () => {
+    mockApi({ items: [fullItem] });
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText('Jane Doe')).toBeInTheDocument());
+
+    await userEvent.click(screen.getByLabelText('Graduation year'));
+    await userEvent.click(await screen.findByRole('option', { name: '2030' }));
+
+    await waitFor(() => expect(lastResumesCall()).toContain('graduationYear=2030'));
+  });
+
+  it('does not offer a gender filter to a blind client', async () => {
+    mockApi({ visibility: 'BLIND', items: [blindItem] });
+    renderPage();
+
+    await waitFor(() => expect(screen.getByLabelText('Graduation year')).toBeInTheDocument());
+    expect(screen.queryByLabelText('Gender')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Min GPA')).not.toBeInTheDocument();
+  });
+
+  it('offers the gender filter at BASIC and the GPA range only at FULL', async () => {
+    mockApi({ visibility: 'BASIC', items: [fullItem] });
+    const { unmount } = renderPage();
+
+    await waitFor(() => expect(screen.getByLabelText('Gender')).toBeInTheDocument());
+    expect(screen.queryByLabelText('Min GPA')).not.toBeInTheDocument();
+    unmount();
+
+    mockApi({ visibility: 'FULL', items: [fullItem] });
+    renderPage();
+
+    await waitFor(() => expect(screen.getByLabelText('Min GPA')).toBeInTheDocument());
+  });
+
+  it('starts with both types included and asks for no kind at all', async () => {
+    mockApi({ items: [fullItem] });
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText('Jane Doe')).toBeInTheDocument());
+
+    expect(screen.getByRole('checkbox', { name: 'Members' })).toBeChecked();
+    expect(screen.getByRole('checkbox', { name: 'Applicants' })).toBeChecked();
+    // Both ticked is the whole library, which is no filter rather than an
+    // impossible "APPLICANT and MEMBER".
+    expect(lastResumesCall()).not.toContain('kind=');
+  });
+
+  it('narrows to one type when the other is unticked', async () => {
+    mockApi({ items: [fullItem] });
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText('Jane Doe')).toBeInTheDocument());
+
+    await userEvent.click(screen.getByRole('checkbox', { name: 'Applicants' }));
+    await waitFor(() => expect(lastResumesCall()).toContain('kind=MEMBER'));
+  });
+
+  it('asks the server for nothing when neither type is ticked', async () => {
+    mockApi({ items: [fullItem] });
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText('Jane Doe')).toBeInTheDocument());
+    const before = apiClient.get.mock.calls.length;
+
+    await userEvent.click(screen.getByRole('checkbox', { name: 'Applicants' }));
+    await waitFor(() => expect(lastResumesCall()).toContain('kind=MEMBER'));
+    const afterFirst = apiClient.get.mock.calls.length;
+
+    await userEvent.click(screen.getByRole('checkbox', { name: 'Members' }));
+
+    // An empty selection matches nothing. Sending it would drop the kind param
+    // entirely and come back with the unfiltered library, which reads as the
+    // filter being ignored.
+    await waitFor(() => expect(screen.getByText('No type selected')).toBeInTheDocument());
+    expect(apiClient.get.mock.calls.length).toBe(afterFirst);
+    expect(afterFirst).toBeGreaterThan(before);
+  });
+
+  it('returns to the first page when a filter narrows the set', async () => {
+    mockApi({ items: [fullItem], total: 200 });
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText('Jane Doe')).toBeInTheDocument());
+
+    await userEvent.click(screen.getByRole('button', { name: /go to next page/i }));
+    await waitFor(() => expect(lastResumesCall()).toContain('offset=25'));
+
+    await userEvent.click(screen.getByLabelText('Major'));
+    await userEvent.click(await screen.findByRole('option', { name: 'Statistics' }));
+
+    // Narrowing while on page 2 would otherwise land on an empty page that
+    // reads as "no results" when there are plenty.
+    await waitFor(() => expect(lastResumesCall()).toContain('offset=0'));
+  });
+});
+
+describe('sorting', () => {
+  it('toggles direction on the active column and sends it to the server', async () => {
+    mockApi({ visibility: 'FULL', items: [fullItem] });
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText('Jane Doe')).toBeInTheDocument());
+
+    await userEvent.click(screen.getByRole('button', { name: /^name$/i }));
+    await waitFor(() => expect(lastResumesCall()).toContain('sort=name&dir=asc'));
+
+    await userEvent.click(screen.getByRole('button', { name: /^name$/i }));
+    await waitFor(() => expect(lastResumesCall()).toContain('sort=name&dir=desc'));
+  });
+
+  it('sorts by every numeric column a FULL client can see', async () => {
+    mockApi({ visibility: 'FULL', items: [fullItem] });
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText('Jane Doe')).toBeInTheDocument());
+
+    await userEvent.click(screen.getByRole('button', { name: /^major gpa$/i }));
+    await waitFor(() => expect(lastResumesCall()).toContain('sort=majorGpa'));
+
+    await userEvent.click(screen.getByRole('button', { name: /^gpa$/i }));
+    await waitFor(() => expect(lastResumesCall()).toContain('sort=cumulativeGpa'));
+
+    await userEvent.click(screen.getByRole('button', { name: /^class$/i }));
+    await waitFor(() => expect(lastResumesCall()).toContain('sort=graduationYear'));
+  });
+
+  it('does not make a hidden column sortable', async () => {
+    mockApi({ visibility: 'BLIND', items: [blindItem] });
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText('ASSIGN1A')).toBeInTheDocument());
+    expect(screen.queryByRole('button', { name: /^gpa$/i })).not.toBeInTheDocument();
+  });
+});
+
+describe('selection and export', () => {
+  const setupExport = () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      headers: { get: () => 'attachment; filename="acme-recruiting-resumes-2026-08-26.csv"' },
+      blob: async () => new Blob(['ref,name'], { type: 'text/csv' }),
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+    // jsdom implements neither of these, and the export path uses both.
+    vi.stubGlobal('URL', {
+      ...URL,
+      createObjectURL: vi.fn(() => 'blob:mock'),
+      revokeObjectURL: vi.fn(),
+    });
+    return fetchMock;
+  };
+
+  it('disables export until something is selected', async () => {
+    mockApi({ items: [fullItem] });
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText('Jane Doe')).toBeInTheDocument());
+    expect(screen.getByRole('button', { name: /export csv/i })).toBeDisabled();
+  });
+
+  it('posts only the selected assignment ids', async () => {
+    const fetchMock = setupExport();
+    mockApi({ items: [fullItem, { ...blindItem, firstName: 'Sam', lastName: 'Lee' }] });
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText('Jane Doe')).toBeInTheDocument());
+
+    await userEvent.click(screen.getByLabelText('Select Jane Doe'));
+    expect(screen.getByText('1 selected')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: /export csv/i }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    const [url, options] = fetchMock.mock.calls[0];
+    expect(url).toBe('/api/client/resumes/export');
+    expect(options.method).toBe('POST');
+    expect(JSON.parse(options.body)).toEqual({ assignmentIds: ['assign-2ccc-dddd'] });
+  });
+
+  it('selects every row on the page from the header checkbox', async () => {
+    mockApi({ items: [fullItem, { ...blindItem, firstName: 'Sam', lastName: 'Lee' }] });
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText('Jane Doe')).toBeInTheDocument());
+
+    await userEvent.click(screen.getByLabelText('Select all rows on this page'));
+    expect(screen.getByText('2 selected')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByLabelText('Select all rows on this page'));
+    expect(screen.getByText('0 selected')).toBeInTheDocument();
+  });
+
+  it('checking a row does not open the resume preview', async () => {
+    mockApi({ items: [fullItem] });
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText('Jane Doe')).toBeInTheDocument());
+    await userEvent.click(screen.getByLabelText('Select Jane Doe'));
+
+    expect(screen.queryByTestId('preview')).not.toBeInTheDocument();
+  });
+
+  it('surfaces the server error when an export is refused', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: false,
+        status: 400,
+        json: async () => ({ error: 'You can export at most 1000 resumes at a time.' }),
+      }))
+    );
+    mockApi({ items: [fullItem] });
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText('Jane Doe')).toBeInTheDocument());
+    await userEvent.click(screen.getByLabelText('Select Jane Doe'));
+    await userEvent.click(screen.getByRole('button', { name: /export csv/i }));
+
     await waitFor(() =>
-      expect(apiClient.get).toHaveBeenCalledWith(expect.stringContaining('q=econ'))
+      expect(screen.getByText(/at most 1000 resumes/i)).toBeInTheDocument()
+    );
+  });
+});
+
+describe('truncation', () => {
+  it('reports a bounded result set instead of presenting a prefix as the whole library', async () => {
+    apiClient.get = vi.fn((url) => {
+      if (url.startsWith('/client/me')) {
+        return Promise.resolve({
+          organization: 'Acme Recruiting',
+          visibility: 'BASIC',
+          resumeCount: 5000,
+          maxExport: 1000,
+          ...FIELDS_BY_VISIBILITY.BASIC,
+        });
+      }
+      if (url.startsWith('/client/facets')) return Promise.resolve({});
+      return Promise.resolve({
+        items: [fullItem],
+        total: 5000,
+        truncated: true,
+        notes: ['Showing the 2000 most recently shared resumes of 5000. Narrow the filters to see the rest.'],
+        limit: 25,
+        offset: 0,
+      });
+    });
+    renderPage();
+
+    await waitFor(() =>
+      expect(screen.getByText(/2000 most recently shared resumes of 5000/i)).toBeInTheDocument()
     );
   });
 });

--- a/client/src/pages/ClientResumeLibrary.test.jsx
+++ b/client/src/pages/ClientResumeLibrary.test.jsx
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import ClientResumeLibrary from './ClientResumeLibrary';
+import apiClient from '../utils/api';
+
+vi.mock('../components/AccessControl', () => ({ default: ({ children }) => children }));
+vi.mock('../context/AuthContext', () => ({
+  useAuth: () => ({ user: { id: 'client-1', role: 'CLIENT', fullName: 'Acme Recruiting' }, token: 't' }),
+}));
+vi.mock('../components/DocumentPreviewModal', () => ({
+  default: ({ src, title }) => (
+    <div data-testid="preview" data-src={src}>
+      {title}
+    </div>
+  ),
+}));
+
+const blindItem = {
+  assignmentId: 'assign-1',
+  kind: 'APPLICANT',
+  pdfUrl: '/api/client/resumes/assign-1/pdf',
+  available: true,
+  graduationYear: '2030',
+  major1: 'Business Economics',
+  major2: null,
+};
+
+const fullItem = {
+  ...blindItem,
+  assignmentId: 'assign-2',
+  pdfUrl: '/api/client/resumes/assign-2/pdf',
+  firstName: 'Jane',
+  lastName: 'Doe',
+  gender: 'Female',
+  email: 'jane@ucla.edu',
+  cumulativeGpa: '3.85',
+};
+
+const mockApi = ({ visibility = 'BASIC', items = [], total = items.length } = {}) => {
+  apiClient.get = vi.fn((url) => {
+    if (url.startsWith('/client/me')) {
+      return Promise.resolve({ organization: 'Acme Recruiting', visibility, resumeCount: total });
+    }
+    if (url.startsWith('/client/resumes')) {
+      return Promise.resolve({ items, total, limit: 24, offset: 0 });
+    }
+    return Promise.resolve({});
+  });
+};
+
+const renderPage = () =>
+  render(
+    <MemoryRouter>
+      <ClientResumeLibrary />
+    </MemoryRouter>
+  );
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  apiClient.token = 'test-token';
+});
+
+describe('ClientResumeLibrary', () => {
+  it('renders the assigned resumes with the organization name', async () => {
+    mockApi({ items: [fullItem] });
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText('Jane Doe')).toBeInTheDocument());
+    expect(screen.getByText(/Acme Recruiting/)).toBeInTheDocument();
+    expect(screen.getByText(/Business Economics/)).toBeInTheDocument();
+  });
+
+  it('renders a blind row without a name', async () => {
+    mockApi({ visibility: 'BLIND', items: [blindItem] });
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText('Candidate')).toBeInTheDocument());
+    expect(screen.queryByText('Jane Doe')).not.toBeInTheDocument();
+  });
+
+  it('offers no way to download a resume', async () => {
+    mockApi({ items: [fullItem] });
+    const { container } = renderPage();
+
+    await waitFor(() => expect(screen.getByText('Jane Doe')).toBeInTheDocument());
+
+    // View-only is the whole point: no download control, and nothing that
+    // hands the browser a file directly.
+    expect(screen.queryByText(/download/i)).not.toBeInTheDocument();
+    expect(container.querySelector('a[download]')).toBeNull();
+    expect(container.querySelector('a[href^="https://drive.google.com"]')).toBeNull();
+  });
+
+  it('opens the preview against the assignment-scoped proxy URL', async () => {
+    mockApi({ items: [fullItem] });
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText('Jane Doe')).toBeInTheDocument());
+    await userEvent.click(screen.getByText('Jane Doe'));
+
+    const preview = await screen.findByTestId('preview');
+    expect(preview.getAttribute('data-src')).toBe('/api/client/resumes/assign-2/pdf');
+  });
+
+  it('shows an empty state when nothing has been shared yet', async () => {
+    mockApi({ items: [] });
+    renderPage();
+
+    await waitFor(() =>
+      expect(screen.getByText(/No resumes have been shared yet/i)).toBeInTheDocument()
+    );
+  });
+
+  it('marks an unavailable resume rather than opening a pane that 404s', async () => {
+    mockApi({ visibility: 'BLIND', items: [{ ...blindItem, available: false }] });
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText(/Resume not available/i)).toBeInTheDocument());
+  });
+
+  it('tells a blind client the search does not cover names', async () => {
+    mockApi({ visibility: 'BLIND', items: [blindItem] });
+    renderPage();
+
+    await waitFor(() =>
+      expect(screen.getByPlaceholderText(/Search by major or graduation year/i)).toBeInTheDocument()
+    );
+  });
+
+  it('sends the search term to the server', async () => {
+    mockApi({ items: [fullItem] });
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText('Jane Doe')).toBeInTheDocument());
+    await userEvent.type(screen.getByPlaceholderText(/Search by name/i), 'econ');
+    await userEvent.click(screen.getByRole('button', { name: /^search$/i }));
+
+    await waitFor(() =>
+      expect(apiClient.get).toHaveBeenCalledWith(expect.stringContaining('q=econ'))
+    );
+  });
+});

--- a/client/src/pages/Login.jsx
+++ b/client/src/pages/Login.jsx
@@ -22,7 +22,7 @@ const Login = () => {
   // Redirect if user is already logged in
   useEffect(() => {
     if (!loading && user) {
-      navigate('/dashboard');
+      navigate(user.role === 'CLIENT' ? '/partner/resumes' : '/dashboard');
     }
   }, [user, loading, navigate]);
 
@@ -47,7 +47,9 @@ const Login = () => {
     const result = await login(email, password);
 
     if (result.success) {
-      navigate('/application-list');
+      // Talent Partner Network clients have exactly one page, and every other
+      // route 403s for them.
+      navigate(result.user?.role === 'CLIENT' ? '/partner/resumes' : '/application-list');
     } else {
       setError(result.error);
     }

--- a/client/src/pages/MemberDashboard.jsx
+++ b/client/src/pages/MemberDashboard.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useAuth } from '../context/AuthContext';
+import MemberResumeCard from '../components/MemberResumeCard';
 import {
   Box,
   Typography,
@@ -218,6 +219,8 @@ export default function MemberDashboard() {
           Welcome, {user?.fullName}.
         </Typography>
       </Box>
+
+      <MemberResumeCard />
 
       {/* Tasks and Resources Container */}
       <Grid container spacing={3}>

--- a/client/src/pages/TalentPoolPartnerNetwork.jsx
+++ b/client/src/pages/TalentPoolPartnerNetwork.jsx
@@ -22,7 +22,10 @@ import {
   InputLabel,
   LinearProgress,
 } from '@mui/material';
+import Tabs from '@mui/material/Tabs';
+import Tab from '@mui/material/Tab';
 import AccessControl from '../components/AccessControl';
+import TalentPoolClients from '../components/TalentPoolClients';
 import apiClient from '../utils/api';
 import { useAuth } from '../context/AuthContext';
 
@@ -87,6 +90,8 @@ const TalentPoolPartnerNetwork = () => {
   const [error, setError] = useState('');
   const [search, setSearch] = useState('');
   const [openingResumeId, setOpeningResumeId] = useState(null);
+  // Overview is the original opt-in roster; Clients is the portal side.
+  const [tab, setTab] = useState('overview');
 
   const load = useCallback(async (targetCycleId) => {
     setLoading(true);
@@ -200,6 +205,15 @@ const TalentPoolPartnerNetwork = () => {
           </Typography>
         </Box>
 
+        <Tabs value={tab} onChange={(_, v) => setTab(v)} sx={{ mb: 3 }}>
+          <Tab value="overview" label="Opt-in overview" />
+          <Tab value="clients" label="Partner clients" />
+        </Tabs>
+
+        {tab === 'clients' && <TalentPoolClients />}
+
+        {tab === 'overview' && (
+        <>
         {error && <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError('')}>{error}</Alert>}
         {loading && <LinearProgress sx={{ mb: 2 }} />}
 
@@ -356,6 +370,8 @@ const TalentPoolPartnerNetwork = () => {
             </TableContainer>
           )}
         </Paper>
+        </>
+        )}
       </Box>
     </AccessControl>
   );

--- a/client/src/styles/ClientLayout.css
+++ b/client/src/styles/ClientLayout.css
@@ -241,6 +241,17 @@
   width: 100%;
 }
 
+/* `.content-container` is a global class name shared with Layout.css and
+   CandidateLayout.css, all three capping at 1200px. A client's only page is a
+   wide spreadsheet, so it gets the whole viewport instead - zooming out then
+   actually buys more columns rather than just shrinking the text.
+   Scoped by ancestor so the specificity beats the other two files' rule no
+   matter which order the bundler emits them in, and so neither the admin nor
+   the candidate layout changes. */
+.client-layout-container .content-container {
+  max-width: none;
+}
+
 /* Responsive Design */
 @media (min-width: 768px) {
   .mobile-menu-btn {

--- a/client/src/styles/ClientLayout.css
+++ b/client/src/styles/ClientLayout.css
@@ -1,0 +1,318 @@
+@import './variables.css';
+
+/* Candidate Layout Styles */
+.client-layout-container {
+  min-height: 100vh;
+  background-color: var(--bg-primary);
+  font-family: var(--font-family);
+  display: flex;
+  flex-direction: column;
+}
+
+/* Top Navigation Bar */
+.client-top-nav {
+  background-color: var(--nav-bg);
+  box-shadow: var(--shadow-sm);
+  border-bottom: 1px solid var(--nav-border);
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 100;
+}
+
+.nav-container {
+  max-width: none;
+  margin: 0;
+  padding: 0 1.5rem;
+}
+
+.nav-content {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  height: 64px;
+}
+
+.nav-left {
+  display: flex;
+  align-items: center;
+}
+
+.mobile-menu-btn {
+  display: none;
+  padding: 0.5rem;
+  border-radius: var(--border-radius-sm);
+  color: var(--nav-text);
+  background: none;
+  border: none;
+  cursor: pointer;
+  margin-right: 1rem;
+}
+
+.mobile-menu-btn:hover {
+  color: var(--primary-blue);
+  background-color: var(--bg-gray-light);
+}
+
+.mobile-menu-btn:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--primary-blue);
+}
+
+.logo-section {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.logo-subtitle {
+  margin-left: 1rem;
+  font-size: 0.875rem;
+  color: var(--nav-text-secondary);
+}
+
+.nav-right {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.user-info {
+  text-align: right;
+}
+
+.user-name {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--nav-text);
+  margin: 0;
+}
+
+.user-role {
+  font-size: 0.75rem;
+  color: var(--nav-text-secondary);
+  margin: 0;
+}
+
+.logout-btn {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--primary-blue);
+  font-size: 0.875rem;
+  font-weight: 500;
+  border-radius: var(--border-radius-sm);
+  color: var(--primary-blue);
+  background-color: transparent;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.logout-btn:hover {
+  background-color: var(--primary-blue);
+  color: var(--text-white);
+}
+
+.logout-btn:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--primary-blue);
+}
+
+.logout-icon {
+  width: 1rem;
+  height: 1rem;
+  margin-right: 0.5rem;
+}
+
+/* Main Layout */
+.main-layout {
+  display: flex;
+  margin-top: 64px; /* Account for fixed header */
+  min-height: calc(100vh - 64px);
+}
+
+/* Candidate Sidebar */
+.client-sidebar {
+  width: 260px;
+  background-color: var(--bg-white);
+  border-right: 1px solid var(--border-light);
+  position: fixed;
+  top: 64px;
+  left: 0;
+  bottom: 0;
+  overflow-y: auto;
+  transform: translateX(-100%);
+  transition: transform 0.3s ease-in-out;
+  z-index: 50;
+}
+
+.client-sidebar.open {
+  transform: translateX(0);
+}
+
+.sidebar-content {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  padding: 1.5rem 0 1rem 0;
+}
+
+.sidebar-nav {
+  flex: 1;
+  padding: 0 1rem;
+  overflow-y: auto;
+}
+
+.nav-item {
+  display: flex;
+  align-items: center;
+  padding: 0.75rem 1rem;
+  margin-bottom: 0.125rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  text-decoration: none;
+  border-radius: var(--border-radius);
+  transition: all 0.2s;
+}
+
+.nav-item:not(.active) {
+  color: var(--text-secondary);
+}
+
+.nav-item:not(.active):hover {
+  background-color: var(--bg-primary);
+  color: var(--text-primary);
+}
+
+.nav-item.active {
+  background-color: var(--primary-blue);
+  color: var(--text-white);
+}
+
+.nav-icon {
+  width: 1.25rem;
+  height: 1.25rem;
+  margin-right: 0.75rem;
+  flex-shrink: 0;
+}
+
+.nav-item:not(.active) .nav-icon {
+  color: var(--text-muted);
+}
+
+.nav-item.active .nav-icon {
+  color: var(--text-white);
+}
+
+.nav-item:hover .nav-icon {
+  color: var(--text-secondary);
+}
+
+.nav-item.active:hover .nav-icon {
+  color: var(--text-white);
+}
+
+/* Mobile sidebar overlay */
+.sidebar-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 40;
+  background-color: var(--overlay);
+}
+
+/* Content Area */
+.content-area {
+  flex: 1;
+  margin-left: 0;
+  overflow-x: hidden;
+}
+
+.main-content {
+  padding: 2rem;
+  max-width: 100%;
+  min-height: calc(100vh - 64px);
+  overflow-y: auto;
+}
+
+.content-container {
+  max-width: 1200px;
+  margin: 0 auto;
+  width: 100%;
+}
+
+/* Responsive Design */
+@media (min-width: 768px) {
+  .mobile-menu-btn {
+    display: none;
+  }
+  
+  .logo-subtitle {
+    display: block;
+  }
+  
+  .user-info {
+    display: block;
+  }
+  
+  .client-sidebar {
+    position: fixed;
+    transform: translateX(0);
+  }
+  
+  .content-area {
+    margin-left: 260px;
+  }
+  
+  .main-content {
+    padding: 2rem 2rem 2rem 2rem;
+  }
+}
+
+@media (max-width: 767px) {
+  .mobile-menu-btn {
+    display: inline-flex;
+  }
+
+  .logo-subtitle {
+    display: none;
+  }
+
+  .user-info {
+    display: none;
+  }
+
+  .nav-container {
+    padding: 0 1rem;
+  }
+
+  .main-content {
+    padding: 1.5rem 1rem;
+  }
+
+  .client-sidebar {
+    width: min(85vw, 280px);
+  }
+}
+
+@media (max-width: 480px) {
+  .nav-container {
+    padding: 0 0.75rem;
+  }
+
+  .main-content {
+    padding: 1rem 0.75rem;
+  }
+
+  .logout-btn {
+    padding: 0.5rem;
+  }
+
+  .logout-btn .logout-text {
+    display: none;
+  }
+
+  .logout-icon {
+    margin-right: 0;
+  }
+}

--- a/client/src/styles/ClientResumeLibrary.css
+++ b/client/src/styles/ClientResumeLibrary.css
@@ -1,0 +1,33 @@
+/* Undoes, for this page only, the global MUI table overrides that Staging.css
+   and CandidateManagement.css declare on bare `.MuiTable-root` /
+   `.MuiTableContainer-root`. Those files are imported for their own pages but
+   nothing scopes their selectors, so every MUI table in the bundle inherits
+   them - including this one.
+
+   The three that break a spreadsheet view:
+
+     table-layout: fixed   - a column can no longer grow to fit its content, so
+                             a header like "Major GPA" is clipped and a long
+                             cell prints over its neighbour instead of widening
+                             or wrapping. It also makes `min-width` on a cell a
+                             no-op: under fixed layout only `width` counts.
+     min-width: 900px      - carries !important, so it beat the wider minimum
+                             this table sets and squeezed 13 columns into 900px.
+     overflow-y: visible   - defeats maxHeight on the container, which is what
+                             the sticky header scrolls inside.
+
+   Scoped to this page rather than fixed at the source: those selectors have
+   been styling the admin tables for as long as they have existed, and quietly
+   restyling every one of them is a much larger change than this branch is for.
+
+   !important is required here only because the rules being overridden use it. */
+
+.client-resume-library .MuiTable-root {
+  table-layout: auto !important;
+  min-width: 1080px !important;
+}
+
+.client-resume-library .MuiTableContainer-root {
+  overflow-x: auto !important;
+  overflow-y: auto !important;
+}

--- a/client/src/styles/theme.route-audit.test.js
+++ b/client/src/styles/theme.route-audit.test.js
@@ -9,6 +9,7 @@ const ROUTE_CSS_FILES = [
   'CandidateApplications.css',
   'CandidateEvents.css',
   'CandidateList.css',
+  'ClientLayout.css',
 ];
 
 const INTERVIEW_JSX_FILES = [

--- a/server/prisma/migrations/20260825130000_add_client_user_role/migration.sql
+++ b/server/prisma/migrations/20260825130000_add_client_user_role/migration.sql
@@ -1,0 +1,16 @@
+-- Talent Partner Network: the client role.
+--
+-- The TPN page already had a "Registered clients" stat card whose placeholder
+-- read "There is no client user role yet - accounts are USER, MEMBER, or ADMIN."
+-- This is that role. A CLIENT reaches only /api/client/* - see
+-- src/middleware/externalContainment.js.
+--
+-- Alone in its own migration on purpose: PostgreSQL forbids *using* a newly
+-- added enum value in the same transaction that added it. Nothing in the
+-- companion migration references the literal 'CLIENT', so one combined file
+-- would work today - but `prisma db execute` wraps a file in an implicit
+-- transaction and `prisma migrate deploy` in an explicit one, so the moment
+-- anyone adds a `WHERE role = 'CLIENT'` backfill here it would break in a way
+-- that is annoying to diagnose. Splitting costs nothing.
+
+ALTER TYPE "UserRole" ADD VALUE IF NOT EXISTS 'CLIENT';

--- a/server/prisma/migrations/20260825130100_add_client_resume_portal/migration.sql
+++ b/server/prisma/migrations/20260825130100_add_client_resume_portal/migration.sql
@@ -1,0 +1,189 @@
+-- Talent Partner Network: client resume portal.
+--
+-- Applicant consent is Application.talentPoolOptIn (added by the TPN migration
+-- 20260825000000_add_talent_pool_opt_in); member consent is
+-- member_resumes.shareConsent. Nothing here is assignable without one of those
+-- recording an explicit yes.
+--
+-- Written to be safely re-runnable (see CLAUDE.md: migrations here are applied
+-- with `prisma db execute`, which has no transaction wrapper of its own, so a
+-- half-applied file has to survive a second run). CREATE TYPE and
+-- ADD CONSTRAINT have no IF NOT EXISTS form, hence the DO/EXCEPTION guards.
+
+-- CreateEnum
+DO $$ BEGIN
+  CREATE TYPE "ResumeVisibility" AS ENUM ('BLIND', 'BASIC', 'FULL');
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+-- CreateTable
+CREATE TABLE IF NOT EXISTS "talent_partner_clients" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "organization" TEXT NOT NULL,
+    "visibility" "ResumeVisibility" NOT NULL DEFAULT 'BLIND',
+    "notes" TEXT,
+    "createdById" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    CONSTRAINT "talent_partner_clients_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE IF NOT EXISTS "member_resumes" (
+    "id" TEXT NOT NULL,
+    "memberId" TEXT NOT NULL,
+    "isCurrent" BOOLEAN NOT NULL DEFAULT true,
+    "storagePath" TEXT NOT NULL,
+    "originalName" TEXT NOT NULL,
+    "fileSize" INTEGER NOT NULL,
+    "major1" TEXT NOT NULL,
+    "major2" TEXT,
+    "graduationYear" TEXT NOT NULL,
+    "gender" TEXT,
+    "shareConsent" BOOLEAN NOT NULL DEFAULT false,
+    "consentAt" TIMESTAMP(3),
+    "consentRevokedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    CONSTRAINT "member_resumes_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE IF NOT EXISTS "client_assignment_batches" (
+    "id" TEXT NOT NULL,
+    "clientId" TEXT NOT NULL,
+    "createdById" TEXT NOT NULL,
+    "filterJson" JSONB,
+    "matchedCount" INTEGER NOT NULL DEFAULT 0,
+    "note" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "client_assignment_batches_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE IF NOT EXISTS "client_resume_assignments" (
+    "id" TEXT NOT NULL,
+    "clientId" TEXT NOT NULL,
+    "batchId" TEXT NOT NULL,
+    "applicationId" TEXT,
+    "memberResumeId" TEXT,
+    "assignedById" TEXT NOT NULL,
+    "assignedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "revokedAt" TIMESTAMP(3),
+    "revokedById" TEXT,
+    CONSTRAINT "client_resume_assignments_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE IF NOT EXISTS "client_resume_access_logs" (
+    "id" TEXT NOT NULL,
+    "clientId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "assignmentId" TEXT,
+    "ipAddress" TEXT,
+    "userAgent" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "client_resume_access_logs_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX IF NOT EXISTS "talent_partner_clients_userId_key" ON "talent_partner_clients"("userId");
+CREATE INDEX IF NOT EXISTS "talent_partner_clients_organization_idx" ON "talent_partner_clients"("organization");
+
+-- One live resume per member. Partial unique index: Prisma cannot express a
+-- filtered unique index, so this is SQL-only. It is what lets a re-upload create
+-- a new row instead of mutating the old one, which is in turn what makes an
+-- already-committed assignment immutable.
+CREATE UNIQUE INDEX IF NOT EXISTS "member_resumes_memberId_current_key" ON "member_resumes"("memberId") WHERE "isCurrent";
+CREATE INDEX IF NOT EXISTS "member_resumes_memberId_isCurrent_idx" ON "member_resumes"("memberId", "isCurrent");
+CREATE INDEX IF NOT EXISTS "member_resumes_shareConsent_isCurrent_idx" ON "member_resumes"("shareConsent", "isCurrent");
+
+CREATE INDEX IF NOT EXISTS "client_assignment_batches_clientId_createdAt_idx" ON "client_assignment_batches"("clientId", "createdAt");
+
+-- Covers the portal's only list query - filter by client, drop revoked, sort by
+-- assignedAt - in a single index.
+CREATE INDEX IF NOT EXISTS "client_resume_assignments_clientId_revokedAt_assignedAt_idx" ON "client_resume_assignments"("clientId", "revokedAt", "assignedAt");
+CREATE INDEX IF NOT EXISTS "client_resume_assignments_batchId_idx" ON "client_resume_assignments"("batchId");
+-- PostgreSQL does not auto-index foreign key columns, and the assignment
+-- preview filters on both of these to answer "already assigned to this client?".
+CREATE INDEX IF NOT EXISTS "client_resume_assignments_applicationId_idx" ON "client_resume_assignments"("applicationId");
+CREATE INDEX IF NOT EXISTS "client_resume_assignments_memberResumeId_idx" ON "client_resume_assignments"("memberResumeId");
+
+-- A plain UNIQUE over the two nullable target columns would prevent nothing:
+-- PostgreSQL treats NULLs as distinct, so every applicant row (memberResumeId
+-- NULL) would count as unique regardless of applicationId. Two partial unique
+-- indexes scoped to live rows do the job, and leave revoke-then-reassign legal.
+CREATE UNIQUE INDEX IF NOT EXISTS "client_resume_assignments_client_app_live_key"
+  ON "client_resume_assignments"("clientId", "applicationId")
+  WHERE "applicationId" IS NOT NULL AND "revokedAt" IS NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS "client_resume_assignments_client_member_live_key"
+  ON "client_resume_assignments"("clientId", "memberResumeId")
+  WHERE "memberResumeId" IS NOT NULL AND "revokedAt" IS NULL;
+
+CREATE INDEX IF NOT EXISTS "client_resume_access_logs_clientId_createdAt_idx" ON "client_resume_access_logs"("clientId", "createdAt");
+CREATE INDEX IF NOT EXISTS "client_resume_access_logs_assignmentId_idx" ON "client_resume_access_logs"("assignmentId");
+
+-- An assignment targets an applicant or a member, never both and never neither.
+-- Prisma cannot represent CHECK, so this is SQL-only.
+DO $$ BEGIN
+  ALTER TABLE "client_resume_assignments"
+    ADD CONSTRAINT "client_resume_assignments_one_target"
+    CHECK (num_nonnulls("applicationId", "memberResumeId") = 1);
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+-- AddForeignKey
+DO $$ BEGIN
+  ALTER TABLE "talent_partner_clients" ADD CONSTRAINT "talent_partner_clients_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+DO $$ BEGIN
+  ALTER TABLE "talent_partner_clients" ADD CONSTRAINT "talent_partner_clients_createdById_fkey" FOREIGN KEY ("createdById") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+DO $$ BEGIN
+  ALTER TABLE "member_resumes" ADD CONSTRAINT "member_resumes_memberId_fkey" FOREIGN KEY ("memberId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+DO $$ BEGIN
+  ALTER TABLE "client_assignment_batches" ADD CONSTRAINT "client_assignment_batches_clientId_fkey" FOREIGN KEY ("clientId") REFERENCES "talent_partner_clients"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+DO $$ BEGIN
+  ALTER TABLE "client_assignment_batches" ADD CONSTRAINT "client_assignment_batches_createdById_fkey" FOREIGN KEY ("createdById") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+DO $$ BEGIN
+  ALTER TABLE "client_resume_assignments" ADD CONSTRAINT "client_resume_assignments_clientId_fkey" FOREIGN KEY ("clientId") REFERENCES "talent_partner_clients"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+DO $$ BEGIN
+  ALTER TABLE "client_resume_assignments" ADD CONSTRAINT "client_resume_assignments_batchId_fkey" FOREIGN KEY ("batchId") REFERENCES "client_assignment_batches"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+DO $$ BEGIN
+  ALTER TABLE "client_resume_assignments" ADD CONSTRAINT "client_resume_assignments_applicationId_fkey" FOREIGN KEY ("applicationId") REFERENCES "applications"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+DO $$ BEGIN
+  ALTER TABLE "client_resume_assignments" ADD CONSTRAINT "client_resume_assignments_memberResumeId_fkey" FOREIGN KEY ("memberResumeId") REFERENCES "member_resumes"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+DO $$ BEGIN
+  ALTER TABLE "client_resume_assignments" ADD CONSTRAINT "client_resume_assignments_assignedById_fkey" FOREIGN KEY ("assignedById") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+DO $$ BEGIN
+  ALTER TABLE "client_resume_assignments" ADD CONSTRAINT "client_resume_assignments_revokedById_fkey" FOREIGN KEY ("revokedById") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+DO $$ BEGIN
+  ALTER TABLE "client_resume_access_logs" ADD CONSTRAINT "client_resume_access_logs_clientId_fkey" FOREIGN KEY ("clientId") REFERENCES "talent_partner_clients"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+DO $$ BEGIN
+  ALTER TABLE "client_resume_access_logs" ADD CONSTRAINT "client_resume_access_logs_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+DO $$ BEGIN
+  ALTER TABLE "client_resume_access_logs" ADD CONSTRAINT "client_resume_access_logs_assignmentId_fkey" FOREIGN KEY ("assignmentId") REFERENCES "client_resume_assignments"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;

--- a/server/prisma/migrations/20260826000000_add_client_access_action/migration.sql
+++ b/server/prisma/migrations/20260826000000_add_client_access_action/migration.sql
@@ -1,0 +1,27 @@
+-- Distinguish what a client actually did, in the one table that records it.
+--
+-- Until now every row in client_resume_access_logs was a PDF fetch, and the only
+-- way to tell a refused attempt from a successful one was that assignmentId
+-- happened to be null. That was already thin, and CSV export makes it wrong:
+-- an export writes one row per selected resume, which is indistinguishable from
+-- the client having opened each of them.
+--
+-- Re-runnable, per the hand-apply flow in CLAUDE.md: the enum is created only if
+-- absent, the column added only if absent, and the default backfills existing
+-- rows as VIEW - which is what every row written before this migration was.
+
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'ClientAccessAction') THEN
+        CREATE TYPE "ClientAccessAction" AS ENUM ('VIEW', 'VIEW_DENIED', 'EXPORT');
+    END IF;
+END
+$$;
+
+ALTER TABLE "client_resume_access_logs"
+    ADD COLUMN IF NOT EXISTS "action" "ClientAccessAction" NOT NULL DEFAULT 'VIEW';
+
+-- The admin-facing question is "what has this partner pulled out of the portal",
+-- which reads by client and action over a time window.
+CREATE INDEX IF NOT EXISTS "client_resume_access_logs_clientId_action_createdAt_idx"
+    ON "client_resume_access_logs" ("clientId", "action", "createdAt");

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -52,6 +52,13 @@ model User {
   createdMessageTemplates    MessageTemplate[]              @relation("MessageTemplateCreator")
   sentMessageLogs            MessageLog[]                   @relation("MessageLogSender")
   scheduledMessages          MessageSchedule[]              @relation("ScheduleSender")
+  talentPartnerClient        TalentPartnerClient?            @relation("TalentPartnerClientUser")
+  createdTalentPartners      TalentPartnerClient[]           @relation("TalentPartnerClientCreator")
+  memberResumes              MemberResume[]
+  createdClientBatches       ClientAssignmentBatch[]         @relation("ClientBatchCreator")
+  assignedClientResumes      ClientResumeAssignment[]        @relation("ClientAssignmentAssigner")
+  revokedClientResumes       ClientResumeAssignment[]        @relation("ClientAssignmentRevoker")
+  clientAccessLogs           ClientResumeAccessLog[]         @relation("ClientAccessLogUser")
 
   @@map("users")
 }
@@ -125,6 +132,7 @@ model Application {
   flaggedDocuments      FlaggedDocument[]
   interviewEvaluations  InterviewEvaluation[]
   caseAssignments       CaseAssignment[]
+  clientAssignments     ClientResumeAssignment[]
 
   @@map("applications")
 }
@@ -838,6 +846,10 @@ enum UserRole {
   USER
   ADMIN
   MEMBER
+  // Talent Partner Network buyer. Reaches only /api/client/* - see
+  // src/middleware/externalContainment.js. Created exclusively through
+  // POST /api/admin/talent-pool/clients so a TalentPartnerClient row always exists.
+  CLIENT
 }
 
 enum ApplicationStatus {
@@ -961,4 +973,153 @@ model MessageSchedule {
   @@index([status])
   @@index([cycleId])
   @@map("message_schedules")
+}
+
+
+// ---------------------------------------------------------------------------
+// Talent Partner Network - client resume portal
+// ---------------------------------------------------------------------------
+// Applicant consent lives on Application.talentPoolOptIn (added by the TPN
+// commit); member consent lives on MemberResume.shareConsent. Nothing in this
+// section is assignable without one of those recording an explicit yes.
+
+enum ResumeVisibility {
+  BLIND
+  BASIC
+  FULL
+}
+
+/// One outside organization that bought resume-database access. 1:1 with a User
+/// of role CLIENT, which owns email/password/isActive - so the existing
+/// PATCH /api/users/:id/deactivate and invalidateUserCache apply unchanged and
+/// this table deliberately has no isActive of its own.
+model TalentPartnerClient {
+  id           String                   @id @default(uuid())
+  userId       String                   @unique
+  organization String
+  visibility   ResumeVisibility         @default(BLIND)
+  notes        String?
+  createdById  String
+  createdAt    DateTime                 @default(now())
+  updatedAt    DateTime                 @updatedAt
+  user         User                     @relation("TalentPartnerClientUser", fields: [userId], references: [id], onDelete: Cascade)
+  creator      User                     @relation("TalentPartnerClientCreator", fields: [createdById], references: [id])
+  assignments  ClientResumeAssignment[]
+  batches      ClientAssignmentBatch[]
+  accessLogs   ClientResumeAccessLog[]
+
+  @@index([organization])
+  @@map("talent_partner_clients")
+}
+
+/// Member-uploaded resume. Deliberately NOT unique on memberId: re-uploading
+/// creates a new row and demotes the old one (isCurrent = false), so an
+/// already-committed assignment keeps pointing at the exact file that was
+/// assigned. With a unique memberId the snapshot guarantee would be false for
+/// members - a re-upload would silently swap the PDF under a client.
+///
+/// NOTE: a partial unique index enforces one isCurrent row per member. It lives
+/// in migration.sql only - Prisma cannot express filtered unique indexes, and
+/// `prisma migrate dev` will want to drop it.
+model MemberResume {
+  id               String                   @id @default(uuid())
+  memberId         String
+  isCurrent        Boolean                  @default(true)
+  storagePath      String
+  originalName     String
+  fileSize         Int
+  major1           String
+  major2           String?
+  // Normalized 4-digit year collected at upload. NOT derived from
+  // User.graduationClass, which is free text like "Spring 2027" and therefore
+  // does not filter alike with Application.graduationYear ("2029").
+  graduationYear   String
+  gender           String?
+  shareConsent     Boolean                  @default(false)
+  consentAt        DateTime?
+  consentRevokedAt DateTime?
+  createdAt        DateTime                 @default(now())
+  updatedAt        DateTime                 @updatedAt
+  member           User                     @relation(fields: [memberId], references: [id], onDelete: Cascade)
+  assignments      ClientResumeAssignment[]
+
+  @@index([memberId, isCurrent])
+  @@index([shareConsent, isCurrent])
+  @@map("member_resumes")
+}
+
+/// One admin "assign" action. filterJson records the filter that produced the
+/// batch purely as documentation - the assignments are a snapshot and are never
+/// re-derived from it.
+model ClientAssignmentBatch {
+  id           String                   @id @default(uuid())
+  clientId     String
+  createdById  String
+  filterJson   Json?
+  matchedCount Int                      @default(0)
+  note         String?
+  createdAt    DateTime                 @default(now())
+  client       TalentPartnerClient      @relation(fields: [clientId], references: [id], onDelete: Cascade)
+  creator      User                     @relation("ClientBatchCreator", fields: [createdById], references: [id])
+  assignments  ClientResumeAssignment[]
+
+  @@index([clientId, createdAt])
+  @@map("client_assignment_batches")
+}
+
+/// SNAPSHOT. Exactly one of applicationId / memberResumeId is non-null, enforced
+/// by a CHECK constraint in migration.sql (Prisma cannot express CHECK).
+/// Revocation is soft, matching the deactivatedAt / CaseAssignment.overriddenAt
+/// convention, so history and the access log keep valid foreign keys.
+///
+/// NOTE: duplicate assignment is prevented by two partial unique indexes in
+/// migration.sql. A plain @@unique would not work - Postgres treats NULLs as
+/// distinct, so every row with a null target would count as unique.
+model ClientResumeAssignment {
+  id             String                  @id @default(uuid())
+  clientId       String
+  batchId        String
+  applicationId  String?
+  memberResumeId String?
+  assignedById   String
+  assignedAt     DateTime                @default(now())
+  revokedAt      DateTime?
+  revokedById    String?
+  client         TalentPartnerClient     @relation(fields: [clientId], references: [id], onDelete: Cascade)
+  batch          ClientAssignmentBatch   @relation(fields: [batchId], references: [id])
+  application    Application?            @relation(fields: [applicationId], references: [id])
+  memberResume   MemberResume?           @relation(fields: [memberResumeId], references: [id])
+  assigner       User                    @relation("ClientAssignmentAssigner", fields: [assignedById], references: [id])
+  revoker        User?                   @relation("ClientAssignmentRevoker", fields: [revokedById], references: [id])
+  accessLogs     ClientResumeAccessLog[]
+
+  // Covers the portal's only list query (filter + sort) in one index.
+  @@index([clientId, revokedAt, assignedAt])
+  @@index([batchId])
+  // Postgres does not auto-index foreign key columns, and the preview's
+  // "already assigned?" check filters on these.
+  @@index([applicationId])
+  @@index([memberResumeId])
+  @@map("client_resume_assignments")
+}
+
+/// The first access-log table in this schema. House style is attribution columns
+/// on the row (User.deactivatedBy, CaseAssignment.overriddenBy), but an
+/// attribution column cannot express a repeated event, and a resume view is
+/// exactly that. Written on every PDF fetch, including denied ones.
+model ClientResumeAccessLog {
+  id           String                  @id @default(uuid())
+  clientId     String
+  userId       String
+  assignmentId String?
+  ipAddress    String?
+  userAgent    String?
+  createdAt    DateTime                @default(now())
+  client       TalentPartnerClient     @relation(fields: [clientId], references: [id], onDelete: Cascade)
+  user         User                    @relation("ClientAccessLogUser", fields: [userId], references: [id])
+  assignment   ClientResumeAssignment? @relation(fields: [assignmentId], references: [id])
+
+  @@index([clientId, createdAt])
+  @@index([assignmentId])
+  @@map("client_resume_access_logs")
 }

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -1112,6 +1112,11 @@ model ClientResumeAccessLog {
   clientId     String
   userId       String
   assignmentId String?
+  // What the client did. Defaults to VIEW so every row written before the
+  // action column existed keeps its original meaning - they were all PDF
+  // fetches. An EXPORT writes one row per resume in the CSV, so the count of
+  // rows a partner has pulled out stays readable off this table alone.
+  action       ClientAccessAction      @default(VIEW)
   ipAddress    String?
   userAgent    String?
   createdAt    DateTime                @default(now())
@@ -1120,6 +1125,17 @@ model ClientResumeAccessLog {
   assignment   ClientResumeAssignment? @relation(fields: [assignmentId], references: [id])
 
   @@index([clientId, createdAt])
+  @@index([clientId, action, createdAt])
   @@index([assignmentId])
   @@map("client_resume_access_logs")
+}
+
+/// VIEW_DENIED is written when a client asks for an assignment id that is not
+/// theirs, was revoked, or has no file their visibility permits - the half of
+/// the record worth keeping, and previously indistinguishable from a VIEW with
+/// a null assignmentId.
+enum ClientAccessAction {
+  VIEW
+  VIEW_DENIED
+  EXPORT
 }

--- a/server/scripts/apply-tpn-migrations.mjs
+++ b/server/scripts/apply-tpn-migrations.mjs
@@ -6,8 +6,8 @@
 // not the 6543 transaction pooler the CLI cannot use), run each migration file,
 // then record it so a future `migrate deploy` does not replay it.
 //
-// Both migration files are written to be re-runnable, so running this twice is
-// safe.
+// Every migration file listed below is written to be re-runnable, so running
+// this twice is safe.
 //
 //   node scripts/apply-tpn-migrations.mjs          # apply
 //   node scripts/apply-tpn-migrations.mjs --check  # connectivity + state only
@@ -24,6 +24,7 @@ const prismaCli = path.join(serverDir, 'node_modules', 'prisma', 'build', 'index
 const MIGRATIONS = [
   '20260825130000_add_client_user_role',
   '20260825130100_add_client_resume_portal',
+  '20260826000000_add_client_access_action',
 ];
 
 function sessionUrl() {
@@ -43,6 +44,28 @@ function run(args, env = {}) {
     stdio: 'pipe',
     encoding: 'utf8',
   });
+}
+
+/**
+ * `migrate resolve --applied` fails with P3008 when the migration is already in
+ * _prisma_migrations. That is the expected state for every migration this script
+ * has run before, so treating it as fatal made the whole script single-use: once
+ * the first migration was recorded, a later run died on it and never reached the
+ * newly added file at the end of the list.
+ *
+ * Already-recorded is the desired end state, so it is success. Every other
+ * failure still throws.
+ */
+function record(name, env) {
+  try {
+    return run(['migrate', 'resolve', '--applied', name], env);
+  } catch (error) {
+    const output = `${error.stdout || ''}${error.stderr || ''}`;
+    if (output.includes('P3008')) {
+      return 'already recorded as applied.\n';
+    }
+    throw error;
+  }
 }
 
 const url = sessionUrl();
@@ -69,7 +92,7 @@ for (const name of MIGRATIONS) {
   console.log(`\n--- applying ${name}`);
   console.log(run(['db', 'execute', '--url', url, '--file', file]));
   console.log(`--- recording ${name}`);
-  console.log(run(['migrate', 'resolve', '--applied', name], { DIRECT_URL: url }));
+  console.log(record(name, { DIRECT_URL: url }));
 }
 
 console.log('\nDone. Run `npx prisma generate` if the client is not already current.');

--- a/server/scripts/apply-tpn-migrations.mjs
+++ b/server/scripts/apply-tpn-migrations.mjs
@@ -1,0 +1,75 @@
+// Applies the Talent Partner Network migrations using the session pooler.
+//
+// `prisma migrate dev` / `migrate deploy` authenticate with DIRECT_URL, whose
+// password is stale in this repo (see CLAUDE.md). This script does what
+// CLAUDE.md documents by hand: rebuild DATABASE_URL on port 5432 (session mode,
+// not the 6543 transaction pooler the CLI cannot use), run each migration file,
+// then record it so a future `migrate deploy` does not replay it.
+//
+// Both migration files are written to be re-runnable, so running this twice is
+// safe.
+//
+//   node scripts/apply-tpn-migrations.mjs          # apply
+//   node scripts/apply-tpn-migrations.mjs --check  # connectivity + state only
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const serverDir = path.join(__dirname, '..');
+const prismaCli = path.join(serverDir, 'node_modules', 'prisma', 'build', 'index.js');
+
+const MIGRATIONS = [
+  '20260825130000_add_client_user_role',
+  '20260825130100_add_client_resume_portal',
+];
+
+function sessionUrl() {
+  const env = fs.readFileSync(path.join(serverDir, '.env'), 'utf8');
+  const match = env.match(/^DATABASE_URL=(.*)$/m);
+  if (!match) throw new Error('DATABASE_URL not found in server/.env');
+  const raw = match[1].trim().replace(/^["']|["']$/g, '');
+  const url = new URL(raw);
+  url.port = '5432';
+  return url.toString();
+}
+
+function run(args, env = {}) {
+  return execFileSync(process.execPath, [prismaCli, ...args], {
+    cwd: serverDir,
+    env: { ...process.env, ...env },
+    stdio: 'pipe',
+    encoding: 'utf8',
+  });
+}
+
+const url = sessionUrl();
+const check = process.argv.includes('--check');
+
+const probePath = path.join(serverDir, '.tpn-probe.sql');
+
+if (check) {
+  fs.writeFileSync(
+    probePath,
+    "SELECT to_regclass('public.talent_partner_clients') IS NOT NULL AS portal_tables_exist;\n"
+  );
+  try {
+    console.log(run(['db', 'execute', '--url', url, '--file', probePath]));
+    console.log('Connectivity OK via session pooler (port 5432).');
+  } finally {
+    fs.rmSync(probePath, { force: true });
+  }
+  process.exit(0);
+}
+
+for (const name of MIGRATIONS) {
+  const file = path.join(serverDir, 'prisma', 'migrations', name, 'migration.sql');
+  console.log(`\n--- applying ${name}`);
+  console.log(run(['db', 'execute', '--url', url, '--file', file]));
+  console.log(`--- recording ${name}`);
+  console.log(run(['migrate', 'resolve', '--applied', name], { DIRECT_URL: url }));
+}
+
+console.log('\nDone. Run `npx prisma generate` if the client is not already current.');

--- a/server/scripts/tpn-probe-pdf.mjs
+++ b/server/scripts/tpn-probe-pdf.mjs
@@ -1,0 +1,62 @@
+// Read-only: does every assigned resume resolve to a Drive file id, and does
+// one of them actually stream? This is the check that would have caught the 500.
+import prisma from '../src/prismaClient.js';
+import { resolveResumeSource, extractDriveFileId } from '../src/utils/clientVisibility.js';
+import { getFileStream } from '../src/services/google/drive.js';
+
+const client = await prisma.talentPartnerClient.findFirst();
+const { id: clientId, visibility } = client;
+console.log(`client ${client.organization} visibility=${visibility}\n`);
+
+const assignments = await prisma.clientResumeAssignment.findMany({
+  where: { clientId, revokedAt: null },
+  include: {
+    application: { select: { id: true, resumeUrl: true, blindResumeUrl: true } },
+    memberResume: { select: { id: true, storagePath: true } },
+  },
+});
+
+let ok = 0;
+const bad = [];
+for (const a of assignments) {
+  const source = resolveResumeSource(a, visibility);
+  if (source) ok += 1;
+  else bad.push(a.id);
+}
+console.log(`resolvable under ${visibility}: ${ok}/${assignments.length}`);
+if (bad.length) console.log('unresolvable assignment ids:', bad.slice(0, 5));
+
+// Same rows under BLIND, which reads a different column.
+let blindOk = 0;
+for (const a of assignments) if (resolveResumeSource(a, 'BLIND')) blindOk += 1;
+console.log(`resolvable under BLIND:  ${blindOk}/${assignments.length}`);
+
+// Both stored URL shapes must extract identically.
+console.log('\nextractor spot-check:');
+for (const v of [
+  '/api/files/1JduFdD3X2R7GV4eMvxxwpbS3AP0qys5N/pdf',
+  'https://uconsultingats.com/api/files/1CvCqDHXy_RqLDQLyeJ5VDl9abc/pdf',
+  'https://drive.google.com/file/d/1abcDEF/view?usp=sharing',
+  '1BareIdLooksLikeThis',
+  '',
+  null,
+]) console.log(`  ${JSON.stringify(v)} -> ${JSON.stringify(extractDriveFileId(v))}`);
+
+// The real thing: pull actual bytes from Drive for the first assignment.
+const first = assignments.find((a) => resolveResumeSource(a, visibility));
+const source = resolveResumeSource(first, visibility);
+console.log(`\nstreaming assignment ${first.id} (fileId ${source.fileId}) ...`);
+try {
+  const stream = await getFileStream(source.fileId);
+  let bytes = 0;
+  await new Promise((resolve, reject) => {
+    stream.on('data', (c) => { bytes += c.length; });
+    stream.on('end', resolve);
+    stream.on('error', reject);
+  });
+  console.log(`  OK - ${bytes} bytes received from Drive`);
+} catch (e) {
+  console.error('  STREAM FAILED:', e.message);
+}
+
+await prisma.$disconnect();

--- a/server/scripts/tpn-smoke-client.mjs
+++ b/server/scripts/tpn-smoke-client.mjs
@@ -1,0 +1,51 @@
+// Read-only end-to-end smoke as the real CLIENT account against a running
+// server: list, then actually pull a PDF through the portal's proxy route.
+//
+//   node scripts/tpn-smoke-client.mjs [port]
+import jwt from 'jsonwebtoken';
+import prisma from '../src/prismaClient.js';
+import config from '../src/config.js';
+
+const base = `http://localhost:${process.argv[2] || '3001'}`;
+
+const partner = await prisma.talentPartnerClient.findFirst({
+  include: { user: { select: { id: true, email: true } } },
+});
+if (!partner) throw new Error('no partner client');
+
+const token = jwt.sign({ userId: partner.user.id }, config.jwtSecret, { expiresIn: '5m' });
+const auth = { Authorization: `Bearer ${token}` };
+console.log(`acting as CLIENT ${partner.user.email} (${partner.organization}, ${partner.visibility})\n`);
+
+const me = await fetch(`${base}/api/client/me`, { headers: auth });
+console.log(`${me.status}  GET /api/client/me\n     ${JSON.stringify(await me.json())}\n`);
+
+const list = await fetch(`${base}/api/client/resumes?limit=3`, { headers: auth });
+const page = await list.json();
+console.log(`${list.status}  GET /api/client/resumes?limit=3`);
+console.log(`     total=${page.total} items=${page.items?.length}`);
+console.log(`     first: ${JSON.stringify(page.items?.[0])}\n`);
+
+const serialized = JSON.stringify(page);
+for (const needle of ['/api/files/', 'drive.google.com', 'storagePath', 'studentId']) {
+  console.log(`     leak check ${needle.padEnd(18)} ${serialized.includes(needle) ? 'FOUND - BAD' : 'clean'}`);
+}
+
+const first = page.items?.[0];
+if (first) {
+  const pdf = await fetch(`${base}${first.pdfUrl}`, { headers: auth });
+  const buf = Buffer.from(await pdf.arrayBuffer());
+  console.log(`\n${pdf.status}  GET ${first.pdfUrl}`);
+  console.log(`     content-type: ${pdf.headers.get('content-type')}`);
+  console.log(`     disposition:  ${pdf.headers.get('content-disposition')}`);
+  console.log(`     cache:        ${pdf.headers.get('cache-control')}`);
+  console.log(`     bytes: ${buf.length}  starts with %PDF: ${buf.subarray(0, 4).toString() === '%PDF'}`);
+}
+
+const bogus = await fetch(`${base}/api/client/resumes/00000000-0000-0000-0000-000000000000/pdf`, { headers: auth });
+console.log(`\n${bogus.status}  GET /pdf for an id this client does not own (expect 404)`);
+
+const contained = await fetch(`${base}/api/users`, { headers: auth });
+console.log(`${contained.status}  GET /api/users as CLIENT (expect 403)`);
+
+await prisma.$disconnect();

--- a/server/scripts/tpn-smoke-portal.mjs
+++ b/server/scripts/tpn-smoke-portal.mjs
@@ -1,0 +1,207 @@
+// End-to-end smoke for the portal's filter / sort / export surface, as the real
+// CLIENT account against a running server.
+//
+//   node scripts/tpn-smoke-portal.mjs [port] [partner-email]
+//
+// Companion to tpn-smoke-client.mjs, which covers the list and the PDF proxy.
+// This one covers what was added on top: /facets, the filter and sort params,
+// and the CSV export.
+//
+// NOT read-only: an export writes one EXPORT row per resume into
+// client_resume_access_logs, which is the point - the last section reads them
+// back. Nothing else here writes.
+//
+// The visibility-dependent assertions are checked against whatever level the
+// partner is on right now; flip it in the admin UI (Talent Pool -> the client ->
+// Visibility) and re-run to cover the other levels.
+import jwt from 'jsonwebtoken';
+import prisma from '../src/prismaClient.js';
+import config from '../src/config.js';
+
+const base = `http://localhost:${process.argv[2] || '3001'}`;
+const wantedEmail = process.argv[3];
+
+// Deterministic on purpose. A bare findFirst() returns an arbitrary row once a
+// second partner exists, so a run could silently report on a different client -
+// and every visibility assertion below is read off whichever one it picked.
+const partner = await prisma.talentPartnerClient.findFirst({
+  where: wantedEmail ? { user: { email: wantedEmail } } : undefined,
+  include: { user: { select: { id: true, email: true } } },
+  orderBy: { createdAt: 'asc' },
+});
+if (!partner) {
+  throw new Error(
+    wantedEmail
+      ? `no partner client with email ${wantedEmail}`
+      : 'no partner client - create one in the admin Talent Pool page first'
+  );
+}
+
+const partnerCount = await prisma.talentPartnerClient.count();
+if (partnerCount > 1 && !wantedEmail) {
+  console.log(
+    `note: ${partnerCount} partner clients exist; testing the oldest. ` +
+      'Pass an email as the second argument to pick another.\n'
+  );
+}
+
+const token = jwt.sign({ userId: partner.user.id }, config.jwtSecret, { expiresIn: '5m' });
+const auth = { Authorization: `Bearer ${token}` };
+const visibility = partner.visibility;
+
+const showsIdentity = visibility === 'BASIC' || visibility === 'FULL';
+const showsContact = visibility === 'FULL';
+
+let failures = 0;
+const check = (label, ok, detail = '') => {
+  if (!ok) failures += 1;
+  console.log(`     ${ok ? 'ok  ' : 'FAIL'} ${label}${detail ? `  ${detail}` : ''}`);
+};
+
+const get = async (path) => {
+  const res = await fetch(`${base}${path}`, { headers: auth });
+  return { res, body: await res.json() };
+};
+
+console.log(`acting as CLIENT ${partner.user.email} (${partner.organization}, ${visibility})\n`);
+
+// --- capabilities -----------------------------------------------------------
+const { body: me } = await get('/api/client/me');
+console.log(`GET /api/client/me`);
+console.log(`     filterable: ${me.filterableFields?.join(', ')}`);
+console.log(`     sortable:   ${me.sortableFields?.join(', ')}`);
+check('gender filter matches visibility', me.filterableFields?.includes('gender') === showsIdentity);
+check('gpa filter matches visibility', me.filterableFields?.includes('gpa') === showsContact);
+check('name sort matches visibility', me.sortableFields?.includes('name') === showsIdentity);
+
+// --- facets -----------------------------------------------------------------
+const { body: facets } = await get('/api/client/facets');
+console.log(`\nGET /api/client/facets`);
+console.log(`     graduationYear: ${(facets.graduationYear || []).join(' ') || 'none'}`);
+console.log(`     major:          ${(facets.major || []).slice(0, 6).join(' | ') || 'none'}`);
+console.log(`     gender:         ${(facets.gender || []).join(' ') || '(absent)'}`);
+check('gender facet matches visibility', Boolean(facets.gender) === showsIdentity);
+
+// --- filtering --------------------------------------------------------------
+const { body: all } = await get('/api/client/resumes?limit=100');
+console.log(`\nGET /api/client/resumes  total=${all.total}`);
+
+const year = facets.graduationYear?.[0];
+if (year) {
+  const { body: filtered } = await get(`/api/client/resumes?graduationYear=${year}&limit=100`);
+  console.log(`\nGET /api/client/resumes?graduationYear=${year}  total=${filtered.total}`);
+  check('filter narrows or equals the unfiltered total', filtered.total <= all.total);
+  check(
+    'every row matches the filter',
+    filtered.items.every((i) => String(i.graduationYear).toLowerCase() === year.toLowerCase())
+  );
+}
+
+// A BLIND client must not be able to filter by a field they cannot see - the
+// server drops it rather than honouring it.
+if (!showsIdentity) {
+  const { body: gendered } = await get('/api/client/resumes?gender=Female&limit=100');
+  check('gender filter is ignored under BLIND', gendered.total === all.total,
+    `${gendered.total} vs ${all.total}`);
+}
+
+// --- sorting ----------------------------------------------------------------
+const { body: asc } = await get('/api/client/resumes?sort=graduationYear&dir=asc&limit=100');
+const { body: desc } = await get('/api/client/resumes?sort=graduationYear&dir=desc&limit=100');
+const years = (page) => page.items.map((i) => i.graduationYear).filter(Boolean);
+console.log(`\nGET /api/client/resumes?sort=graduationYear`);
+console.log(`     asc:  ${years(asc).slice(0, 8).join(' ')}`);
+console.log(`     desc: ${years(desc).slice(0, 8).join(' ')}`);
+check('asc is non-decreasing', years(asc).every((y, i, a) => i === 0 || a[i - 1] <= y));
+check('desc is non-increasing', years(desc).every((y, i, a) => i === 0 || a[i - 1] >= y));
+check('blanks sort last in both directions',
+  asc.items.findIndex((i) => !i.graduationYear) === -1 ||
+  asc.items.findIndex((i) => !i.graduationYear) >= years(asc).length);
+
+if (showsContact) {
+  const { body: gpa } = await get('/api/client/resumes?sort=cumulativeGpa&dir=desc&limit=100');
+  const values = gpa.items.map((i) => i.cumulativeGpa).filter(Boolean).map(Number);
+  console.log(`     gpa desc: ${values.slice(0, 8).join(' ')}`);
+  // The bug this catches: sorting a decimal column lexically puts 10.00 below 3.10.
+  check('GPA sorts numerically', values.every((v, i, a) => i === 0 || a[i - 1] >= v));
+}
+
+// --- export -----------------------------------------------------------------
+const ids = all.items.slice(0, 3).map((i) => i.assignmentId);
+if (ids.length === 0) {
+  console.log('\nno assignments to export - assign some in the admin Talent Pool page');
+} else {
+  const before = await prisma.clientResumeAccessLog.count({
+    where: { clientId: partner.id, action: 'EXPORT' },
+  });
+
+  const res = await fetch(`${base}/api/client/resumes/export`, {
+    method: 'POST',
+    headers: { ...auth, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ assignmentIds: ids }),
+  });
+
+  // Read the raw bytes, not res.text(). The WHATWG fetch spec strips a leading
+  // BOM when decoding UTF-8, so asserting on the decoded string would report a
+  // missing BOM even when it is on the wire - which is exactly what Excel reads.
+  const raw = Buffer.from(await res.arrayBuffer());
+  const csv = raw.toString('utf8');
+
+  console.log(`\n${res.status}  POST /api/client/resumes/export  (${ids.length} ids)`);
+  console.log(`     content-type: ${res.headers.get('content-type')}`);
+  console.log(`     disposition:  ${res.headers.get('content-disposition')}`);
+  console.log(`     nosniff:      ${res.headers.get('x-content-type-options')}`);
+  console.log(`\n${csv.split('\r\n').slice(0, 4).join('\n')}\n`);
+
+  check('status 200', res.status === 200);
+  check('leads with a UTF-8 BOM on the wire',
+    raw[0] === 0xef && raw[1] === 0xbb && raw[2] === 0xbf,
+    [...raw.subarray(0, 3)].map((b) => b.toString(16).padStart(2, '0')).join(' '));
+  check('rows separated by CRLF', csv.includes('\r\n'));
+  check('one header + one row per id', csv.trim().split('\r\n').length === ids.length + 1);
+
+  const header = csv.trim().split('\r\n')[0];
+  check('name columns match visibility', header.includes('First Name') === showsIdentity);
+  check('contact columns match visibility', header.includes('Email') === showsContact);
+  check('GPA column matches visibility', header.includes('Cumulative GPA') === showsContact);
+
+  // The whole point of the export being metadata-only.
+  for (const needle of ['/api/files/', 'drive.google.com', 'storagePath', 'studentId', '.pdf']) {
+    check(`no ${needle}`, !csv.includes(needle));
+  }
+
+  // A formula-injection cell would start with a bare =, + or @ after a comma.
+  check('no unescaped formula cell', !/(^|,)[=+@]/m.test(csv));
+
+  const after = await prisma.clientResumeAccessLog.count({
+    where: { clientId: partner.id, action: 'EXPORT' },
+  });
+  check('one EXPORT log row per exported resume', after - before === ids.length,
+    `wrote ${after - before}`);
+
+  // Caps and refusals.
+  const empty = await fetch(`${base}/api/client/resumes/export`, {
+    method: 'POST',
+    headers: { ...auth, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ assignmentIds: [] }),
+  });
+  check('empty selection refused with 400', empty.status === 400);
+
+  const tooMany = await fetch(`${base}/api/client/resumes/export`, {
+    method: 'POST',
+    headers: { ...auth, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ assignmentIds: Array.from({ length: 1001 }, (_, i) => `x-${i}`) }),
+  });
+  check('over-cap selection refused with 400', tooMany.status === 400);
+
+  const borrowed = await fetch(`${base}/api/client/resumes/export`, {
+    method: 'POST',
+    headers: { ...auth, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ assignmentIds: ['00000000-0000-0000-0000-000000000000'] }),
+  });
+  check('an id this client does not own exports nothing (404)', borrowed.status === 404);
+}
+
+console.log(`\n${failures === 0 ? 'ALL CHECKS PASSED' : `${failures} CHECK(S) FAILED`}`);
+await prisma.$disconnect();
+process.exit(failures === 0 ? 0 : 1);

--- a/server/scripts/tpn-smoke.mjs
+++ b/server/scripts/tpn-smoke.mjs
@@ -1,0 +1,50 @@
+// Read-only smoke test against a running server. Mints a short-lived admin JWT
+// locally (same secret the server uses) and exercises the GET endpoints.
+// Writes nothing.
+//
+//   node scripts/tpn-smoke.mjs [port]
+import jwt from 'jsonwebtoken';
+import prisma from '../src/prismaClient.js';
+import config from '../src/config.js';
+
+const port = process.argv[2] || '3001';
+const base = `http://localhost:${port}`;
+
+const admin = await prisma.user.findFirst({
+  where: { role: 'ADMIN', isActive: true },
+  select: { id: true, email: true },
+});
+if (!admin) throw new Error('No active ADMIN user found');
+
+const token = jwt.sign({ userId: admin.id }, config.jwtSecret, { expiresIn: '5m' });
+const auth = { Authorization: `Bearer ${token}` };
+
+const show = async (label, path, init = {}) => {
+  const res = await fetch(`${base}${path}`, { ...init, headers: { ...auth, ...(init.headers || {}) } });
+  let body = '';
+  try {
+    body = JSON.stringify(await res.json()).slice(0, 220);
+  } catch {
+    body = '(non-JSON)';
+  }
+  console.log(`${String(res.status).padEnd(4)} ${label}\n     ${body}\n`);
+  return res;
+};
+
+console.log(`\nActing as admin: ${admin.email}\n`);
+
+await show('GET  /api/admin/talent-pool/clients', '/api/admin/talent-pool/clients');
+await show('GET  /api/admin/talent-pool/filter-fields', '/api/admin/talent-pool/filter-fields');
+await show('GET  /api/admin/talent-pool/stats  (registeredClients should be a number now)', '/api/admin/talent-pool/stats');
+
+console.log('--- an ADMIN must NOT reach the client portal ---');
+await show('GET  /api/client/resumes  (expect 403)', '/api/client/resumes');
+
+console.log('--- preview refuses an empty filter rather than matching everything ---');
+await show(
+  'POST /api/admin/talent-pool/clients/does-not-exist/preview  (expect 404)',
+  '/api/admin/talent-pool/clients/does-not-exist/preview',
+  { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ filter: { rows: [] } }) }
+);
+
+await prisma.$disconnect();

--- a/server/scripts/tpn-testdata-report.mjs
+++ b/server/scripts/tpn-testdata-report.mjs
@@ -1,0 +1,53 @@
+// Read-only: what is actually available to assign right now, across all cycles?
+import prisma from '../src/prismaClient.js';
+
+const cycles = await prisma.recruitingCycle.findMany({
+  select: { id: true, name: true, isActive: true, _count: { select: { applications: true } } },
+  orderBy: { createdAt: 'desc' },
+});
+
+console.log('\n=== Cycles ===');
+for (const c of cycles) {
+  console.log(`  ${c.isActive ? '*' : ' '} ${c.name.padEnd(24)} ${c._count.applications} applications  ${c.id}`);
+}
+
+const optIn = await prisma.application.groupBy({
+  by: ['cycleId', 'talentPoolOptIn'],
+  _count: { _all: true },
+});
+
+const nameById = new Map(cycles.map((c) => [c.id, c.name]));
+
+console.log('\n=== talentPoolOptIn by cycle ===');
+for (const row of optIn) {
+  const label = row.talentPoolOptIn === null ? 'never asked' : row.talentPoolOptIn ? 'YES' : 'no';
+  console.log(`  ${(nameById.get(row.cycleId) || row.cycleId || 'no cycle').padEnd(24)} ${label.padEnd(12)} ${row._count._all}`);
+}
+
+const assignable = await prisma.application.count({
+  where: { talentPoolOptIn: true, resumeUrl: { not: '' } },
+});
+const assignableBlind = await prisma.application.count({
+  where: { talentPoolOptIn: true, resumeUrl: { not: '' }, blindResumeUrl: { not: null } },
+});
+
+console.log('\n=== Assignable across ALL cycles ===');
+console.log(`  BASIC/FULL client: ${assignable}`);
+console.log(`  BLIND client:      ${assignableBlind}`);
+
+const years = await prisma.application.groupBy({
+  by: ['graduationYear'],
+  where: { talentPoolOptIn: true },
+  _count: { _all: true },
+});
+const genders = await prisma.application.groupBy({
+  by: ['gender'],
+  where: { talentPoolOptIn: true },
+  _count: { _all: true },
+});
+
+console.log('\n=== Filter values that will match (opted-in only) ===');
+console.log('  graduationYear:', years.map((y) => `${y.graduationYear}(${y._count._all})`).join(' ') || 'none');
+console.log('  gender:', genders.map((g) => `${g.gender}(${g._count._all})`).join(' ') || 'none');
+
+await prisma.$disconnect();

--- a/server/scripts/verify-tpn-schema.mjs
+++ b/server/scripts/verify-tpn-schema.mjs
@@ -1,0 +1,35 @@
+// Reads back what the TPN migrations created, using the Prisma client (which
+// returns rows, unlike `prisma db execute`).
+import prisma from '../src/prismaClient.js';
+
+const rows = await prisma.$queryRaw`
+  SELECT
+    (SELECT count(*) FROM pg_enum e
+      JOIN pg_type t ON t.oid = e.enumtypid
+      WHERE t.typname = 'UserRole' AND e.enumlabel = 'CLIENT')::int  AS client_role,
+    (SELECT count(*) FROM information_schema.tables
+      WHERE table_schema = 'public'
+        AND table_name IN ('talent_partner_clients','member_resumes',
+                           'client_assignment_batches','client_resume_assignments',
+                           'client_resume_access_logs'))::int         AS portal_tables,
+    (SELECT count(*) FROM pg_indexes
+      WHERE schemaname = 'public'
+        AND indexname IN ('member_resumes_memberId_current_key',
+                          'client_resume_assignments_client_app_live_key',
+                          'client_resume_assignments_client_member_live_key'))::int AS partial_unique_indexes,
+    (SELECT count(*) FROM pg_constraint
+      WHERE conname = 'client_resume_assignments_one_target')::int    AS check_constraint
+`;
+
+console.log(rows[0]);
+
+const expected = { client_role: 1, portal_tables: 5, partial_unique_indexes: 3, check_constraint: 1 };
+const actual = rows[0];
+const bad = Object.entries(expected).filter(([k, v]) => Number(actual[k]) !== v);
+
+if (bad.length) {
+  console.error('MISMATCH:', bad.map(([k, v]) => `${k} expected ${v}, got ${actual[k]}`).join('; '));
+  process.exit(1);
+}
+console.log('All TPN schema objects present.');
+await prisma.$disconnect();

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -25,10 +25,17 @@ import masterCommunicationsRoutes from './routes/masterCommunications.js';
 import { processScheduledMessages } from './services/masterCommunications.js';
 import { requireAuth, requireAdmin } from './middleware/auth.js';
 import externalContainment from './middleware/externalContainment.js';
+import clientRoutes from './routes/client.js';
+import talentPoolAdminRoutes from './routes/talentPoolAdmin.js';
 import featureRequestRoutes from './routes/featureRequests.js';
 import releaseNotesRoutes from './routes/releaseNotes.js';
 
 const app = express();
+
+// Render (and any single-hop proxy) sits in front of this service. Without
+// this, req.ip is the proxy's address and every access-log row records it
+// instead of the caller.
+app.set('trust proxy', 1);
 
 // Single-service deploys (Render staging) build the SPA into client/dist and
 // serve it from here. Locally that directory doesn't exist — the Vite dev
@@ -71,11 +78,14 @@ app.use('/api/auth', authRoutes);
 app.use('/api/applications', applicationsRoutes);
 app.use('/api/files', filesRoutes);
 app.use('/api/admin/release-notes', requireAuth, requireAdmin, releaseNotesRoutes);
+// Ahead of the catch-all /api/admin mount, same as release-notes above.
+app.use('/api/admin/talent-pool', requireAuth, requireAdmin, talentPoolAdminRoutes);
 app.use('/api/admin', adminRoutes);
 app.use('/api/review-teams', reviewTeamsRoutes);
 app.use('/api/users', usersRoutes);
 app.use('/api/interview-resources', interviewResourcesRoutes);
 app.use('/api/member', memberRoutes);
+app.use('/api/client', clientRoutes);
 app.use('/api/conversations', conversationsRoutes);
 app.use('/api/master-communications', masterCommunicationsRoutes);
 app.use('/api/feature-requests', featureRequestRoutes);

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -24,6 +24,7 @@ import conversationsRoutes from './routes/conversations.js';
 import masterCommunicationsRoutes from './routes/masterCommunications.js';
 import { processScheduledMessages } from './services/masterCommunications.js';
 import { requireAuth, requireAdmin } from './middleware/auth.js';
+import externalContainment from './middleware/externalContainment.js';
 import featureRequestRoutes from './routes/featureRequests.js';
 import releaseNotesRoutes from './routes/releaseNotes.js';
 
@@ -59,6 +60,11 @@ app.use('/api/uploads', express.static('uploads', {
     res.set('Cross-Origin-Resource-Policy', 'cross-origin');
   }
 }));
+
+// Talent Partner Network clients reach only /api/client/*. Mounted ahead of
+// every route so a route file that forgets its own role gate is still covered.
+// Transparent to every other role and to unauthenticated requests.
+app.use(externalContainment);
 
 // Routes
 app.use('/api/auth', authRoutes);

--- a/server/src/middleware/auth.js
+++ b/server/src/middleware/auth.js
@@ -6,63 +6,94 @@ import config from '../config.js';
 const userCache = new Map();
 const CACHE_TTL = 5 * 60 * 1000; // 5 minutes
 
-// Middleware to verify JWT token and attach user to request
-export const requireAuth = async (req, res, next) => {
+// Fields every caller of resolveUserFromRequest gets. Deliberately excludes
+// password, resetToken and resetTokenExpiry.
+const AUTH_USER_SELECT = {
+  id: true,
+  email: true,
+  fullName: true,
+  role: true,
+  isActive: true,
+  graduationClass: true,
+  studentId: true,
+  profileImage: true,
+  createdAt: true
+};
+
+/**
+ * Resolve the authenticated user for a request, reading and populating the same
+ * 5-minute cache `requireAuth` uses. Returns `{ user }` on success or
+ * `{ error }` where error is one of 'no-token' | 'invalid' | 'not-found' |
+ * 'deactivated'.
+ *
+ * Extracted so the CLIENT containment middleware can ask "who is this?" before
+ * the route's own requireAuth runs, without a second DB round trip and without
+ * exporting the cache Map. Containment runs first, warms the cache, and
+ * requireAuth then hits it.
+ */
+export const resolveUserFromRequest = async (req) => {
+  const token = req.headers.authorization?.replace('Bearer ', '');
+
+  if (!token) {
+    return { error: 'no-token' };
+  }
+
   try {
-    const token = req.headers.authorization?.replace('Bearer ', '');
-    
-    if (!token) {
-      return res.status(401).json({ error: 'Authentication required' });
-    }
-    
     const decoded = jwt.verify(token, config.jwtSecret);
     const userId = decoded.userId;
-    
-    // Check cache first to reduce DB calls
+
     const cached = userCache.get(userId);
     if (cached && (Date.now() - cached.timestamp) < CACHE_TTL) {
-      req.user = cached.user;
-      return next();
+      return { user: cached.user };
     }
-    
-    // Only query DB if not in cache or cache expired
+
     const user = await prisma.user.findUnique({
       where: { id: userId },
-      select: {
-        id: true,
-        email: true,
-        fullName: true,
-        role: true,
-        isActive: true,
-        graduationClass: true,
-        studentId: true,
-        profileImage: true,
-        createdAt: true
-        // Explicitly exclude password
-      }
+      select: AUTH_USER_SELECT
     });
-    
+
     if (!user) {
-      return res.status(401).json({ error: 'User not found' });
+      return { error: 'not-found' };
     }
 
     if (user.isActive === false) {
       userCache.delete(userId);
-      return res.status(401).json({ error: 'Account deactivated' });
+      return { error: 'deactivated' };
     }
-    
-    // Cache the user data
-    userCache.set(userId, {
-      user,
-      timestamp: Date.now()
-    });
-    
-    req.user = user;
-    next();
-    
+
+    userCache.set(userId, { user, timestamp: Date.now() });
+
+    return { user };
   } catch (error) {
-    console.error('Auth middleware error:', error);
-    res.status(401).json({ error: 'Invalid token' });
+    return { error: 'invalid', cause: error };
+  }
+};
+
+// Middleware to verify JWT token and attach user to request
+export const requireAuth = async (req, res, next) => {
+  // Containment may already have resolved this request. Same cache either way,
+  // but skipping re-work keeps the hot path to a single lookup.
+  if (req.user) {
+    return next();
+  }
+
+  const result = await resolveUserFromRequest(req);
+
+  if (result.user) {
+    req.user = result.user;
+    return next();
+  }
+
+  switch (result.error) {
+    case 'no-token':
+      return res.status(401).json({ error: 'Authentication required' });
+    case 'not-found':
+      return res.status(401).json({ error: 'User not found' });
+    case 'deactivated':
+      return res.status(401).json({ error: 'Account deactivated' });
+    default:
+      console.error('Auth middleware error:', result.cause);
+      return res.status(401).json({ error: 'Invalid token' });
   }
 };
 
@@ -100,4 +131,35 @@ export const requireAdminOrMember = async (req, res, next) => {
     return res.status(403).json({ error: 'Admin or member access required' });
   }
   next();
-}; 
+};
+
+/**
+ * Gate for the Talent Partner Network portal. Allowlist-style like requireAdmin:
+ * the role must be exactly CLIENT. Loads the partner row onto req.partnerClient
+ * so no route handler has to, and turns an orphaned CLIENT user (one with no
+ * partner row, which POST /api/admin/talent-pool/clients makes impossible) into
+ * a clear message rather than a crash.
+ */
+export const requireClient = async (req, res, next) => {
+  if (req.user?.role !== 'CLIENT') {
+    return res.status(403).json({ error: 'Talent partner access required' });
+  }
+
+  try {
+    const partnerClient = await prisma.talentPartnerClient.findUnique({
+      where: { userId: req.user.id }
+    });
+
+    if (!partnerClient) {
+      return res.status(403).json({
+        error: 'Your partner account is not configured. Contact UConsulting.'
+      });
+    }
+
+    req.partnerClient = partnerClient;
+    next();
+  } catch (error) {
+    console.error('[requireClient]', error);
+    res.status(500).json({ error: 'Failed to load partner account' });
+  }
+};

--- a/server/src/middleware/externalContainment.js
+++ b/server/src/middleware/externalContainment.js
@@ -1,0 +1,71 @@
+import { resolveUserFromRequest } from './auth.js';
+
+/**
+ * Containment for the CLIENT role (Talent Partner Network buyers).
+ *
+ * Why this is global rather than a gate added to each route file: several route
+ * files - candidate.js, public.js, featureRequests.js, files.js, users.js, and
+ * parts of member.js, reviewTeams.js and applications.js - mount a bare
+ * requireAuth with no role check. Patching each one would be a denylist by
+ * omission: the next route file someone adds is a hole, and nothing fails when
+ * it appears. One middleware plus one test file gives a single assertion
+ * surface - "a CLIENT gets 403 on everything not listed here".
+ *
+ * The per-route gates stay exactly as they are. requireClient on /api/client is
+ * the real gate; this is defense in depth.
+ *
+ * The rule this middleware must never break: it is completely transparent to
+ * anything that is not a confirmed, active CLIENT. A missing, malformed or
+ * expired token falls through untouched so the downstream requireAuth still
+ * produces its own 401 - turning an authentication failure into a 403 would
+ * both leak information and break every existing test.
+ */
+
+// Endpoints a CLIENT legitimately needs outside the portal itself.
+const CLIENT_ALLOWED_EXACT = new Set([
+  '/api/auth/login',
+  '/api/auth/verify',
+  '/api/health'
+]);
+
+const CLIENT_ALLOWED_PREFIX = '/api/client/';
+
+export const externalContainment = async (req, res, next) => {
+  // Never touch SPA static assets or the client-side routing fallback. This is
+  // also why the middleware is mounted top-level rather than at app.use('/api',
+  // ...) - under a mount path req.path would be relative to it and every string
+  // in the allowlist would silently stop matching.
+  if (!req.path.startsWith('/api/')) {
+    return next();
+  }
+
+  const result = await resolveUserFromRequest(req);
+
+  // No token, bad token, expired token, deleted or deactivated user: not our
+  // business. Downstream produces the right 401.
+  if (!result.user) {
+    return next();
+  }
+
+  // Cache the resolution for the downstream requireAuth so this costs no extra
+  // query for any role.
+  req.user = result.user;
+
+  if (result.user.role !== 'CLIENT') {
+    return next();
+  }
+
+  const allowed =
+    CLIENT_ALLOWED_EXACT.has(req.path) ||
+    req.path.startsWith(CLIENT_ALLOWED_PREFIX);
+
+  if (allowed) {
+    return next();
+  }
+
+  return res.status(403).json({
+    error: 'This account does not have access to that area'
+  });
+};
+
+export default externalContainment;

--- a/server/src/middleware/externalContainment.test.js
+++ b/server/src/middleware/externalContainment.test.js
@@ -1,0 +1,185 @@
+// The containment proof for the CLIENT role.
+//
+// A sentinel catch-all sits behind the middleware and answers 200 for any path.
+// Reaching it means the middleware let the request through. That tests the
+// containment rule itself rather than the role gates of whichever routers
+// happen to exist today - so a route file added next month is covered by these
+// assertions without anyone remembering to update them.
+import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest';
+import express from 'express';
+import jwt from 'jsonwebtoken';
+import prisma from '../prismaClient.js';
+import externalContainment from './externalContainment.js';
+
+vi.mock('../prismaClient.js', () => ({
+  default: {
+    user: { findUnique: vi.fn() }
+  }
+}));
+
+const adminUser = { id: 'admin-1', role: 'ADMIN', isActive: true, email: 'a@example.com', fullName: 'Admin' };
+const memberUser = { id: 'member-1', role: 'MEMBER', isActive: true, email: 'm@example.com', fullName: 'Member' };
+const candidateUser = { id: 'user-1', role: 'USER', isActive: true, email: 'c@example.com', fullName: 'Candidate' };
+const clientUser = { id: 'client-1', role: 'CLIENT', isActive: true, email: 'p@partner.com', fullName: 'Partner Co' };
+const deactivatedClient = { id: 'client-2', role: 'CLIENT', isActive: false, email: 'x@partner.com', fullName: 'Ex Partner' };
+
+const ALL_USERS = [adminUser, memberUser, candidateUser, clientUser, deactivatedClient];
+
+const tokenFor = (user) => jwt.sign({ userId: user.id }, process.env.JWT_SECRET);
+
+let server;
+let port;
+
+const request = (path, { user, rawToken } = {}) => {
+  const headers = {};
+  if (user) headers.Authorization = `Bearer ${tokenFor(user)}`;
+  if (rawToken) headers.Authorization = `Bearer ${rawToken}`;
+  return fetch(`http://localhost:${port}${path}`, { headers });
+};
+
+// Every path a CLIENT must be shut out of. Deliberately spans the route files
+// that mount a bare requireAuth with no role gate of their own - those are the
+// ones this middleware exists for.
+const FORBIDDEN_PATHS = [
+  '/api/users',
+  '/api/users/admin-1',
+  '/api/files/some-drive-id/pdf',
+  '/api/files/some-drive-id/image',
+  '/api/applications',
+  '/api/applications/app-1',
+  '/api/admin/users',
+  '/api/admin/talent-pool/stats',
+  '/api/member/gtkuc-profile',
+  '/api/member/resume',
+  '/api/candidates',
+  '/api/feature-requests',
+  '/api/cases/case-1',
+  '/api/review-teams',
+  '/api/conversations',
+  '/api/interview-resources',
+  '/api/my-meeting-signups'
+];
+
+beforeAll(async () => {
+  const app = express();
+  app.use(express.json());
+  app.use(externalContainment);
+  // Sentinel: anything that gets past containment lands here.
+  app.use((req, res) => res.status(200).json({ reached: true, path: req.path }));
+  server = app.listen(0);
+  await new Promise((resolve) => server.on('listening', resolve));
+  port = server.address().port;
+});
+
+afterAll(async () => {
+  await new Promise((resolve) => server.close(resolve));
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  prisma.user.findUnique.mockImplementation(({ where: { id } }) =>
+    ALL_USERS.find((u) => u.id === id) || null
+  );
+});
+
+describe('externalContainment - CLIENT is confined to the portal', () => {
+  it('blocks a CLIENT on every non-portal API path', async () => {
+    const results = await Promise.all(
+      FORBIDDEN_PATHS.map(async (path) => {
+        const res = await request(path, { user: clientUser });
+        return { path, status: res.status, body: await res.json() };
+      })
+    );
+
+    for (const { path, status, body } of results) {
+      expect({ path, status }).toEqual({ path, status: 403 });
+      expect(body.error).toBe('This account does not have access to that area');
+      expect(body.reached).toBeUndefined();
+    }
+  });
+
+  it('lets a CLIENT through to the portal and to login/verify/health', async () => {
+    const allowed = [
+      '/api/client/me',
+      '/api/client/resumes',
+      '/api/client/resumes/assignment-1/pdf',
+      '/api/auth/login',
+      '/api/auth/verify',
+      '/api/health'
+    ];
+
+    const results = await Promise.all(
+      allowed.map(async (path) => ({ path, status: (await request(path, { user: clientUser })).status }))
+    );
+
+    expect(results).toEqual(allowed.map((path) => ({ path, status: 200 })));
+  });
+
+  it('does not treat /api/clientele as a portal path', async () => {
+    // The prefix check is '/api/client/' with the trailing slash for exactly
+    // this reason - '/api/client' must not become a wildcard.
+    const res = await request('/api/clientele/secrets', { user: clientUser });
+    expect(res.status).toBe(403);
+  });
+});
+
+describe('externalContainment - transparent to everyone else', () => {
+  it('leaves ADMIN, MEMBER and USER untouched on every path a CLIENT is blocked from', async () => {
+    for (const user of [adminUser, memberUser, candidateUser]) {
+      const results = await Promise.all(
+        FORBIDDEN_PATHS.map(async (path) => ({
+          path,
+          status: (await request(path, { user })).status
+        }))
+      );
+      expect({ role: user.role, results }).toEqual({
+        role: user.role,
+        results: FORBIDDEN_PATHS.map((path) => ({ path, status: 200 }))
+      });
+    }
+  });
+
+  it('passes unauthenticated requests through so downstream still answers 401, not 403', async () => {
+    const res = await request('/api/users');
+    expect(res.status).toBe(200); // reached the sentinel; containment did not intervene
+    expect((await res.json()).reached).toBe(true);
+  });
+
+  it('passes malformed and wrongly-signed tokens through rather than converting them to 403', async () => {
+    const garbage = await request('/api/users', { rawToken: 'not-a-jwt' });
+    const wrongSecret = await request('/api/users', {
+      rawToken: jwt.sign({ userId: clientUser.id }, 'a-different-secret')
+    });
+
+    expect(garbage.status).toBe(200);
+    expect(wrongSecret.status).toBe(200);
+  });
+
+  it('passes an expired CLIENT token through - authentication failure is not our 403', async () => {
+    const expired = jwt.sign({ userId: clientUser.id }, process.env.JWT_SECRET, { expiresIn: -10 });
+    const res = await request('/api/users', { rawToken: expired });
+    expect(res.status).toBe(200);
+  });
+
+  it('passes a deactivated CLIENT through so requireAuth answers 401 Account deactivated', async () => {
+    const res = await request('/api/users', { user: deactivatedClient });
+    expect(res.status).toBe(200);
+  });
+
+  it('ignores non-API paths entirely', async () => {
+    const res = await request('/staging', { user: clientUser });
+    expect(res.status).toBe(200);
+  });
+});
+
+describe('externalContainment - request cost', () => {
+  it('resolves the user once and hands it to the downstream requireAuth', async () => {
+    // First call populates the shared cache; the second must not re-query.
+    await request('/api/client/me', { user: clientUser });
+    const callsAfterFirst = prisma.user.findUnique.mock.calls.length;
+    await request('/api/client/me', { user: clientUser });
+
+    expect(callsAfterFirst).toBeLessThanOrEqual(1);
+    expect(prisma.user.findUnique.mock.calls.length).toBe(callsAfterFirst);
+  });
+});

--- a/server/src/routes/admin.js
+++ b/server/src/routes/admin.js
@@ -5620,6 +5620,10 @@ router.get('/talent-pool/stats', async (req, res) => {
       applicants = Array.from(seen.values());
     }
 
+    const registeredClients = await prisma.talentPartnerClient.count({
+      where: { user: { isActive: true } }
+    });
+
     // Counted off the same array the roster renders, so the breakdown always
     // agrees with the rows behind it.
     const optedIn = applicants.filter((a) => a.talentPoolOptIn === true).length;
@@ -5640,14 +5644,15 @@ router.get('/talent-pool/stats', async (req, res) => {
       deduplicated: selectedCycleId === 'all',
       duplicatesCollapsed,
       totalApplications: applications.length,
-      // Two metrics on the TPN page have no source of truth yet:
-      //   * resumesUpdatedRecently - applications store a resume at submission
-      //     time only; there is no "resume last updated" timestamp to count.
-      //   * registeredClients - UserRole has no CLIENT variant yet.
-      // Reported as null so the UI can show "not tracked yet" rather than a
-      // zero that reads like a real measurement.
+      // resumesUpdatedRecently still has no source of truth: applications store
+      // a resume at submission time only, with no "resume last updated"
+      // timestamp to count. Reported as null so the UI shows "not tracked yet"
+      // rather than a zero that reads like a real measurement.
       resumesUpdatedRecently: null,
-      registeredClients: null
+      // registeredClients is now real - active CLIENT accounts with a partner
+      // row. Deactivated ones are excluded: the number is meant to answer "how
+      // many organizations can log in right now?".
+      registeredClients
     });
   } catch (error) {
     console.error('Error fetching talent pool stats:', error);

--- a/server/src/routes/auth.js
+++ b/server/src/routes/auth.js
@@ -86,8 +86,10 @@ router.post('/register', async (req, res) => {
       { expiresIn: config.jwtExpiresIn },
     );
 
-    // Return user info (without password) and token
-    const { password: _, ...userWithoutPassword } = user;
+    // Return user info and token. resetToken/resetTokenExpiry are stripped
+    // alongside the password - this payload now goes to Talent Partner Network
+    // clients too, and a live reset token is an account takeover primitive.
+    const { password: _, resetToken: __, resetTokenExpiry: ___, ...userWithoutPassword } = user;
     res.status(201).json({
       message: 'User created successfully',
       user: userWithoutPassword,
@@ -136,8 +138,10 @@ router.post('/login', async (req, res) => {
       { expiresIn: config.jwtExpiresIn },
     );
 
-    // Return user info (without password) and token
-    const { password: _, ...userWithoutPassword } = user;
+    // Return user info and token. resetToken/resetTokenExpiry are stripped
+    // alongside the password - this payload now goes to Talent Partner Network
+    // clients too, and a live reset token is an account takeover primitive.
+    const { password: _, resetToken: __, resetTokenExpiry: ___, ...userWithoutPassword } = user;
     res.json({
       message: 'Login successful',
       user: userWithoutPassword,
@@ -172,7 +176,7 @@ router.get('/verify', async (req, res) => {
       return res.status(401).json({ error: 'Account deactivated' });
     }
     
-    const { password: _, ...userWithoutPassword } = user;
+    const { password: _, resetToken: __, resetTokenExpiry: ___, ...userWithoutPassword } = user;
     res.json({ user: userWithoutPassword });
     
   } catch (error) {
@@ -189,6 +193,14 @@ router.post('/forgot-password', async (req, res) => {
 
     if (!user) {
       // Don't reveal if email exists
+      return res.json({ message: 'If that email exists, a reset link has been sent.' });
+    }
+
+    // Talent Partner Network clients have no self-service password reset - an
+    // admin sets their password. This endpoint is unauthenticated, so the
+    // containment middleware cannot see the role; the check has to live here.
+    // Same generic response as an unknown email, and no token is minted.
+    if (user.role === 'CLIENT') {
       return res.json({ message: 'If that email exists, a reset link has been sent.' });
     }
 
@@ -232,6 +244,12 @@ router.post('/reset-password', async (req, res) => {
     });
 
     if (!user) {
+      return res.status(400).json({ error: 'Invalid or expired token' });
+    }
+
+    // Belt and braces for the forgot-password guard above: a CLIENT should
+    // never hold a reset token, and if one exists it is not honoured.
+    if (user.role === 'CLIENT') {
       return res.status(400).json({ error: 'Invalid or expired token' });
     }
 
@@ -324,8 +342,10 @@ router.post('/register-member', async (req, res) => {
       { expiresIn: config.jwtExpiresIn },
     );
 
-    // Return user info (without password) and token
-    const { password: _, ...userWithoutPassword } = user;
+    // Return user info and token. resetToken/resetTokenExpiry are stripped
+    // alongside the password - this payload now goes to Talent Partner Network
+    // clients too, and a live reset token is an account takeover primitive.
+    const { password: _, resetToken: __, resetTokenExpiry: ___, ...userWithoutPassword } = user;
     res.status(201).json({
       message: 'Member created successfully',
       user: userWithoutPassword,

--- a/server/src/routes/client.js
+++ b/server/src/routes/client.js
@@ -1,13 +1,17 @@
 // The Talent Partner Network portal: everything a CLIENT account can reach.
 //
-// Three routes, all read-only. The containment middleware already 403s a CLIENT
-// anywhere else; requireClient here is the actual gate, and it loads the partner
-// row onto req.partnerClient.
+// Five routes, four read-only and one that renders a CSV. The containment
+// middleware already 403s a CLIENT anywhere else; requireClient here is the
+// actual gate, and it loads the partner row onto req.partnerClient.
 //
 // The security shape of this file: a client addresses resumes only by
 // assignment id, and every lookup is scoped to their own clientId. A wrong or
 // revoked id answers 404 rather than 403 so ids are not enumerable - a 403
 // would confirm the id exists.
+//
+// Every response body is built by projectAssignment(), never by a hand-written
+// select. That is what keeps the filter, facet, table and CSV paths from
+// drifting apart: four features, one projection, one place a field can leak.
 import express from 'express';
 import fs from 'node:fs';
 import path from 'node:path';
@@ -17,9 +21,21 @@ import { requireAuth, requireClient } from '../middleware/auth.js';
 import { getFileStream } from '../services/google/drive.js';
 import {
   projectAssignment,
-  resolveResumeSource,
-  searchableFields
+  resolveResumeSource
 } from '../utils/clientVisibility.js';
+import {
+  MAX_EXPORT,
+  MAX_MATERIALIZED,
+  buildAssignmentFilters,
+  buildFacets,
+  buildSearchClause,
+  csvFilename,
+  filterableFields,
+  sanitizeClientQuery,
+  sortRows,
+  sortableFields,
+  toCsv
+} from '../utils/clientResumeQuery.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 // Same root cases.js uses, and deliberately not the statically-served uploads/
@@ -30,8 +46,6 @@ const MEMBER_RESUME_ROOT = path.join(STORAGE_DIR, 'member-resumes');
 const router = express.Router();
 
 router.use(requireAuth, requireClient);
-
-const MAX_PAGE = 100;
 
 // Included fields are the superset the projection may read. The projection, not
 // this select, decides what actually reaches the client.
@@ -66,42 +80,78 @@ const ASSIGNMENT_INCLUDE = {
   }
 };
 
-/**
- * Search only across fields the client's visibility already exposes. Under
- * BLIND that excludes names - otherwise the result count answers "is this
- * person in my set?", which is deanonymization by another route.
- */
-const buildSearchWhere = (q, visibility) => {
-  const fields = searchableFields(visibility);
-  const or = [];
-  let memberNameAdded = false;
+const logAccess = (fields) =>
+  prisma.clientResumeAccessLog
+    .create({ data: fields })
+    // A logging failure must not decide whether a client can read a resume they
+    // were legitimately assigned.
+    .catch((error) => console.error('[client access log]', error));
 
-  for (const field of fields) {
-    if (field === 'firstName' || field === 'lastName') {
-      or.push({ application: { [field]: { contains: q, mode: 'insensitive' } } });
-      if (!memberNameAdded) {
-        or.push({ memberResume: { member: { fullName: { contains: q, mode: 'insensitive' } } } });
-        memberNameAdded = true;
-      }
-      continue;
-    }
-    or.push({ application: { [field]: { contains: q, mode: 'insensitive' } } });
-    or.push({ memberResume: { [field]: { contains: q, mode: 'insensitive' } } });
+const requestContext = (req) => ({
+  clientId: req.partnerClient.id,
+  userId: req.user.id,
+  ipAddress: req.ip || null,
+  userAgent: req.headers['user-agent']?.slice(0, 500) || null
+});
+
+/**
+ * Load and project the client's own assignments matching a sanitized spec.
+ *
+ * Filtering happens in the database so `total` is exact and cheap; sorting
+ * happens in memory over the projected DTOs, because an assignment points at an
+ * application OR a member resume and no Prisma orderBy interleaves two nullable
+ * to-one relations on the same column. See sortRows() for the full reasoning.
+ *
+ * MAX_MATERIALIZED bounds that in-memory set. When it bites, `truncated` says
+ * so - serving a sorted prefix as though it were the whole library would be the
+ * one failure here that looks exactly like success.
+ */
+const loadProjected = async ({ clientId, visibility, q, filters }) => {
+  const { and, notes } = buildAssignmentFilters(filters);
+  const where = { clientId, revokedAt: null };
+  const AND = [...and];
+  if (q) AND.push(buildSearchClause(q, visibility));
+  if (AND.length > 0) where.AND = AND;
+
+  const [total, assignments] = await Promise.all([
+    prisma.clientResumeAssignment.count({ where }),
+    prisma.clientResumeAssignment.findMany({
+      where,
+      include: ASSIGNMENT_INCLUDE,
+      orderBy: { assignedAt: 'desc' },
+      take: MAX_MATERIALIZED
+    })
+  ]);
+
+  const rows = assignments.map((a) => projectAssignment(a, visibility));
+  const truncated = total > rows.length;
+  if (truncated) {
+    notes.push(
+      `Showing the ${rows.length} most recently shared resumes of ${total}. Narrow the filters to see the rest.`
+    );
   }
 
-  return { OR: or };
+  return { rows, total, truncated, notes };
 };
 
 router.get('/me', async (req, res) => {
   try {
+    const { id: clientId, visibility } = req.partnerClient;
+
     const resumeCount = await prisma.clientResumeAssignment.count({
-      where: { clientId: req.partnerClient.id, revokedAt: null }
+      where: { clientId, revokedAt: null }
     });
 
     res.json({
       organization: req.partnerClient.organization,
-      visibility: req.partnerClient.visibility,
-      resumeCount
+      visibility,
+      resumeCount,
+      // The UI renders columns, filter controls and sort headers from these, so
+      // a level that hides a field hides its control too rather than offering
+      // one that silently does nothing.
+      filterableFields: filterableFields(visibility),
+      sortableFields: sortableFields(visibility),
+      maxExport: MAX_EXPORT
     });
   } catch (error) {
     console.error('[GET /api/client/me]', error);
@@ -109,35 +159,60 @@ router.get('/me', async (req, res) => {
   }
 });
 
-router.get('/resumes', async (req, res) => {
+/**
+ * Distinct values for the filter bar, computed over this client's own library
+ * so a dropdown never offers a choice that returns nothing.
+ *
+ * Deliberately unfiltered by the current query: dropdowns that reshuffle as you
+ * pick make it impossible to widen a selection you have already narrowed.
+ */
+router.get('/facets', async (req, res) => {
   try {
     const { id: clientId, visibility } = req.partnerClient;
 
-    const limit = Math.min(parseInt(req.query.limit, 10) || 25, MAX_PAGE);
-    const offset = Math.max(parseInt(req.query.offset, 10) || 0, 0);
-    const q = typeof req.query.q === 'string' ? req.query.q.trim() : '';
+    const assignments = await prisma.clientResumeAssignment.findMany({
+      where: { clientId, revokedAt: null },
+      include: ASSIGNMENT_INCLUDE,
+      orderBy: { assignedAt: 'desc' },
+      take: MAX_MATERIALIZED
+    });
 
-    const where = { clientId, revokedAt: null };
-    if (q) {
-      where.AND = [buildSearchWhere(q, visibility)];
+    const rows = assignments.map((a) => projectAssignment(a, visibility));
+    res.json(buildFacets(rows, visibility));
+  } catch (error) {
+    console.error('[GET /api/client/facets]', error);
+    res.status(500).json({ error: 'Failed to load filter options' });
+  }
+});
+
+router.get('/resumes', async (req, res) => {
+  try {
+    const { id: clientId, visibility } = req.partnerClient;
+    const { value, errors } = sanitizeClientQuery(req.query, visibility);
+
+    if (errors.length > 0) {
+      return res.status(400).json({ error: errors[0], errors });
     }
 
-    const [total, assignments] = await Promise.all([
-      prisma.clientResumeAssignment.count({ where }),
-      prisma.clientResumeAssignment.findMany({
-        where,
-        include: ASSIGNMENT_INCLUDE,
-        orderBy: { assignedAt: 'desc' },
-        take: limit,
-        skip: offset
-      })
-    ]);
+    const { rows, total, truncated, notes } = await loadProjected({
+      clientId,
+      visibility,
+      q: value.q,
+      filters: value.filters
+    });
+
+    const sorted = sortRows(rows, value.sort);
+    const page = sorted.slice(value.offset, value.offset + value.limit);
 
     res.json({
-      items: assignments.map((a) => projectAssignment(a, visibility)),
+      items: page,
       total,
-      limit,
-      offset
+      truncated,
+      notes,
+      limit: value.limit,
+      offset: value.offset,
+      sort: value.sort,
+      filters: value.filters
     });
   } catch (error) {
     console.error('[GET /api/client/resumes]', error);
@@ -145,29 +220,82 @@ router.get('/resumes', async (req, res) => {
   }
 });
 
+/**
+ * Export selected rows as CSV.
+ *
+ * POST rather than GET for two reasons: a selection is a list of ids that does
+ * not belong in a URL or a proxy log, and an export is a recorded act, which a
+ * cacheable GET is the wrong verb for.
+ *
+ * The CSV carries exactly the columns projectAssignment() emits at this
+ * visibility - no Drive ids, no storage paths, nothing the client could not
+ * already read on screen. It is a spreadsheet of the table, not a second, more
+ * generous API.
+ */
+router.post('/resumes/export', async (req, res) => {
+  try {
+    const { id: clientId, visibility, organization } = req.partnerClient;
+
+    const ids = Array.isArray(req.body?.assignmentIds) ? req.body.assignmentIds : null;
+    if (!ids || ids.length === 0) {
+      return res.status(400).json({ error: 'Select at least one resume to export.' });
+    }
+    if (ids.length > MAX_EXPORT) {
+      return res
+        .status(400)
+        .json({ error: `You can export at most ${MAX_EXPORT} resumes at a time.` });
+    }
+
+    const wanted = [...new Set(ids.filter((id) => typeof id === 'string' && id))];
+    if (wanted.length === 0) {
+      return res.status(400).json({ error: 'Select at least one resume to export.' });
+    }
+
+    // Scoped to this client's own live assignments, so a borrowed or revoked id
+    // contributes no row. Silently dropping rather than 404ing keeps the same
+    // non-enumerability property the PDF route has.
+    const assignments = await prisma.clientResumeAssignment.findMany({
+      where: { id: { in: wanted }, clientId, revokedAt: null },
+      include: ASSIGNMENT_INCLUDE
+    });
+
+    if (assignments.length === 0) {
+      return res.status(404).json({ error: 'None of those resumes are available to export.' });
+    }
+
+    const rows = sortRows(
+      assignments.map((a) => projectAssignment(a, visibility)),
+      { field: 'assignedAt', dir: 'desc' }
+    );
+
+    const context = requestContext(req);
+    await prisma.clientResumeAccessLog
+      .createMany({
+        data: rows.map((row) => ({ ...context, assignmentId: row.assignmentId, action: 'EXPORT' }))
+      })
+      .catch((error) => console.error('[client access log]', error));
+
+    const csv = toCsv(rows, visibility);
+    res.setHeader('Content-Type', 'text/csv; charset=utf-8');
+    res.setHeader(
+      'Content-Disposition',
+      `attachment; filename="${csvFilename(organization)}"`
+    );
+    res.setHeader('Cache-Control', 'no-store');
+    res.setHeader('X-Content-Type-Options', 'nosniff');
+    return res.send(csv);
+  } catch (error) {
+    console.error('[POST /api/client/resumes/export]', error);
+    if (!res.headersSent) {
+      res.status(500).json({ error: 'Failed to build your export' });
+    }
+  }
+});
+
 router.get('/resumes/:assignmentId/pdf', async (req, res) => {
   const { assignmentId } = req.params;
   const { id: clientId, visibility } = req.partnerClient;
-
-  // Every view is recorded, including the ones that are refused - a denied
-  // attempt is the more interesting half of the record.
-  const logView = async () => {
-    try {
-      await prisma.clientResumeAccessLog.create({
-        data: {
-          clientId,
-          userId: req.user.id,
-          assignmentId: assignmentId || null,
-          ipAddress: req.ip || null,
-          userAgent: req.headers['user-agent']?.slice(0, 500) || null
-        }
-      });
-    } catch (error) {
-      // A logging failure must not decide whether a client can read a resume
-      // they were legitimately assigned.
-      console.error('[client access log]', error);
-    }
-  };
+  const context = requestContext(req);
 
   try {
     const assignment = await prisma.clientResumeAssignment.findFirst({
@@ -176,29 +304,23 @@ router.get('/resumes/:assignmentId/pdf', async (req, res) => {
     });
 
     if (!assignment) {
-      // 404 rather than 403: a 403 would confirm the id exists.
-      await prisma.clientResumeAccessLog
-        .create({
-          data: {
-            clientId,
-            userId: req.user.id,
-            assignmentId: null,
-            ipAddress: req.ip || null,
-            userAgent: req.headers['user-agent']?.slice(0, 500) || null
-          }
-        })
-        .catch((error) => console.error('[client access log]', error));
+      // 404 rather than 403: a 403 would confirm the id exists. The log still
+      // records the attempt - a denied one is the more interesting half of the
+      // record, which is why it carries its own action.
+      await logAccess({ ...context, assignmentId: null, action: 'VIEW_DENIED' });
       return res.status(404).json({ error: 'Resume not found' });
     }
 
     const source = resolveResumeSource(assignment, visibility);
-    await logView();
 
     if (!source) {
       // BLIND with no redacted resume on file, or a member resume for a BLIND
       // client. Never fall back to the unredacted file.
+      await logAccess({ ...context, assignmentId, action: 'VIEW_DENIED' });
       return res.status(404).json({ error: 'This resume is not available.' });
     }
+
+    await logAccess({ ...context, assignmentId, action: 'VIEW' });
 
     // No filename in the disposition - it would carry the applicant's name
     // straight past a BLIND projection.

--- a/server/src/routes/client.js
+++ b/server/src/routes/client.js
@@ -1,0 +1,231 @@
+// The Talent Partner Network portal: everything a CLIENT account can reach.
+//
+// Three routes, all read-only. The containment middleware already 403s a CLIENT
+// anywhere else; requireClient here is the actual gate, and it loads the partner
+// row onto req.partnerClient.
+//
+// The security shape of this file: a client addresses resumes only by
+// assignment id, and every lookup is scoped to their own clientId. A wrong or
+// revoked id answers 404 rather than 403 so ids are not enumerable - a 403
+// would confirm the id exists.
+import express from 'express';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import prisma from '../prismaClient.js';
+import { requireAuth, requireClient } from '../middleware/auth.js';
+import { getFileStream } from '../services/google/drive.js';
+import {
+  projectAssignment,
+  resolveResumeSource,
+  searchableFields
+} from '../utils/clientVisibility.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+// Same root cases.js uses, and deliberately not the statically-served uploads/
+// directory - see the comment in routes/cases.js.
+const STORAGE_DIR = path.join(__dirname, '../../storage');
+const MEMBER_RESUME_ROOT = path.join(STORAGE_DIR, 'member-resumes');
+
+const router = express.Router();
+
+router.use(requireAuth, requireClient);
+
+const MAX_PAGE = 100;
+
+// Included fields are the superset the projection may read. The projection, not
+// this select, decides what actually reaches the client.
+const ASSIGNMENT_INCLUDE = {
+  application: {
+    select: {
+      id: true,
+      firstName: true,
+      lastName: true,
+      email: true,
+      phoneNumber: true,
+      graduationYear: true,
+      major1: true,
+      major2: true,
+      gender: true,
+      cumulativeGpa: true,
+      majorGpa: true,
+      resumeUrl: true,
+      blindResumeUrl: true
+    }
+  },
+  memberResume: {
+    select: {
+      id: true,
+      storagePath: true,
+      graduationYear: true,
+      major1: true,
+      major2: true,
+      gender: true,
+      member: { select: { fullName: true, email: true } }
+    }
+  }
+};
+
+/**
+ * Search only across fields the client's visibility already exposes. Under
+ * BLIND that excludes names - otherwise the result count answers "is this
+ * person in my set?", which is deanonymization by another route.
+ */
+const buildSearchWhere = (q, visibility) => {
+  const fields = searchableFields(visibility);
+  const or = [];
+  let memberNameAdded = false;
+
+  for (const field of fields) {
+    if (field === 'firstName' || field === 'lastName') {
+      or.push({ application: { [field]: { contains: q, mode: 'insensitive' } } });
+      if (!memberNameAdded) {
+        or.push({ memberResume: { member: { fullName: { contains: q, mode: 'insensitive' } } } });
+        memberNameAdded = true;
+      }
+      continue;
+    }
+    or.push({ application: { [field]: { contains: q, mode: 'insensitive' } } });
+    or.push({ memberResume: { [field]: { contains: q, mode: 'insensitive' } } });
+  }
+
+  return { OR: or };
+};
+
+router.get('/me', async (req, res) => {
+  try {
+    const resumeCount = await prisma.clientResumeAssignment.count({
+      where: { clientId: req.partnerClient.id, revokedAt: null }
+    });
+
+    res.json({
+      organization: req.partnerClient.organization,
+      visibility: req.partnerClient.visibility,
+      resumeCount
+    });
+  } catch (error) {
+    console.error('[GET /api/client/me]', error);
+    res.status(500).json({ error: 'Failed to load your account' });
+  }
+});
+
+router.get('/resumes', async (req, res) => {
+  try {
+    const { id: clientId, visibility } = req.partnerClient;
+
+    const limit = Math.min(parseInt(req.query.limit, 10) || 25, MAX_PAGE);
+    const offset = Math.max(parseInt(req.query.offset, 10) || 0, 0);
+    const q = typeof req.query.q === 'string' ? req.query.q.trim() : '';
+
+    const where = { clientId, revokedAt: null };
+    if (q) {
+      where.AND = [buildSearchWhere(q, visibility)];
+    }
+
+    const [total, assignments] = await Promise.all([
+      prisma.clientResumeAssignment.count({ where }),
+      prisma.clientResumeAssignment.findMany({
+        where,
+        include: ASSIGNMENT_INCLUDE,
+        orderBy: { assignedAt: 'desc' },
+        take: limit,
+        skip: offset
+      })
+    ]);
+
+    res.json({
+      items: assignments.map((a) => projectAssignment(a, visibility)),
+      total,
+      limit,
+      offset
+    });
+  } catch (error) {
+    console.error('[GET /api/client/resumes]', error);
+    res.status(500).json({ error: 'Failed to load your resume library' });
+  }
+});
+
+router.get('/resumes/:assignmentId/pdf', async (req, res) => {
+  const { assignmentId } = req.params;
+  const { id: clientId, visibility } = req.partnerClient;
+
+  // Every view is recorded, including the ones that are refused - a denied
+  // attempt is the more interesting half of the record.
+  const logView = async () => {
+    try {
+      await prisma.clientResumeAccessLog.create({
+        data: {
+          clientId,
+          userId: req.user.id,
+          assignmentId: assignmentId || null,
+          ipAddress: req.ip || null,
+          userAgent: req.headers['user-agent']?.slice(0, 500) || null
+        }
+      });
+    } catch (error) {
+      // A logging failure must not decide whether a client can read a resume
+      // they were legitimately assigned.
+      console.error('[client access log]', error);
+    }
+  };
+
+  try {
+    const assignment = await prisma.clientResumeAssignment.findFirst({
+      where: { id: assignmentId, clientId, revokedAt: null },
+      include: ASSIGNMENT_INCLUDE
+    });
+
+    if (!assignment) {
+      // 404 rather than 403: a 403 would confirm the id exists.
+      await prisma.clientResumeAccessLog
+        .create({
+          data: {
+            clientId,
+            userId: req.user.id,
+            assignmentId: null,
+            ipAddress: req.ip || null,
+            userAgent: req.headers['user-agent']?.slice(0, 500) || null
+          }
+        })
+        .catch((error) => console.error('[client access log]', error));
+      return res.status(404).json({ error: 'Resume not found' });
+    }
+
+    const source = resolveResumeSource(assignment, visibility);
+    await logView();
+
+    if (!source) {
+      // BLIND with no redacted resume on file, or a member resume for a BLIND
+      // client. Never fall back to the unredacted file.
+      return res.status(404).json({ error: 'This resume is not available.' });
+    }
+
+    // No filename in the disposition - it would carry the applicant's name
+    // straight past a BLIND projection.
+    res.setHeader('Content-Type', 'application/pdf');
+    res.setHeader('Content-Disposition', 'inline');
+    res.setHeader('Cache-Control', 'no-store');
+    res.setHeader('X-Content-Type-Options', 'nosniff');
+
+    if (source.kind === 'drive') {
+      const stream = await getFileStream(source.fileId);
+      return stream.pipe(res);
+    }
+
+    const absPath = path.join(STORAGE_DIR, source.storagePath);
+    if (!absPath.startsWith(MEMBER_RESUME_ROOT)) {
+      return res.status(400).json({ error: 'Invalid path' });
+    }
+    if (!fs.existsSync(absPath)) {
+      return res.status(404).json({ error: 'This resume is not available.' });
+    }
+    return fs.createReadStream(absPath).pipe(res);
+  } catch (error) {
+    console.error('[GET /api/client/resumes/:assignmentId/pdf]', error);
+    if (!res.headersSent) {
+      res.status(500).json({ error: 'Failed to load resume' });
+    }
+  }
+});
+
+export default router;

--- a/server/src/routes/client.routes.test.js
+++ b/server/src/routes/client.routes.test.js
@@ -1,0 +1,311 @@
+// Security coverage for the Talent Partner Network portal. The assertions that
+// matter: a client cannot read a resume that is not currently assigned to them,
+// a BLIND client is never served an unredacted file, and no Drive id or storage
+// path ever crosses the response boundary.
+import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest';
+import express from 'express';
+import jwt from 'jsonwebtoken';
+import prisma from '../prismaClient.js';
+import clientRoutes from './client.js';
+import { getFileStream } from '../services/google/drive.js';
+
+vi.mock('../prismaClient.js', () => ({
+  default: {
+    user: { findUnique: vi.fn() },
+    talentPartnerClient: { findUnique: vi.fn() },
+    clientResumeAssignment: { count: vi.fn(), findMany: vi.fn(), findFirst: vi.fn() },
+    clientResumeAccessLog: { create: vi.fn() }
+  }
+}));
+
+vi.mock('../services/google/drive.js', () => ({
+  getFileStream: vi.fn(),
+  getFileMetadata: vi.fn()
+}));
+
+const DRIVE_REAL = 'drive-real-resume-id';
+const DRIVE_BLIND = 'drive-blind-resume-id';
+
+const clientUser = { id: 'client-user-1', role: 'CLIENT', isActive: true, email: 'p@acme.com', fullName: 'Acme' };
+const otherClientUser = { id: 'client-user-2', role: 'CLIENT', isActive: true, email: 'q@other.com', fullName: 'Other' };
+const adminUser = { id: 'admin-1', role: 'ADMIN', isActive: true, email: 'a@uc.org', fullName: 'Admin' };
+const memberUser = { id: 'member-1', role: 'MEMBER', isActive: true, email: 'm@uc.org', fullName: 'Member' };
+const candidateUser = { id: 'user-1', role: 'USER', isActive: true, email: 'c@uc.org', fullName: 'Candidate' };
+
+const ALL_USERS = [clientUser, otherClientUser, adminUser, memberUser, candidateUser];
+
+const partnerFor = (visibility) => ({
+  id: 'partner-1',
+  userId: clientUser.id,
+  organization: 'Acme Recruiting',
+  visibility
+});
+
+const assignmentRow = (overrides = {}) => ({
+  id: 'assign-1',
+  assignedAt: new Date('2026-08-01T00:00:00.000Z'),
+  application: {
+    id: 'app-1',
+    firstName: 'Jane',
+    lastName: 'Doe',
+    email: 'jane@ucla.edu',
+    phoneNumber: '310-555-0100',
+    graduationYear: '2030',
+    major1: 'Economics',
+    major2: null,
+    gender: 'Female',
+    cumulativeGpa: '3.85',
+    majorGpa: '3.90',
+    resumeUrl: DRIVE_REAL,
+    blindResumeUrl: DRIVE_BLIND
+  },
+  memberResume: null,
+  ...overrides
+});
+
+const tokenFor = (user) => jwt.sign({ userId: user.id }, process.env.JWT_SECRET);
+
+let server;
+let port;
+
+const request = (path, { user } = {}) => {
+  const headers = {};
+  if (user) headers.Authorization = `Bearer ${tokenFor(user)}`;
+  return fetch(`http://localhost:${port}${path}`, { headers });
+};
+
+// A minimal readable that satisfies .pipe(res).
+const fakeStream = () => {
+  const { Readable } = require('node:stream');
+  return Readable.from([Buffer.from('%PDF-1.4 fake')]);
+};
+
+beforeAll(async () => {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/client', clientRoutes);
+  server = app.listen(0);
+  await new Promise((resolve) => server.on('listening', resolve));
+  port = server.address().port;
+});
+
+afterAll(async () => {
+  await new Promise((resolve) => server.close(resolve));
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  prisma.user.findUnique.mockImplementation(({ where: { id } }) =>
+    ALL_USERS.find((u) => u.id === id) || null
+  );
+  prisma.talentPartnerClient.findUnique.mockResolvedValue(partnerFor('BASIC'));
+  prisma.clientResumeAssignment.count.mockResolvedValue(0);
+  prisma.clientResumeAssignment.findMany.mockResolvedValue([]);
+  prisma.clientResumeAssignment.findFirst.mockResolvedValue(null);
+  prisma.clientResumeAccessLog.create.mockResolvedValue({ id: 'log-1' });
+  getFileStream.mockImplementation(async () => fakeStream());
+});
+
+describe('portal access control', () => {
+  it('refuses every non-CLIENT role', async () => {
+    for (const user of [adminUser, memberUser, candidateUser]) {
+      const res = await request('/api/client/resumes', { user });
+      expect({ role: user.role, status: res.status }).toEqual({ role: user.role, status: 403 });
+    }
+  });
+
+  it('refuses an unauthenticated request with 401, not 403', async () => {
+    const res = await request('/api/client/resumes');
+    expect(res.status).toBe(401);
+  });
+
+  it('refuses a CLIENT with no partner row', async () => {
+    prisma.talentPartnerClient.findUnique.mockResolvedValue(null);
+    const res = await request('/api/client/resumes', { user: clientUser });
+    expect(res.status).toBe(403);
+    expect((await res.json()).error).toMatch(/not configured/i);
+  });
+});
+
+describe('resume list', () => {
+  it('scopes the query to this client and excludes revoked assignments', async () => {
+    await request('/api/client/resumes', { user: clientUser });
+
+    const where = prisma.clientResumeAssignment.findMany.mock.calls[0][0].where;
+    expect(where.clientId).toBe('partner-1');
+    expect(where.revokedAt).toBeNull();
+  });
+
+  it('never emits a Drive id or a /api/files URL', async () => {
+    prisma.clientResumeAssignment.findMany.mockResolvedValue([assignmentRow()]);
+    prisma.clientResumeAssignment.count.mockResolvedValue(1);
+
+    const res = await request('/api/client/resumes', { user: clientUser });
+    const body = await res.text();
+
+    expect(body).not.toContain(DRIVE_REAL);
+    expect(body).not.toContain(DRIVE_BLIND);
+    expect(body).not.toContain('/api/files/');
+    expect(JSON.parse(body).items[0].pdfUrl).toBe('/api/client/resumes/assign-1/pdf');
+  });
+
+  it('omits names for a BLIND client', async () => {
+    prisma.talentPartnerClient.findUnique.mockResolvedValue(partnerFor('BLIND'));
+    prisma.clientResumeAssignment.findMany.mockResolvedValue([assignmentRow()]);
+
+    const res = await request('/api/client/resumes', { user: clientUser });
+    const item = (await res.json()).items[0];
+
+    expect(item).not.toHaveProperty('firstName');
+    expect(item).not.toHaveProperty('email');
+    expect(item.major1).toBe('Economics');
+  });
+
+  it('does not let a BLIND client search by name', async () => {
+    prisma.talentPartnerClient.findUnique.mockResolvedValue(partnerFor('BLIND'));
+    await request('/api/client/resumes?q=Jane', { user: clientUser });
+
+    const where = prisma.clientResumeAssignment.findMany.mock.calls[0][0].where;
+    const searched = JSON.stringify(where.AND);
+    expect(searched).not.toContain('firstName');
+    expect(searched).not.toContain('lastName');
+    expect(searched).toContain('major1');
+  });
+
+  it('allows name search once identity is already visible', async () => {
+    await request('/api/client/resumes?q=Jane', { user: clientUser });
+    const where = prisma.clientResumeAssignment.findMany.mock.calls[0][0].where;
+    expect(JSON.stringify(where.AND)).toContain('firstName');
+  });
+
+  it('caps page size', async () => {
+    await request('/api/client/resumes?limit=100000', { user: clientUser });
+    expect(prisma.clientResumeAssignment.findMany.mock.calls[0][0].take).toBe(100);
+  });
+});
+
+describe('resume PDF - the assignment id is the only key', () => {
+  it('scopes the lookup to this client and to live assignments', async () => {
+    prisma.clientResumeAssignment.findFirst.mockResolvedValue(assignmentRow());
+    await request('/api/client/resumes/assign-1/pdf', { user: clientUser });
+
+    const where = prisma.clientResumeAssignment.findFirst.mock.calls[0][0].where;
+    expect(where).toMatchObject({ id: 'assign-1', clientId: 'partner-1', revokedAt: null });
+  });
+
+  it('answers 404 - not 403 - for an assignment belonging to another client', async () => {
+    // findFirst is already scoped by clientId, so another client's id simply
+    // does not match.
+    prisma.clientResumeAssignment.findFirst.mockResolvedValue(null);
+
+    const res = await request('/api/client/resumes/someone-elses-assignment/pdf', { user: clientUser });
+
+    expect(res.status).toBe(404);
+    expect(getFileStream).not.toHaveBeenCalled();
+  });
+
+  it('answers 404 for a revoked assignment and streams nothing', async () => {
+    prisma.clientResumeAssignment.findFirst.mockResolvedValue(null);
+    const res = await request('/api/client/resumes/assign-1/pdf', { user: clientUser });
+    expect(res.status).toBe(404);
+    expect(getFileStream).not.toHaveBeenCalled();
+  });
+
+  it('serves the redacted file to a BLIND client, and never the real one', async () => {
+    prisma.talentPartnerClient.findUnique.mockResolvedValue(partnerFor('BLIND'));
+    prisma.clientResumeAssignment.findFirst.mockResolvedValue(assignmentRow());
+
+    await request('/api/client/resumes/assign-1/pdf', { user: clientUser });
+
+    expect(getFileStream).toHaveBeenCalledWith(DRIVE_BLIND);
+    expect(getFileStream).not.toHaveBeenCalledWith(DRIVE_REAL);
+  });
+
+  it('refuses rather than falling back when a BLIND client has no redacted file', async () => {
+    prisma.talentPartnerClient.findUnique.mockResolvedValue(partnerFor('BLIND'));
+    const row = assignmentRow();
+    row.application.blindResumeUrl = null;
+    prisma.clientResumeAssignment.findFirst.mockResolvedValue(row);
+
+    const res = await request('/api/client/resumes/assign-1/pdf', { user: clientUser });
+
+    expect(res.status).toBe(404);
+    // The important half: it did not quietly serve the unredacted resume.
+    expect(getFileStream).not.toHaveBeenCalled();
+  });
+
+  it('refuses a member resume for a BLIND client', async () => {
+    prisma.talentPartnerClient.findUnique.mockResolvedValue(partnerFor('BLIND'));
+    prisma.clientResumeAssignment.findFirst.mockResolvedValue({
+      id: 'assign-2',
+      assignedAt: new Date(),
+      application: null,
+      memberResume: {
+        id: 'mr-1',
+        storagePath: 'member-resumes/mr-1/resume.pdf',
+        graduationYear: '2027',
+        major1: 'Statistics',
+        member: { fullName: 'Alex Rivera' }
+      }
+    });
+
+    const res = await request('/api/client/resumes/assign-2/pdf', { user: clientUser });
+    expect(res.status).toBe(404);
+  });
+
+  it('serves the real file at BASIC and FULL', async () => {
+    for (const visibility of ['BASIC', 'FULL']) {
+      vi.clearAllMocks();
+      prisma.user.findUnique.mockImplementation(({ where: { id } }) =>
+        ALL_USERS.find((u) => u.id === id) || null
+      );
+      prisma.talentPartnerClient.findUnique.mockResolvedValue(partnerFor(visibility));
+      prisma.clientResumeAssignment.findFirst.mockResolvedValue(assignmentRow());
+      prisma.clientResumeAccessLog.create.mockResolvedValue({ id: 'log' });
+      getFileStream.mockImplementation(async () => fakeStream());
+
+      await request('/api/client/resumes/assign-1/pdf', { user: clientUser });
+      expect(getFileStream).toHaveBeenCalledWith(DRIVE_REAL);
+    }
+  });
+
+  it('streams inline and never as an attachment', async () => {
+    prisma.clientResumeAssignment.findFirst.mockResolvedValue(assignmentRow());
+    const res = await request('/api/client/resumes/assign-1/pdf', { user: clientUser });
+
+    expect(res.headers.get('content-disposition')).toBe('inline');
+    expect(res.headers.get('content-disposition')).not.toMatch(/attachment/);
+    // No filename - it would carry the applicant's name past a BLIND projection.
+    expect(res.headers.get('content-disposition')).not.toMatch(/filename/);
+    expect(res.headers.get('cache-control')).toBe('no-store');
+  });
+});
+
+describe('access logging', () => {
+  it('records a successful view', async () => {
+    prisma.clientResumeAssignment.findFirst.mockResolvedValue(assignmentRow());
+    await request('/api/client/resumes/assign-1/pdf', { user: clientUser });
+
+    expect(prisma.clientResumeAccessLog.create).toHaveBeenCalledTimes(1);
+    expect(prisma.clientResumeAccessLog.create.mock.calls[0][0].data).toMatchObject({
+      clientId: 'partner-1',
+      userId: clientUser.id,
+      assignmentId: 'assign-1'
+    });
+  });
+
+  it('records a refused view too - the denied attempts are the interesting ones', async () => {
+    prisma.clientResumeAssignment.findFirst.mockResolvedValue(null);
+    await request('/api/client/resumes/not-mine/pdf', { user: clientUser });
+
+    expect(prisma.clientResumeAccessLog.create).toHaveBeenCalledTimes(1);
+  });
+
+  it('still serves the resume if logging fails', async () => {
+    prisma.clientResumeAssignment.findFirst.mockResolvedValue(assignmentRow());
+    prisma.clientResumeAccessLog.create.mockRejectedValue(new Error('log table down'));
+
+    const res = await request('/api/client/resumes/assign-1/pdf', { user: clientUser });
+    expect(res.status).toBe(200);
+  });
+});

--- a/server/src/routes/client.routes.test.js
+++ b/server/src/routes/client.routes.test.js
@@ -26,6 +26,13 @@ vi.mock('../services/google/drive.js', () => ({
 const DRIVE_REAL = 'drive-real-resume-id';
 const DRIVE_BLIND = 'drive-blind-resume-id';
 
+// What the column actually holds: a proxy URL wrapping the Drive id. The
+// assertions below check getFileStream receives the bare id, so storing the
+// bare id in the fixture would make them tautological - and did, until a
+// wrapped URL reached the Drive SDK in the browser and 500'd.
+const RESUME_URL_REAL = `/api/files/${DRIVE_REAL}/pdf`;
+const RESUME_URL_BLIND = `https://uconsultingats.com/api/files/${DRIVE_BLIND}/pdf`;
+
 const clientUser = { id: 'client-user-1', role: 'CLIENT', isActive: true, email: 'p@acme.com', fullName: 'Acme' };
 const otherClientUser = { id: 'client-user-2', role: 'CLIENT', isActive: true, email: 'q@other.com', fullName: 'Other' };
 const adminUser = { id: 'admin-1', role: 'ADMIN', isActive: true, email: 'a@uc.org', fullName: 'Admin' };
@@ -56,8 +63,8 @@ const assignmentRow = (overrides = {}) => ({
     gender: 'Female',
     cumulativeGpa: '3.85',
     majorGpa: '3.90',
-    resumeUrl: DRIVE_REAL,
-    blindResumeUrl: DRIVE_BLIND
+    resumeUrl: RESUME_URL_REAL,
+    blindResumeUrl: RESUME_URL_BLIND
   },
   memberResume: null,
   ...overrides

--- a/server/src/routes/client.routes.test.js
+++ b/server/src/routes/client.routes.test.js
@@ -14,7 +14,7 @@ vi.mock('../prismaClient.js', () => ({
     user: { findUnique: vi.fn() },
     talentPartnerClient: { findUnique: vi.fn() },
     clientResumeAssignment: { count: vi.fn(), findMany: vi.fn(), findFirst: vi.fn() },
-    clientResumeAccessLog: { create: vi.fn() }
+    clientResumeAccessLog: { create: vi.fn(), createMany: vi.fn() }
   }
 }));
 
@@ -110,8 +110,19 @@ beforeEach(() => {
   prisma.clientResumeAssignment.findMany.mockResolvedValue([]);
   prisma.clientResumeAssignment.findFirst.mockResolvedValue(null);
   prisma.clientResumeAccessLog.create.mockResolvedValue({ id: 'log-1' });
+  prisma.clientResumeAccessLog.createMany.mockResolvedValue({ count: 1 });
   getFileStream.mockImplementation(async () => fakeStream());
 });
+
+const post = (path, body, { user } = {}) => {
+  const headers = { 'Content-Type': 'application/json' };
+  if (user) headers.Authorization = `Bearer ${tokenFor(user)}`;
+  return fetch(`http://localhost:${port}${path}`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(body)
+  });
+};
 
 describe('portal access control', () => {
   it('refuses every non-CLIENT role', async () => {
@@ -185,9 +196,35 @@ describe('resume list', () => {
     expect(JSON.stringify(where.AND)).toContain('firstName');
   });
 
+  // Paging moved into memory when sorting did (an assignment points at an
+  // application OR a member resume, and no orderBy interleaves the two), so the
+  // cap is now on what the response carries rather than on the query's take.
   it('caps page size', async () => {
-    await request('/api/client/resumes?limit=100000', { user: clientUser });
-    expect(prisma.clientResumeAssignment.findMany.mock.calls[0][0].take).toBe(100);
+    prisma.clientResumeAssignment.count.mockResolvedValue(500);
+    prisma.clientResumeAssignment.findMany.mockResolvedValue(
+      Array.from({ length: 500 }, (_, i) => assignmentRow({ id: `assign-${i}` }))
+    );
+
+    const res = await request('/api/client/resumes?limit=100000', { user: clientUser });
+    const body = await res.json();
+
+    expect(body.limit).toBe(100);
+    expect(body.items).toHaveLength(100);
+  });
+
+  it('bounds what it materializes, and says so rather than serving a prefix silently', async () => {
+    prisma.clientResumeAssignment.count.mockResolvedValue(5000);
+    prisma.clientResumeAssignment.findMany.mockResolvedValue(
+      Array.from({ length: 2000 }, (_, i) => assignmentRow({ id: `assign-${i}` }))
+    );
+
+    const res = await request('/api/client/resumes', { user: clientUser });
+    const body = await res.json();
+
+    expect(prisma.clientResumeAssignment.findMany.mock.calls[0][0].take).toBe(2000);
+    expect(body.total).toBe(5000);
+    expect(body.truncated).toBe(true);
+    expect(body.notes.join(' ')).toContain('2000');
   });
 });
 
@@ -313,6 +350,260 @@ describe('access logging', () => {
     prisma.clientResumeAccessLog.create.mockRejectedValue(new Error('log table down'));
 
     const res = await request('/api/client/resumes/assign-1/pdf', { user: clientUser });
+    expect(res.status).toBe(200);
+  });
+});
+
+describe('access actions', () => {
+  it('labels a successful view VIEW', async () => {
+    prisma.clientResumeAssignment.findFirst.mockResolvedValue(assignmentRow());
+    await request('/api/client/resumes/assign-1/pdf', { user: clientUser });
+
+    expect(prisma.clientResumeAccessLog.create.mock.calls[0][0].data.action).toBe('VIEW');
+  });
+
+  it('labels an unknown assignment VIEW_DENIED', async () => {
+    prisma.clientResumeAssignment.findFirst.mockResolvedValue(null);
+    await request('/api/client/resumes/not-mine/pdf', { user: clientUser });
+
+    expect(prisma.clientResumeAccessLog.create.mock.calls[0][0].data).toMatchObject({
+      action: 'VIEW_DENIED',
+      assignmentId: null
+    });
+  });
+
+  it('labels a BLIND miss VIEW_DENIED and names the assignment it refused', async () => {
+    prisma.talentPartnerClient.findUnique.mockResolvedValue(partnerFor('BLIND'));
+    const row = assignmentRow();
+    row.application.blindResumeUrl = null;
+    prisma.clientResumeAssignment.findFirst.mockResolvedValue(row);
+
+    const res = await request('/api/client/resumes/assign-1/pdf', { user: clientUser });
+
+    expect(res.status).toBe(404);
+    expect(prisma.clientResumeAccessLog.create.mock.calls[0][0].data).toMatchObject({
+      action: 'VIEW_DENIED',
+      assignmentId: 'assign-1'
+    });
+    expect(getFileStream).not.toHaveBeenCalled();
+  });
+});
+
+describe('account capabilities', () => {
+  it('tells the UI which controls to render, per visibility level', async () => {
+    prisma.talentPartnerClient.findUnique.mockResolvedValue(partnerFor('BLIND'));
+    const blind = await (await request('/api/client/me', { user: clientUser })).json();
+
+    // The UI renders columns, filters and sort headers from these lists, so a
+    // level that hides a field must not advertise a control for it.
+    expect(blind.filterableFields).not.toContain('gender');
+    expect(blind.filterableFields).not.toContain('gpa');
+    expect(blind.sortableFields).not.toContain('name');
+
+    prisma.talentPartnerClient.findUnique.mockResolvedValue(partnerFor('FULL'));
+    const full = await (await request('/api/client/me', { user: clientUser })).json();
+
+    expect(full.filterableFields).toEqual(expect.arrayContaining(['gender', 'gpa']));
+    expect(full.sortableFields).toContain('cumulativeGpa');
+  });
+});
+
+describe('filters', () => {
+  it('scopes the facet query to this client and offers no gender under BLIND', async () => {
+    prisma.talentPartnerClient.findUnique.mockResolvedValue(partnerFor('BLIND'));
+    prisma.clientResumeAssignment.findMany.mockResolvedValue([assignmentRow()]);
+
+    const res = await request('/api/client/facets', { user: clientUser });
+    const body = await res.json();
+
+    expect(prisma.clientResumeAssignment.findMany.mock.calls[0][0].where).toMatchObject({
+      clientId: 'partner-1',
+      revokedAt: null
+    });
+    expect(body.graduationYear).toEqual(['2030']);
+    expect(body).not.toHaveProperty('gender');
+  });
+
+  it('translates a graduation year into a clause against both pools', async () => {
+    await request('/api/client/resumes?graduationYear=2030,2029', { user: clientUser });
+
+    const where = prisma.clientResumeAssignment.findMany.mock.calls[0][0].where;
+    const json = JSON.stringify(where.AND);
+    expect(json).toContain('2030');
+    expect(json).toContain('memberResume');
+  });
+
+  it('ignores a gender filter from a BLIND client instead of honouring it', async () => {
+    prisma.talentPartnerClient.findUnique.mockResolvedValue(partnerFor('BLIND'));
+    await request('/api/client/resumes?gender=Female', { user: clientUser });
+
+    const where = prisma.clientResumeAssignment.findMany.mock.calls[0][0].where;
+    expect(JSON.stringify(where.AND || [])).not.toContain('Female');
+  });
+
+  it('honours a GPA range at FULL and warns that it excludes members', async () => {
+    prisma.talentPartnerClient.findUnique.mockResolvedValue(partnerFor('FULL'));
+    const res = await request('/api/client/resumes?gpaMin=3.50', { user: clientUser });
+    const body = await res.json();
+
+    const where = prisma.clientResumeAssignment.findMany.mock.calls[0][0].where;
+    expect(JSON.stringify(where.AND)).toContain('3.50');
+    expect(body.notes.join(' ')).toMatch(/do not record a GPA/);
+  });
+
+  it('rejects a malformed GPA rather than dropping it silently', async () => {
+    prisma.talentPartnerClient.findUnique.mockResolvedValue(partnerFor('FULL'));
+    const res = await request('/api/client/resumes?gpaMin=abc', { user: clientUser });
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/Minimum GPA/);
+  });
+});
+
+describe('CSV export', () => {
+  const twoRows = [assignmentRow({ id: 'assign-1' }), assignmentRow({ id: 'assign-2' })];
+
+  it('scopes the lookup to this client and to live assignments', async () => {
+    prisma.clientResumeAssignment.findMany.mockResolvedValue(twoRows);
+
+    await post(
+      '/api/client/resumes/export',
+      { assignmentIds: ['assign-1', 'assign-2'] },
+      { user: clientUser }
+    );
+
+    expect(prisma.clientResumeAssignment.findMany.mock.calls[0][0].where).toMatchObject({
+      clientId: 'partner-1',
+      revokedAt: null
+    });
+  });
+
+  it('exports only the columns this visibility already shows', async () => {
+    prisma.talentPartnerClient.findUnique.mockResolvedValue(partnerFor('BLIND'));
+    prisma.clientResumeAssignment.findMany.mockResolvedValue([assignmentRow()]);
+
+    const res = await post('/api/client/resumes/export', { assignmentIds: ['assign-1'] }, {
+      user: clientUser
+    });
+    const csv = await res.text();
+
+    // The CSV is a spreadsheet of the table, not a second and more generous API.
+    expect(csv).not.toContain('Jane');
+    expect(csv).not.toContain('jane@ucla.edu');
+    expect(csv).not.toContain('3.85');
+    expect(csv).not.toContain(DRIVE_REAL);
+    expect(csv).not.toContain(DRIVE_BLIND);
+    expect(csv).toContain('Economics');
+  });
+
+  it('includes identity and contact at FULL', async () => {
+    prisma.talentPartnerClient.findUnique.mockResolvedValue(partnerFor('FULL'));
+    prisma.clientResumeAssignment.findMany.mockResolvedValue([assignmentRow()]);
+
+    const csv = await (
+      await post('/api/client/resumes/export', { assignmentIds: ['assign-1'] }, { user: clientUser })
+    ).text();
+
+    expect(csv).toContain('Jane');
+    expect(csv).toContain('jane@ucla.edu');
+    expect(csv).toContain('3.85');
+  });
+
+  it('sends a CSV attachment that browsers will not sniff', async () => {
+    prisma.clientResumeAssignment.findMany.mockResolvedValue([assignmentRow()]);
+
+    const res = await post('/api/client/resumes/export', { assignmentIds: ['assign-1'] }, {
+      user: clientUser
+    });
+
+    expect(res.headers.get('content-type')).toMatch(/text\/csv/);
+    expect(res.headers.get('content-disposition')).toMatch(/attachment/);
+    expect(res.headers.get('content-disposition')).toMatch(/acme-recruiting-resumes-/);
+    expect(res.headers.get('x-content-type-options')).toBe('nosniff');
+    expect(res.headers.get('cache-control')).toBe('no-store');
+  });
+
+  it('records one EXPORT row per resume actually exported', async () => {
+    prisma.clientResumeAssignment.findMany.mockResolvedValue(twoRows);
+
+    await post(
+      '/api/client/resumes/export',
+      { assignmentIds: ['assign-1', 'assign-2'] },
+      { user: clientUser }
+    );
+
+    const logged = prisma.clientResumeAccessLog.createMany.mock.calls[0][0].data;
+    expect(logged).toHaveLength(2);
+    expect(logged[0]).toMatchObject({
+      clientId: 'partner-1',
+      userId: clientUser.id,
+      action: 'EXPORT'
+    });
+    expect(logged.map((r) => r.assignmentId).sort()).toEqual(['assign-1', 'assign-2']);
+  });
+
+  it('drops a borrowed id rather than exporting it or announcing that it exists', async () => {
+    // findMany is already scoped by clientId, so another client's id simply does
+    // not come back - and 404ing on it would confirm it exists.
+    prisma.clientResumeAssignment.findMany.mockResolvedValue([assignmentRow({ id: 'assign-1' })]);
+
+    const res = await post(
+      '/api/client/resumes/export',
+      { assignmentIds: ['assign-1', 'someone-elses-assignment'] },
+      { user: clientUser }
+    );
+
+    expect(res.status).toBe(200);
+    const csv = await res.text();
+    expect(csv.trim().split('\r\n')).toHaveLength(2); // header + one row
+  });
+
+  it('refuses an empty selection', async () => {
+    const res = await post('/api/client/resumes/export', { assignmentIds: [] }, {
+      user: clientUser
+    });
+    expect(res.status).toBe(400);
+    expect(prisma.clientResumeAccessLog.createMany).not.toHaveBeenCalled();
+  });
+
+  it('refuses a selection larger than the export cap', async () => {
+    const res = await post(
+      '/api/client/resumes/export',
+      { assignmentIds: Array.from({ length: 1001 }, (_, i) => `assign-${i}`) },
+      { user: clientUser }
+    );
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/at most 1000/);
+    expect(prisma.clientResumeAssignment.findMany).not.toHaveBeenCalled();
+  });
+
+  it('answers 404 when nothing in the selection is exportable', async () => {
+    prisma.clientResumeAssignment.findMany.mockResolvedValue([]);
+    const res = await post('/api/client/resumes/export', { assignmentIds: ['gone'] }, {
+      user: clientUser
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it('refuses every non-CLIENT role', async () => {
+    for (const user of [adminUser, memberUser, candidateUser]) {
+      const res = await post(
+        '/api/client/resumes/export',
+        { assignmentIds: ['assign-1'] },
+        { user }
+      );
+      expect({ role: user.role, status: res.status }).toEqual({ role: user.role, status: 403 });
+    }
+  });
+
+  it('still returns the CSV if logging fails', async () => {
+    prisma.clientResumeAssignment.findMany.mockResolvedValue([assignmentRow()]);
+    prisma.clientResumeAccessLog.createMany.mockRejectedValue(new Error('log table down'));
+
+    const res = await post('/api/client/resumes/export', { assignmentIds: ['assign-1'] }, {
+      user: clientUser
+    });
     expect(res.status).toBe(200);
   });
 });

--- a/server/src/routes/member.js
+++ b/server/src/routes/member.js
@@ -1,4 +1,9 @@
 import express from 'express';
+import multer from 'multer';
+import fs from 'node:fs';
+import fsPromises from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { requireAuth, requireAdminOrMember } from '../middleware/auth.js';
 import prisma from '../prismaClient.js';
 import { sendSlackMessage } from '../services/slackService.js';
@@ -20,6 +25,11 @@ import {
   isProfileComplete,
   missingProfileFields
 } from '../utils/gtkucProfile.js';
+import {
+  MEMBER_GENDERS,
+  sanitizeMemberResumeInput,
+  serializeMemberResume
+} from '../utils/memberResume.js';
 // GTKUC profile shown to candidates on the member's slots, loaded with the
 // active cycle's confirmation so the portal knows whether to force the
 // confirm/update modal before the member can open slots.
@@ -1798,6 +1808,225 @@ router.post('/flag-document', requireAuth, async (req, res) => {
   } catch (error) {
     console.error('[POST /api/member/flag-document]', error);
     res.status(500).json({ error: 'Failed to flag document' });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Member resume - Talent Partner Network
+// ---------------------------------------------------------------------------
+// A member's own resume plus the consent that makes it assignable to a partner
+// client. Gated on MEMBER specifically rather than requireAdminOrMember: an
+// admin uploading "their" member resume is meaningless. The ownership key is
+// always req.user.id, never a route param.
+
+const __memberDirname = path.dirname(fileURLToPath(import.meta.url));
+// Same root cases.js uses. Deliberately NOT uploads/, which index.js serves
+// statically and unauthenticated - a resume there would be world-readable.
+const RESUME_STORAGE_DIR = path.join(__memberDirname, '../../storage');
+const MEMBER_RESUME_ROOT = path.join(RESUME_STORAGE_DIR, 'member-resumes');
+
+// In memory so the file can be named by the DB-generated row id, matching the
+// reasoning in cases.js.
+const resumeUpload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: 10 * 1024 * 1024 },
+  fileFilter(req, file, cb) {
+    if (file.mimetype === 'application/pdf') cb(null, true);
+    else cb(new Error('Resume must be a PDF'));
+  }
+});
+
+// There is no global Express error handler in this app, so an unwrapped multer
+// rejection returns an HTML 500 that the client renders as
+// "Server Error (500): <!doctype html...". This wrapper is what turns it into a
+// usable message. Pattern copied from routes/featureRequests.js.
+function resumeUploadMiddleware(req, res, next) {
+  resumeUpload.single('resume')(req, res, (err) => {
+    if (!err) return next();
+    if (err instanceof multer.MulterError) {
+      if (err.code === 'LIMIT_FILE_SIZE') {
+        return res.status(400).json({ error: 'Resume must be 10MB or smaller' });
+      }
+      return res.status(400).json({ error: err.message });
+    }
+    return res.status(400).json({ error: err.message || 'Invalid file upload' });
+  });
+}
+
+const requireMemberRole = (req, res, next) => {
+  if (req.user?.role !== 'MEMBER') {
+    return res.status(403).json({ error: 'Member access required' });
+  }
+  next();
+};
+
+const loadOwnResume = (memberId) =>
+  prisma.memberResume.findFirst({ where: { memberId, isCurrent: true } });
+
+const countLiveAssignments = (resumeId) =>
+  resumeId
+    ? prisma.clientResumeAssignment.count({ where: { memberResumeId: resumeId, revokedAt: null } })
+    : Promise.resolve(0);
+
+router.get('/resume', requireAuth, requireMemberRole, async (req, res) => {
+  try {
+    const resume = await loadOwnResume(req.user.id);
+    const assignedCount = await countLiveAssignments(resume?.id);
+    res.json({ resume: serializeMemberResume(resume, assignedCount), genders: MEMBER_GENDERS });
+  } catch (error) {
+    console.error('[GET /api/member/resume]', error);
+    res.status(500).json({ error: 'Failed to load your resume' });
+  }
+});
+
+router.post('/resume', requireAuth, requireMemberRole, resumeUploadMiddleware, async (req, res) => {
+  try {
+    if (!req.file) {
+      return res.status(400).json({ error: 'Attach a PDF resume' });
+    }
+
+    const { value, errors } = sanitizeMemberResumeInput(req.body || {});
+    if (errors.length > 0) {
+      return res.status(400).json({ error: errors[0], errors });
+    }
+
+    // Re-uploading supersedes rather than overwrites. An assignment already
+    // committed to a client keeps pointing at the exact file that was assigned,
+    // which is what makes the snapshot true for members as well as applicants.
+    const created = await prisma.$transaction(async (tx) => {
+      await tx.memberResume.updateMany({
+        where: { memberId: req.user.id, isCurrent: true },
+        data: { isCurrent: false }
+      });
+      return tx.memberResume.create({
+        data: {
+          memberId: req.user.id,
+          isCurrent: true,
+          storagePath: 'pending',
+          originalName: req.file.originalname ? req.file.originalname.slice(0, 255) : 'resume.pdf',
+          fileSize: req.file.size,
+          major1: value.major1,
+          major2: value.major2,
+          graduationYear: value.graduationYear,
+          gender: value.gender,
+          shareConsent: value.shareConsent,
+          consentAt: value.shareConsent ? new Date() : null
+        }
+      });
+    });
+
+    const relPath = `member-resumes/${created.id}/resume.pdf`;
+    try {
+      await fsPromises.mkdir(path.join(MEMBER_RESUME_ROOT, created.id), { recursive: true });
+      await fsPromises.writeFile(path.join(RESUME_STORAGE_DIR, relPath), req.file.buffer);
+    } catch (writeError) {
+      // Leaving a row pointing at a file that does not exist would make the
+      // resume look uploaded and then 404 for whoever opens it.
+      await prisma.memberResume.delete({ where: { id: created.id } }).catch(() => {});
+      throw writeError;
+    }
+
+    const resume = await prisma.memberResume.update({
+      where: { id: created.id },
+      data: { storagePath: relPath }
+    });
+
+    res.status(201).json({ resume: serializeMemberResume(resume, 0) });
+  } catch (error) {
+    console.error('[POST /api/member/resume]', error);
+    res.status(500).json({ error: 'Failed to upload your resume' });
+  }
+});
+
+router.patch('/resume/consent', requireAuth, requireMemberRole, async (req, res) => {
+  try {
+    const shareConsent = req.body?.shareConsent === true || req.body?.shareConsent === 'true';
+
+    const existing = await loadOwnResume(req.user.id);
+    if (!existing) {
+      return res.status(404).json({ error: 'Upload a resume first' });
+    }
+
+    const now = new Date();
+
+    const resume = await prisma.$transaction(async (tx) => {
+      const updated = await tx.memberResume.update({
+        where: { id: existing.id },
+        data: {
+          shareConsent,
+          consentAt: shareConsent ? now : existing.consentAt,
+          consentRevokedAt: shareConsent ? null : now
+        }
+      });
+
+      if (!shareConsent) {
+        // Withdrawal takes effect immediately rather than waiting for an admin
+        // to notice. This is the one place the snapshot rule yields, and it
+        // yields to the person whose resume it is.
+        await tx.clientResumeAssignment.updateMany({
+          where: { memberResumeId: existing.id, revokedAt: null },
+          data: { revokedAt: now, revokedById: req.user.id }
+        });
+      }
+
+      return updated;
+    });
+
+    const assignedCount = await countLiveAssignments(resume.id);
+    res.json({ resume: serializeMemberResume(resume, assignedCount) });
+  } catch (error) {
+    console.error('[PATCH /api/member/resume/consent]', error);
+    res.status(500).json({ error: 'Failed to update your sharing preference' });
+  }
+});
+
+router.get('/resume/pdf', requireAuth, requireMemberRole, async (req, res) => {
+  try {
+    const resume = await loadOwnResume(req.user.id);
+    if (!resume) return res.status(404).json({ error: 'No resume on file' });
+
+    const absPath = path.join(RESUME_STORAGE_DIR, resume.storagePath);
+    if (!absPath.startsWith(MEMBER_RESUME_ROOT)) {
+      return res.status(400).json({ error: 'Invalid path' });
+    }
+    if (!fs.existsSync(absPath)) {
+      return res.status(404).json({ error: 'No resume on file' });
+    }
+
+    res.setHeader('Content-Type', 'application/pdf');
+    res.setHeader('Content-Disposition', 'inline');
+    res.setHeader('Cache-Control', 'private, max-age=300');
+    fs.createReadStream(absPath).pipe(res);
+  } catch (error) {
+    console.error('[GET /api/member/resume/pdf]', error);
+    res.status(500).json({ error: 'Failed to load your resume' });
+  }
+});
+
+router.delete('/resume', requireAuth, requireMemberRole, async (req, res) => {
+  try {
+    const existing = await loadOwnResume(req.user.id);
+    if (!existing) return res.status(404).json({ error: 'No resume on file' });
+
+    const now = new Date();
+
+    await prisma.$transaction(async (tx) => {
+      await tx.memberResume.update({
+        where: { id: existing.id },
+        data: { isCurrent: false, shareConsent: false, consentRevokedAt: now }
+      });
+      await tx.clientResumeAssignment.updateMany({
+        where: { memberResumeId: existing.id, revokedAt: null },
+        data: { revokedAt: now, revokedById: req.user.id }
+      });
+    });
+
+    // The file stays on disk on purpose: revoked assignment rows still
+    // reference this resume, and the history is worth more than a few hundred KB.
+    res.json({ ok: true });
+  } catch (error) {
+    console.error('[DELETE /api/member/resume]', error);
+    res.status(500).json({ error: 'Failed to remove your resume' });
   }
 });
 

--- a/server/src/routes/memberResume.routes.test.js
+++ b/server/src/routes/memberResume.routes.test.js
@@ -1,0 +1,282 @@
+// Member resume upload and the consent that makes it assignable.
+//
+// The two assertions worth having here: a bad upload produces a usable JSON 400
+// rather than the HTML 500 an unwrapped multer error would give, and
+// withdrawing consent actually pulls the resume back from every client.
+import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest';
+import express from 'express';
+import jwt from 'jsonwebtoken';
+import prisma from '../prismaClient.js';
+import memberRoutes from './member.js';
+
+vi.mock('../prismaClient.js', () => {
+  const tx = {
+    memberResume: { updateMany: vi.fn(), create: vi.fn(), update: vi.fn() },
+    clientResumeAssignment: { updateMany: vi.fn() }
+  };
+  return {
+    default: {
+      __tx: tx,
+      user: { findUnique: vi.fn() },
+      memberResume: {
+        findFirst: vi.fn(),
+        update: vi.fn(),
+        delete: vi.fn(),
+        updateMany: vi.fn()
+      },
+      clientResumeAssignment: { count: vi.fn(), updateMany: vi.fn() },
+      $transaction: vi.fn((fn) => fn(tx))
+    }
+  };
+});
+
+const memberUser = { id: 'member-1', role: 'MEMBER', isActive: true, email: 'm@uc.org', fullName: 'Member One' };
+const adminUser = { id: 'admin-1', role: 'ADMIN', isActive: true, email: 'a@uc.org', fullName: 'Admin' };
+const candidateUser = { id: 'user-1', role: 'USER', isActive: true, email: 'c@uc.org', fullName: 'Candidate' };
+const ALL_USERS = [memberUser, adminUser, candidateUser];
+
+const existingResume = (overrides = {}) => ({
+  id: 'mr-1',
+  memberId: memberUser.id,
+  isCurrent: true,
+  storagePath: 'member-resumes/mr-1/resume.pdf',
+  originalName: 'resume.pdf',
+  fileSize: 1024,
+  major1: 'Statistics',
+  major2: null,
+  graduationYear: '2027',
+  gender: 'Other',
+  shareConsent: true,
+  consentAt: new Date('2026-08-01'),
+  consentRevokedAt: null,
+  createdAt: new Date('2026-08-01'),
+  updatedAt: new Date('2026-08-01'),
+  ...overrides
+});
+
+const tokenFor = (user) => jwt.sign({ userId: user.id }, process.env.JWT_SECRET);
+
+let server;
+let port;
+
+const request = (path, { user, method = 'GET', body } = {}) => {
+  const headers = {};
+  if (user) headers.Authorization = `Bearer ${tokenFor(user)}`;
+  if (body) headers['Content-Type'] = 'application/json';
+  return fetch(`http://localhost:${port}${path}`, {
+    method,
+    headers,
+    ...(body ? { body: JSON.stringify(body) } : {})
+  });
+};
+
+const uploadRequest = ({ user, fileBuffer, fileName = 'resume.pdf', mimeType = 'application/pdf', fields = {} }) => {
+  const form = new FormData();
+  if (fileBuffer) {
+    form.append('resume', new Blob([fileBuffer], { type: mimeType }), fileName);
+  }
+  for (const [k, v] of Object.entries(fields)) form.append(k, String(v));
+  return fetch(`http://localhost:${port}/api/member/resume`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${tokenFor(user)}` },
+    body: form
+  });
+};
+
+beforeAll(async () => {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/member', memberRoutes);
+  server = app.listen(0);
+  await new Promise((resolve) => server.on('listening', resolve));
+  port = server.address().port;
+});
+
+afterAll(async () => {
+  await new Promise((resolve) => server.close(resolve));
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  prisma.user.findUnique.mockImplementation(({ where: { id } }) =>
+    ALL_USERS.find((u) => u.id === id) || null
+  );
+  prisma.memberResume.findFirst.mockResolvedValue(null);
+  prisma.clientResumeAssignment.count.mockResolvedValue(0);
+});
+
+describe('role gating', () => {
+  it('refuses admins and candidates - an admin uploading a member resume is meaningless', async () => {
+    for (const user of [adminUser, candidateUser]) {
+      const res = await request('/api/member/resume', { user });
+      expect({ role: user.role, status: res.status }).toEqual({ role: user.role, status: 403 });
+    }
+  });
+
+  it('refuses an unauthenticated request', async () => {
+    const res = await request('/api/member/resume');
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('upload validation returns JSON, not an HTML 500', () => {
+  it('rejects a non-PDF with a usable message', async () => {
+    const res = await uploadRequest({
+      user: memberUser,
+      fileBuffer: Buffer.from('not a pdf'),
+      fileName: 'resume.png',
+      mimeType: 'image/png',
+      fields: { major1: 'Statistics', graduationYear: '2027' }
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.headers.get('content-type')).toMatch(/application\/json/);
+    expect((await res.json()).error).toMatch(/must be a PDF/i);
+  });
+
+  it('rejects an oversize file with a usable message', async () => {
+    const res = await uploadRequest({
+      user: memberUser,
+      fileBuffer: Buffer.alloc(11 * 1024 * 1024, 1),
+      fields: { major1: 'Statistics', graduationYear: '2027' }
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.headers.get('content-type')).toMatch(/application\/json/);
+    expect((await res.json()).error).toMatch(/10MB or smaller/i);
+  });
+
+  it('rejects a request with no file attached', async () => {
+    const res = await uploadRequest({
+      user: memberUser,
+      fileBuffer: null,
+      fields: { major1: 'Statistics', graduationYear: '2027' }
+    });
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/attach a pdf/i);
+  });
+
+  it('rejects a missing or malformed graduation year', async () => {
+    for (const graduationYear of ['', 'Spring 2027', '27']) {
+      const res = await uploadRequest({
+        user: memberUser,
+        fileBuffer: Buffer.from('%PDF-1.4'),
+        fields: { major1: 'Statistics', graduationYear }
+      });
+      expect({ graduationYear, status: res.status }).toEqual({ graduationYear, status: 400 });
+    }
+  });
+
+  it('rejects a missing major', async () => {
+    const res = await uploadRequest({
+      user: memberUser,
+      fileBuffer: Buffer.from('%PDF-1.4'),
+      fields: { graduationYear: '2027' }
+    });
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/major/i);
+  });
+});
+
+describe('consent withdrawal', () => {
+  it('revokes every live assignment immediately rather than waiting for an admin', async () => {
+    prisma.memberResume.findFirst.mockResolvedValue(existingResume());
+    prisma.__tx.memberResume.update.mockResolvedValue(
+      existingResume({ shareConsent: false, consentRevokedAt: new Date() })
+    );
+    prisma.__tx.clientResumeAssignment.updateMany.mockResolvedValue({ count: 3 });
+
+    const res = await request('/api/member/resume/consent', {
+      user: memberUser,
+      method: 'PATCH',
+      body: { shareConsent: false }
+    });
+
+    expect(res.status).toBe(200);
+    const revokeCall = prisma.__tx.clientResumeAssignment.updateMany.mock.calls[0][0];
+    expect(revokeCall.where).toMatchObject({ memberResumeId: 'mr-1', revokedAt: null });
+    expect(revokeCall.data.revokedAt).toBeInstanceOf(Date);
+  });
+
+  it('does not revoke anything when consent is granted', async () => {
+    prisma.memberResume.findFirst.mockResolvedValue(existingResume({ shareConsent: false }));
+    prisma.__tx.memberResume.update.mockResolvedValue(existingResume({ shareConsent: true }));
+
+    await request('/api/member/resume/consent', {
+      user: memberUser,
+      method: 'PATCH',
+      body: { shareConsent: true }
+    });
+
+    expect(prisma.__tx.clientResumeAssignment.updateMany).not.toHaveBeenCalled();
+  });
+
+  it('treats anything other than an explicit true as no consent', async () => {
+    prisma.memberResume.findFirst.mockResolvedValue(existingResume());
+    prisma.__tx.memberResume.update.mockResolvedValue(existingResume({ shareConsent: false }));
+    prisma.__tx.clientResumeAssignment.updateMany.mockResolvedValue({ count: 0 });
+
+    await request('/api/member/resume/consent', {
+      user: memberUser,
+      method: 'PATCH',
+      body: { shareConsent: 'maybe' }
+    });
+
+    expect(prisma.__tx.memberResume.update.mock.calls[0][0].data.shareConsent).toBe(false);
+  });
+
+  it('404s when there is no resume to withdraw', async () => {
+    prisma.memberResume.findFirst.mockResolvedValue(null);
+    const res = await request('/api/member/resume/consent', {
+      user: memberUser,
+      method: 'PATCH',
+      body: { shareConsent: false }
+    });
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('reading your own resume', () => {
+  it('reports how many clients currently hold it', async () => {
+    prisma.memberResume.findFirst.mockResolvedValue(existingResume());
+    prisma.clientResumeAssignment.count.mockResolvedValue(4);
+
+    const res = await request('/api/member/resume', { user: memberUser });
+    const body = await res.json();
+
+    expect(body.resume.assignedCount).toBe(4);
+    // The member reads their file through the endpoint, not by path.
+    expect(body.resume).not.toHaveProperty('storagePath');
+  });
+
+  it('scopes the lookup to the caller, never a route param', async () => {
+    await request('/api/member/resume', { user: memberUser });
+    expect(prisma.memberResume.findFirst.mock.calls[0][0].where).toEqual({
+      memberId: memberUser.id,
+      isCurrent: true
+    });
+  });
+
+  it('404s the PDF when nothing is on file', async () => {
+    prisma.memberResume.findFirst.mockResolvedValue(null);
+    const res = await request('/api/member/resume/pdf', { user: memberUser });
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('removing a resume', () => {
+  it('supersedes the row and revokes assignments rather than deleting history', async () => {
+    prisma.memberResume.findFirst.mockResolvedValue(existingResume());
+    prisma.__tx.memberResume.update.mockResolvedValue(existingResume({ isCurrent: false }));
+    prisma.__tx.clientResumeAssignment.updateMany.mockResolvedValue({ count: 2 });
+
+    const res = await request('/api/member/resume', { user: memberUser, method: 'DELETE' });
+
+    expect(res.status).toBe(200);
+    expect(prisma.__tx.memberResume.update.mock.calls[0][0].data).toMatchObject({
+      isCurrent: false,
+      shareConsent: false
+    });
+    expect(prisma.__tx.clientResumeAssignment.updateMany).toHaveBeenCalled();
+  });
+});

--- a/server/src/routes/talentPoolAdmin.js
+++ b/server/src/routes/talentPoolAdmin.js
@@ -1,0 +1,627 @@
+// Admin side of the Talent Partner Network: client accounts and resume
+// assignment. Mounted at /api/admin/talent-pool behind requireAuth +
+// requireAdmin (see index.js), following the release-notes precedent rather
+// than growing admin.js, which is already 181KB.
+//
+// The assignment model is a SNAPSHOT. Preview resolves the filter to concrete
+// rows; commit takes the explicit keys the admin left checked and never re-runs
+// the filter. That is what makes the per-row trim binding, and it is why a
+// filter that would match more tomorrow does not quietly widen what a client
+// can see.
+import express from 'express';
+import bcrypt from 'bcryptjs';
+import prisma from '../prismaClient.js';
+import { invalidateUserCache } from '../middleware/auth.js';
+import {
+  FILTER_FIELDS,
+  APPLICATION_STATUSES,
+  PREVIEW_CAP,
+  sanitizeFilterDsl,
+  buildApplicantWhere,
+  buildMemberResumeWhere,
+  buildAssignmentKey,
+  parseAssignmentKey
+} from '../utils/talentPoolFilters.js';
+import { VISIBILITY_LEVELS } from '../utils/clientVisibility.js';
+
+const router = express.Router();
+
+const CLIENT_SELECT = {
+  id: true,
+  organization: true,
+  visibility: true,
+  notes: true,
+  createdAt: true,
+  user: { select: { id: true, email: true, fullName: true, isActive: true } }
+};
+
+const activeCycleId = async () => {
+  const cycle = await prisma.recruitingCycle.findFirst({
+    where: { isActive: true },
+    select: { id: true }
+  });
+  return cycle?.id ?? null;
+};
+
+// ---------------------------------------------------------------------------
+// Client accounts
+// ---------------------------------------------------------------------------
+
+router.get('/clients', async (req, res) => {
+  try {
+    const clients = await prisma.talentPartnerClient.findMany({
+      select: {
+        ...CLIENT_SELECT,
+        _count: { select: { assignments: true } }
+      },
+      orderBy: { createdAt: 'desc' }
+    });
+
+    const liveCounts = await prisma.clientResumeAssignment.groupBy({
+      by: ['clientId'],
+      where: { revokedAt: null },
+      _count: { _all: true }
+    });
+    const liveByClient = new Map(liveCounts.map((r) => [r.clientId, r._count._all]));
+
+    res.json(
+      clients.map(({ _count, ...client }) => ({
+        ...client,
+        assignmentCount: liveByClient.get(client.id) ?? 0
+      }))
+    );
+  } catch (error) {
+    console.error('[GET /api/admin/talent-pool/clients]', error);
+    res.status(500).json({ error: 'Failed to load partner clients' });
+  }
+});
+
+router.post('/clients', async (req, res) => {
+  try {
+    const { email, password, fullName, organization, visibility, notes } = req.body || {};
+
+    if (!email || !password || !fullName || !organization) {
+      return res
+        .status(400)
+        .json({ error: 'Email, password, contact name, and organization are required' });
+    }
+    if (String(password).length < 12) {
+      // These credentials are handed to an outside organization and there is no
+      // self-service reset, so a weak one tends to stay weak.
+      return res.status(400).json({ error: 'Password must be at least 12 characters' });
+    }
+    if (visibility && !VISIBILITY_LEVELS.includes(visibility)) {
+      return res.status(400).json({ error: 'Invalid visibility level' });
+    }
+
+    const existing = await prisma.user.findUnique({ where: { email } });
+    if (existing) {
+      return res.status(400).json({ error: 'Email already exists' });
+    }
+
+    const hashedPassword = await bcrypt.hash(password, 12);
+
+    const client = await prisma.$transaction(async (tx) => {
+      const user = await tx.user.create({
+        data: { email, password: hashedPassword, fullName, role: 'CLIENT' }
+      });
+      return tx.talentPartnerClient.create({
+        data: {
+          userId: user.id,
+          organization,
+          visibility: visibility || 'BLIND',
+          notes: notes || null,
+          createdById: req.user.id
+        },
+        select: CLIENT_SELECT
+      });
+    });
+
+    // Never echo the password back - the admin already has it.
+    res.status(201).json({ client });
+  } catch (error) {
+    console.error('[POST /api/admin/talent-pool/clients]', error);
+    res.status(500).json({ error: 'Failed to create partner client' });
+  }
+});
+
+router.get('/clients/:id', async (req, res) => {
+  try {
+    const client = await prisma.talentPartnerClient.findUnique({
+      where: { id: req.params.id },
+      select: CLIENT_SELECT
+    });
+    if (!client) return res.status(404).json({ error: 'Partner client not found' });
+
+    const assignments = await prisma.clientResumeAssignment.findMany({
+      where: { clientId: client.id, revokedAt: null },
+      orderBy: { assignedAt: 'desc' },
+      take: 1000,
+      include: {
+        application: {
+          select: { id: true, firstName: true, lastName: true, graduationYear: true, major1: true }
+        },
+        memberResume: {
+          select: {
+            id: true,
+            graduationYear: true,
+            major1: true,
+            shareConsent: true,
+            consentRevokedAt: true,
+            member: { select: { fullName: true } }
+          }
+        },
+        batch: { select: { id: true, createdAt: true, note: true } }
+      }
+    });
+
+    res.json({
+      client,
+      // Real names here - this is the admin console, not the portal.
+      assignments: assignments.map((a) => ({
+        id: a.id,
+        kind: a.application ? 'APPLICANT' : 'MEMBER',
+        name: a.application
+          ? `${a.application.firstName} ${a.application.lastName}`.trim()
+          : a.memberResume?.member?.fullName || 'Unknown member',
+        graduationYear: a.application?.graduationYear ?? a.memberResume?.graduationYear ?? null,
+        major1: a.application?.major1 ?? a.memberResume?.major1 ?? null,
+        assignedAt: a.assignedAt,
+        batchId: a.batchId,
+        // Surfaced so an admin can see a member who withdrew after assignment.
+        // Withdrawal auto-revokes, so this should normally be false.
+        consentWithdrawn: Boolean(
+          a.memberResume && (!a.memberResume.shareConsent || a.memberResume.consentRevokedAt)
+        )
+      }))
+    });
+  } catch (error) {
+    console.error('[GET /api/admin/talent-pool/clients/:id]', error);
+    res.status(500).json({ error: 'Failed to load partner client' });
+  }
+});
+
+router.patch('/clients/:id', async (req, res) => {
+  try {
+    const { organization, visibility, notes } = req.body || {};
+    if (visibility && !VISIBILITY_LEVELS.includes(visibility)) {
+      return res.status(400).json({ error: 'Invalid visibility level' });
+    }
+
+    const existing = await prisma.talentPartnerClient.findUnique({ where: { id: req.params.id } });
+    if (!existing) return res.status(404).json({ error: 'Partner client not found' });
+
+    const data = {};
+    if (organization !== undefined) data.organization = organization;
+    if (visibility !== undefined) data.visibility = visibility;
+    if (notes !== undefined) data.notes = notes || null;
+
+    const client = await prisma.talentPartnerClient.update({
+      where: { id: req.params.id },
+      data,
+      select: CLIENT_SELECT
+    });
+
+    // Tightening to BLIND can strand live assignments that have no redacted
+    // resume. Report the count rather than letting them silently 404 later.
+    const warnings = {};
+    if (visibility === 'BLIND' && existing.visibility !== 'BLIND') {
+      warnings.blindUnavailable = await prisma.clientResumeAssignment.count({
+        where: {
+          clientId: client.id,
+          revokedAt: null,
+          OR: [
+            { memberResumeId: { not: null } },
+            { application: { OR: [{ blindResumeUrl: null }, { blindResumeUrl: '' }] } }
+          ]
+        }
+      });
+    }
+
+    res.json({ client, warnings });
+  } catch (error) {
+    console.error('[PATCH /api/admin/talent-pool/clients/:id]', error);
+    res.status(500).json({ error: 'Failed to update partner client' });
+  }
+});
+
+router.post('/clients/:id/password', async (req, res) => {
+  try {
+    const { password } = req.body || {};
+    if (!password || String(password).length < 12) {
+      return res.status(400).json({ error: 'Password must be at least 12 characters' });
+    }
+
+    const client = await prisma.talentPartnerClient.findUnique({ where: { id: req.params.id } });
+    if (!client) return res.status(404).json({ error: 'Partner client not found' });
+
+    await prisma.user.update({
+      where: { id: client.userId },
+      data: { password: await bcrypt.hash(password, 12), resetToken: null, resetTokenExpiry: null }
+    });
+    invalidateUserCache(client.userId);
+
+    res.json({ ok: true });
+  } catch (error) {
+    console.error('[POST /api/admin/talent-pool/clients/:id/password]', error);
+    res.status(500).json({ error: 'Failed to set password' });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Filter vocabulary
+// ---------------------------------------------------------------------------
+
+// Options come from the data, not a hardcoded list. Application.gender and
+// major1 are free text off a Google Form, so a hardcoded "Female" would quietly
+// miss "female" and a hardcoded major list would match nothing at all.
+router.get('/filter-fields', async (req, res) => {
+  try {
+    const [genders, years, majors1, majors2, cycles] = await Promise.all([
+      prisma.application.findMany({
+        distinct: ['gender'],
+        select: { gender: true },
+        where: { gender: { not: null } }
+      }),
+      prisma.application.findMany({ distinct: ['graduationYear'], select: { graduationYear: true } }),
+      prisma.application.findMany({ distinct: ['major1'], select: { major1: true } }),
+      prisma.application.findMany({
+        distinct: ['major2'],
+        select: { major2: true },
+        where: { major2: { not: null } }
+      }),
+      prisma.recruitingCycle.findMany({
+        select: { id: true, name: true, isActive: true },
+        orderBy: { createdAt: 'desc' }
+      })
+    ]);
+
+    const uniqueSorted = (values) =>
+      [...new Set(values.filter((v) => v && String(v).trim()).map((v) => String(v).trim()))].sort();
+
+    res.json({
+      fields: FILTER_FIELDS,
+      options: {
+        gender: uniqueSorted(genders.map((g) => g.gender)),
+        graduationYear: uniqueSorted(years.map((y) => y.graduationYear)),
+        major: uniqueSorted([...majors1.map((m) => m.major1), ...majors2.map((m) => m.major2)]),
+        status: APPLICATION_STATUSES,
+        cycleId: cycles.map((c) => ({ value: c.id, label: c.name, isActive: c.isActive }))
+      }
+    });
+  } catch (error) {
+    console.error('[GET /api/admin/talent-pool/filter-fields]', error);
+    res.status(500).json({ error: 'Failed to load filter options' });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Preview and assign
+// ---------------------------------------------------------------------------
+
+router.post('/clients/:id/preview', async (req, res) => {
+  try {
+    const client = await prisma.talentPartnerClient.findUnique({ where: { id: req.params.id } });
+    if (!client) return res.status(404).json({ error: 'Partner client not found' });
+
+    const { value: dsl, errors } = sanitizeFilterDsl(req.body?.filter);
+    if (errors.length > 0 && dsl.rows.length === 0) {
+      return res.status(400).json({ error: errors[0], errors });
+    }
+
+    const cycleId = await activeCycleId();
+    const applicant = buildApplicantWhere(dsl, { visibility: client.visibility, activeCycleId: cycleId });
+    const member = buildMemberResumeWhere(dsl, { visibility: client.visibility });
+
+    const notes = [...errors, ...applicant.notes, ...member.notes];
+    const excluded = { noOptIn: 0, noBlindResume: 0, memberNoConsent: 0, alreadyAssigned: 0 };
+
+    const rows = [];
+    let total = 0;
+
+    if (applicant.where) {
+      // Diagnostics: how many the consent gate and the blind gate each removed.
+      // filterOnlyWhere is never used to select rows for assignment.
+      const [matched, filterOnly, optedIn] = await Promise.all([
+        prisma.application.count({ where: applicant.where }),
+        prisma.application.count({ where: applicant.filterOnlyWhere }),
+        prisma.application.count({
+          where: { AND: [...applicant.filterOnlyWhere.AND, { talentPoolOptIn: true }] }
+        })
+      ]);
+      excluded.noOptIn = Math.max(filterOnly - optedIn, 0);
+      excluded.noBlindResume = Math.max(optedIn - matched, 0);
+      total += matched;
+
+      const applications = await prisma.application.findMany({
+        where: applicant.where,
+        select: {
+          id: true,
+          firstName: true,
+          lastName: true,
+          graduationYear: true,
+          major1: true,
+          major2: true,
+          gender: true,
+          cumulativeGpa: true
+        },
+        orderBy: { submittedAt: 'desc' },
+        take: PREVIEW_CAP
+      });
+
+      rows.push(
+        ...applications.map((a) => ({
+          key: buildAssignmentKey('APPLICATION', a.id),
+          kind: 'APPLICANT',
+          name: `${a.firstName} ${a.lastName}`.trim(),
+          graduationYear: a.graduationYear,
+          major1: a.major1,
+          major2: a.major2,
+          gender: a.gender,
+          cumulativeGpa: a.cumulativeGpa != null ? String(a.cumulativeGpa) : null
+        }))
+      );
+    }
+
+    if (member.where) {
+      const [matched, filterOnly] = await Promise.all([
+        prisma.memberResume.count({ where: member.where }),
+        prisma.memberResume.count({ where: member.filterOnlyWhere })
+      ]);
+      excluded.memberNoConsent = Math.max(filterOnly - matched, 0);
+      total += matched;
+
+      const memberResumes = await prisma.memberResume.findMany({
+        where: member.where,
+        select: {
+          id: true,
+          graduationYear: true,
+          major1: true,
+          major2: true,
+          gender: true,
+          member: { select: { fullName: true } }
+        },
+        orderBy: { createdAt: 'desc' },
+        take: PREVIEW_CAP
+      });
+
+      rows.push(
+        ...memberResumes.map((m) => ({
+          key: buildAssignmentKey('MEMBER_RESUME', m.id),
+          kind: 'MEMBER',
+          name: m.member?.fullName || 'Unknown member',
+          graduationYear: m.graduationYear,
+          major1: m.major1,
+          major2: m.major2,
+          gender: m.gender,
+          cumulativeGpa: null
+        }))
+      );
+    }
+
+    // Flag rows this client already has so the admin is not re-assigning blind.
+    const applicationIds = rows
+      .map((r) => parseAssignmentKey(r.key))
+      .filter((p) => p?.kind === 'APPLICATION')
+      .map((p) => p.id);
+    const memberResumeIds = rows
+      .map((r) => parseAssignmentKey(r.key))
+      .filter((p) => p?.kind === 'MEMBER_RESUME')
+      .map((p) => p.id);
+
+    const live = await prisma.clientResumeAssignment.findMany({
+      where: {
+        clientId: client.id,
+        revokedAt: null,
+        OR: [
+          { applicationId: { in: applicationIds } },
+          { memberResumeId: { in: memberResumeIds } }
+        ]
+      },
+      select: { applicationId: true, memberResumeId: true }
+    });
+
+    const liveKeys = new Set([
+      ...live.filter((l) => l.applicationId).map((l) => buildAssignmentKey('APPLICATION', l.applicationId)),
+      ...live.filter((l) => l.memberResumeId).map((l) => buildAssignmentKey('MEMBER_RESUME', l.memberResumeId))
+    ]);
+
+    for (const row of rows) {
+      row.alreadyAssigned = liveKeys.has(row.key);
+      if (row.alreadyAssigned) excluded.alreadyAssigned += 1;
+    }
+
+    res.json({
+      rows: rows.slice(0, PREVIEW_CAP),
+      total,
+      truncated: total > rows.length,
+      cap: PREVIEW_CAP,
+      excluded,
+      notes,
+      visibility: client.visibility
+    });
+  } catch (error) {
+    console.error('[POST /api/admin/talent-pool/clients/:id/preview]', error);
+    res.status(500).json({ error: 'Failed to preview matches' });
+  }
+});
+
+router.post('/clients/:id/assign', async (req, res) => {
+  try {
+    const client = await prisma.talentPartnerClient.findUnique({ where: { id: req.params.id } });
+    if (!client) return res.status(404).json({ error: 'Partner client not found' });
+
+    const keys = Array.isArray(req.body?.keys) ? req.body.keys : [];
+    if (keys.length === 0) {
+      return res.status(400).json({ error: 'Select at least one resume to assign' });
+    }
+    if (keys.length > PREVIEW_CAP) {
+      return res.status(400).json({ error: `Assign at most ${PREVIEW_CAP} resumes at a time` });
+    }
+
+    const parsed = [];
+    const skipped = [];
+    const seen = new Set();
+
+    for (const key of keys) {
+      const p = parseAssignmentKey(key);
+      if (!p) {
+        skipped.push({ key, reason: 'Unrecognised selection' });
+        continue;
+      }
+      if (seen.has(key)) continue;
+      seen.add(key);
+      parsed.push({ key, ...p });
+    }
+
+    const applicationIds = parsed.filter((p) => p.kind === 'APPLICATION').map((p) => p.id);
+    const memberResumeIds = parsed.filter((p) => p.kind === 'MEMBER_RESUME').map((p) => p.id);
+
+    // Re-validate every key independently of the filter that produced it. The
+    // commit never re-runs the filter - these lookups are what make the
+    // snapshot safe rather than trusting whatever the browser sent.
+    const [applications, memberResumes, live] = await Promise.all([
+      applicationIds.length
+        ? prisma.application.findMany({
+            where: { id: { in: applicationIds } },
+            select: { id: true, talentPoolOptIn: true, resumeUrl: true, blindResumeUrl: true }
+          })
+        : [],
+      memberResumeIds.length
+        ? prisma.memberResume.findMany({
+            where: { id: { in: memberResumeIds } },
+            select: {
+              id: true,
+              isCurrent: true,
+              shareConsent: true,
+              consentRevokedAt: true
+            }
+          })
+        : [],
+      prisma.clientResumeAssignment.findMany({
+        where: {
+          clientId: client.id,
+          revokedAt: null,
+          OR: [
+            { applicationId: { in: applicationIds } },
+            { memberResumeId: { in: memberResumeIds } }
+          ]
+        },
+        select: { applicationId: true, memberResumeId: true }
+      })
+    ]);
+
+    const appById = new Map(applications.map((a) => [a.id, a]));
+    const memberById = new Map(memberResumes.map((m) => [m.id, m]));
+    const liveApps = new Set(live.map((l) => l.applicationId).filter(Boolean));
+    const liveMembers = new Set(live.map((l) => l.memberResumeId).filter(Boolean));
+
+    const toCreate = [];
+
+    for (const p of parsed) {
+      if (p.kind === 'APPLICATION') {
+        const app = appById.get(p.id);
+        if (!app) {
+          skipped.push({ key: p.key, reason: 'Application no longer exists' });
+        } else if (app.talentPoolOptIn !== true) {
+          skipped.push({ key: p.key, reason: 'Applicant has not opted in to the Talent Partner Network' });
+        } else if (!app.resumeUrl) {
+          skipped.push({ key: p.key, reason: 'No resume on file' });
+        } else if (client.visibility === 'BLIND' && !app.blindResumeUrl) {
+          skipped.push({ key: p.key, reason: 'No redacted resume, and this client is blind-visibility' });
+        } else if (liveApps.has(p.id)) {
+          skipped.push({ key: p.key, reason: 'Already assigned to this client' });
+        } else {
+          toCreate.push({ applicationId: p.id, memberResumeId: null });
+        }
+        continue;
+      }
+
+      const mr = memberById.get(p.id);
+      if (!mr) {
+        skipped.push({ key: p.key, reason: 'Member resume no longer exists' });
+      } else if (!mr.isCurrent) {
+        skipped.push({ key: p.key, reason: 'Member has replaced this resume' });
+      } else if (!mr.shareConsent || mr.consentRevokedAt) {
+        skipped.push({ key: p.key, reason: 'Member has not consented to sharing' });
+      } else if (client.visibility === 'BLIND') {
+        skipped.push({ key: p.key, reason: 'Member resumes have no redacted version' });
+      } else if (liveMembers.has(p.id)) {
+        skipped.push({ key: p.key, reason: 'Already assigned to this client' });
+      } else {
+        toCreate.push({ applicationId: null, memberResumeId: p.id });
+      }
+    }
+
+    if (toCreate.length === 0) {
+      return res.status(400).json({ error: 'Nothing left to assign', skipped, created: 0 });
+    }
+
+    const batch = await prisma.$transaction(async (tx) => {
+      const created = await tx.clientAssignmentBatch.create({
+        data: {
+          clientId: client.id,
+          createdById: req.user.id,
+          // Documentation only. The assignments below are the snapshot and are
+          // never re-derived from this.
+          filterJson: req.body?.filter ?? null,
+          matchedCount: toCreate.length,
+          note: req.body?.note || null
+        }
+      });
+
+      await tx.clientResumeAssignment.createMany({
+        data: toCreate.map((t) => ({
+          clientId: client.id,
+          batchId: created.id,
+          applicationId: t.applicationId,
+          memberResumeId: t.memberResumeId,
+          assignedById: req.user.id
+        }))
+      });
+
+      return created;
+    });
+
+    res.status(201).json({ batchId: batch.id, created: toCreate.length, skipped });
+  } catch (error) {
+    console.error('[POST /api/admin/talent-pool/clients/:id/assign]', error);
+    res.status(500).json({ error: 'Failed to assign resumes' });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Revocation - always soft, so history and the access log keep valid keys
+// ---------------------------------------------------------------------------
+
+router.delete('/clients/:id/assignments/:assignmentId', async (req, res) => {
+  try {
+    const result = await prisma.clientResumeAssignment.updateMany({
+      where: { id: req.params.assignmentId, clientId: req.params.id, revokedAt: null },
+      data: { revokedAt: new Date(), revokedById: req.user.id }
+    });
+
+    if (result.count === 0) {
+      return res.status(404).json({ error: 'Assignment not found' });
+    }
+    res.json({ ok: true });
+  } catch (error) {
+    console.error('[DELETE /api/admin/talent-pool/clients/:id/assignments/:assignmentId]', error);
+    res.status(500).json({ error: 'Failed to revoke assignment' });
+  }
+});
+
+router.delete('/clients/:id/batches/:batchId', async (req, res) => {
+  try {
+    const result = await prisma.clientResumeAssignment.updateMany({
+      where: { batchId: req.params.batchId, clientId: req.params.id, revokedAt: null },
+      data: { revokedAt: new Date(), revokedById: req.user.id }
+    });
+    res.json({ ok: true, revoked: result.count });
+  } catch (error) {
+    console.error('[DELETE /api/admin/talent-pool/clients/:id/batches/:batchId]', error);
+    res.status(500).json({ error: 'Failed to revoke batch' });
+  }
+});
+
+export default router;

--- a/server/src/routes/talentPoolAdmin.routes.test.js
+++ b/server/src/routes/talentPoolAdmin.routes.test.js
@@ -1,0 +1,438 @@
+// Coverage for the admin side of the Talent Partner Network.
+//
+// The load-bearing test in this file is "assign honours the trimmed keys and
+// never re-runs the filter" - that is the whole snapshot guarantee. The rest
+// prove the consent gates cannot be bypassed by posting keys directly.
+import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest';
+import express from 'express';
+import jwt from 'jsonwebtoken';
+import prisma from '../prismaClient.js';
+import talentPoolAdminRoutes from './talentPoolAdmin.js';
+import { requireAuth, requireAdmin } from '../middleware/auth.js';
+
+vi.mock('../prismaClient.js', () => {
+  const tx = {
+    user: { create: vi.fn() },
+    talentPartnerClient: { create: vi.fn() },
+    clientAssignmentBatch: { create: vi.fn() },
+    clientResumeAssignment: { createMany: vi.fn() }
+  };
+  return {
+    default: {
+      __tx: tx,
+      user: { findUnique: vi.fn(), create: vi.fn(), update: vi.fn() },
+      talentPartnerClient: {
+        findUnique: vi.fn(),
+        findMany: vi.fn(),
+        update: vi.fn(),
+        count: vi.fn()
+      },
+      application: { count: vi.fn(), findMany: vi.fn() },
+      memberResume: { count: vi.fn(), findMany: vi.fn() },
+      recruitingCycle: { findFirst: vi.fn(), findMany: vi.fn() },
+      clientResumeAssignment: {
+        findMany: vi.fn(),
+        updateMany: vi.fn(),
+        groupBy: vi.fn(),
+        count: vi.fn()
+      },
+      clientAssignmentBatch: { create: vi.fn() },
+      $transaction: vi.fn((fn) => fn(tx))
+    }
+  };
+});
+
+const adminUser = { id: 'admin-1', role: 'ADMIN', isActive: true, email: 'a@uc.org', fullName: 'Admin' };
+const memberUser = { id: 'member-1', role: 'MEMBER', isActive: true, email: 'm@uc.org', fullName: 'Member' };
+const clientUser = { id: 'client-1', role: 'CLIENT', isActive: true, email: 'p@acme.com', fullName: 'Acme' };
+const ALL_USERS = [adminUser, memberUser, clientUser];
+
+const partner = (visibility = 'BASIC') => ({
+  id: 'partner-1',
+  userId: clientUser.id,
+  organization: 'Acme Recruiting',
+  visibility
+});
+
+const tokenFor = (user) => jwt.sign({ userId: user.id }, process.env.JWT_SECRET);
+
+let server;
+let port;
+
+const request = (path, { user, method = 'GET', body } = {}) => {
+  const headers = {};
+  if (user) headers.Authorization = `Bearer ${tokenFor(user)}`;
+  if (body) headers['Content-Type'] = 'application/json';
+  return fetch(`http://localhost:${port}${path}`, {
+    method,
+    headers,
+    ...(body ? { body: JSON.stringify(body) } : {})
+  });
+};
+
+beforeAll(async () => {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/admin/talent-pool', requireAuth, requireAdmin, talentPoolAdminRoutes);
+  server = app.listen(0);
+  await new Promise((resolve) => server.on('listening', resolve));
+  port = server.address().port;
+});
+
+afterAll(async () => {
+  await new Promise((resolve) => server.close(resolve));
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  prisma.user.findUnique.mockImplementation(({ where }) => {
+    if (where.id) return ALL_USERS.find((u) => u.id === where.id) || null;
+    return null; // by email: no existing user
+  });
+  prisma.talentPartnerClient.findUnique.mockResolvedValue(partner());
+  prisma.recruitingCycle.findFirst.mockResolvedValue({ id: 'cycle-1' });
+  prisma.clientResumeAssignment.findMany.mockResolvedValue([]);
+  prisma.application.count.mockResolvedValue(0);
+  prisma.application.findMany.mockResolvedValue([]);
+  prisma.memberResume.count.mockResolvedValue(0);
+  prisma.memberResume.findMany.mockResolvedValue([]);
+  prisma.__tx.clientAssignmentBatch.create.mockResolvedValue({ id: 'batch-1' });
+  prisma.__tx.clientResumeAssignment.createMany.mockResolvedValue({ count: 0 });
+  prisma.__tx.user.create.mockResolvedValue({ id: 'new-client-user' });
+  prisma.__tx.talentPartnerClient.create.mockResolvedValue(partner());
+});
+
+describe('admin only', () => {
+  it('refuses MEMBER and CLIENT on every endpoint', async () => {
+    const paths = [
+      ['/api/admin/talent-pool/clients', 'GET'],
+      ['/api/admin/talent-pool/clients', 'POST'],
+      ['/api/admin/talent-pool/clients/partner-1/preview', 'POST'],
+      ['/api/admin/talent-pool/clients/partner-1/assign', 'POST']
+    ];
+    for (const user of [memberUser, clientUser]) {
+      for (const [path, method] of paths) {
+        const res = await request(path, { user, method, body: method === 'POST' ? {} : undefined });
+        expect({ path, role: user.role, status: res.status }).toEqual({
+          path,
+          role: user.role,
+          status: 403
+        });
+      }
+    }
+  });
+});
+
+describe('creating a client account', () => {
+  it('creates the user and the partner row together, with the CLIENT role and a hashed password', async () => {
+    const res = await request('/api/admin/talent-pool/clients', {
+      user: adminUser,
+      method: 'POST',
+      body: {
+        email: 'buyer@acme.com',
+        password: 'a-long-enough-password',
+        fullName: 'Buyer Contact',
+        organization: 'Acme Recruiting',
+        visibility: 'BASIC'
+      }
+    });
+
+    expect(res.status).toBe(201);
+    const created = prisma.__tx.user.create.mock.calls[0][0].data;
+    expect(created.role).toBe('CLIENT');
+    expect(created.password).not.toBe('a-long-enough-password');
+    expect(created.password.startsWith('$2')).toBe(true);
+    expect(prisma.__tx.talentPartnerClient.create).toHaveBeenCalled();
+  });
+
+  it('never echoes the password back', async () => {
+    const res = await request('/api/admin/talent-pool/clients', {
+      user: adminUser,
+      method: 'POST',
+      body: {
+        email: 'buyer@acme.com',
+        password: 'a-long-enough-password',
+        fullName: 'Buyer',
+        organization: 'Acme'
+      }
+    });
+    expect(await res.text()).not.toContain('a-long-enough-password');
+  });
+
+  it('rejects a duplicate email', async () => {
+    prisma.user.findUnique.mockImplementation(({ where }) =>
+      where.email ? { id: 'existing' } : ALL_USERS.find((u) => u.id === where.id) || null
+    );
+    const res = await request('/api/admin/talent-pool/clients', {
+      user: adminUser,
+      method: 'POST',
+      body: { email: 'taken@acme.com', password: 'a-long-enough-password', fullName: 'X', organization: 'Y' }
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects a short password - there is no self-service reset for these accounts', async () => {
+    const res = await request('/api/admin/talent-pool/clients', {
+      user: adminUser,
+      method: 'POST',
+      body: { email: 'b@acme.com', password: 'short', fullName: 'X', organization: 'Y' }
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects an unknown visibility level', async () => {
+    const res = await request('/api/admin/talent-pool/clients', {
+      user: adminUser,
+      method: 'POST',
+      body: {
+        email: 'b@acme.com',
+        password: 'a-long-enough-password',
+        fullName: 'X',
+        organization: 'Y',
+        visibility: 'EVERYTHING'
+      }
+    });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('preview', () => {
+  it('refuses an empty filter rather than matching every resume', async () => {
+    const res = await request('/api/admin/talent-pool/clients/partner-1/preview', {
+      user: adminUser,
+      method: 'POST',
+      body: { filter: { pool: 'APPLICANTS', rows: [] } }
+    });
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/at least one filter/i);
+  });
+
+  it('reports how many rows each consent gate excluded', async () => {
+    // 10 match the filter, 7 opted in, 5 of those have a blind resume.
+    prisma.application.count
+      .mockResolvedValueOnce(5) // fully gated
+      .mockResolvedValueOnce(10) // filter only
+      .mockResolvedValueOnce(7); // filter + opt-in
+
+    const res = await request('/api/admin/talent-pool/clients/partner-1/preview', {
+      user: adminUser,
+      method: 'POST',
+      body: { filter: { pool: 'APPLICANTS', rows: [{ field: 'graduationYear', values: ['2030'] }] } }
+    });
+
+    const body = await res.json();
+    expect(body.excluded.noOptIn).toBe(3);
+    expect(body.excluded.noBlindResume).toBe(2);
+  });
+});
+
+describe('assign - the snapshot guarantee', () => {
+  const tenApplications = Array.from({ length: 10 }, (_, i) => ({
+    id: `app-${i}`,
+    talentPoolOptIn: true,
+    resumeUrl: `drive-${i}`,
+    blindResumeUrl: `blind-${i}`
+  }));
+
+  it('assigns exactly the keys it was given, ignoring a filter that would match more', async () => {
+    prisma.application.findMany.mockResolvedValue(
+      tenApplications.filter((a) => ['app-1', 'app-2'].includes(a.id))
+    );
+
+    const res = await request('/api/admin/talent-pool/clients/partner-1/assign', {
+      user: adminUser,
+      method: 'POST',
+      body: {
+        // A filter that would have matched all ten.
+        filter: { pool: 'APPLICANTS', rows: [{ field: 'graduationYear', values: ['2030'] }] },
+        keys: ['APPLICATION:app-1', 'APPLICATION:app-2']
+      }
+    });
+
+    expect(res.status).toBe(201);
+    expect((await res.json()).created).toBe(2);
+
+    const rows = prisma.__tx.clientResumeAssignment.createMany.mock.calls[0][0].data;
+    expect(rows).toHaveLength(2);
+    expect(rows.map((r) => r.applicationId).sort()).toEqual(['app-1', 'app-2']);
+
+    // The filter is recorded as documentation only, never used to select rows.
+    expect(prisma.application.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: { in: ['app-1', 'app-2'] } } })
+    );
+  });
+
+  it('stores the filter on the batch purely as a record', async () => {
+    prisma.application.findMany.mockResolvedValue([tenApplications[0]]);
+    const filter = { pool: 'APPLICANTS', rows: [{ field: 'graduationYear', values: ['2030'] }] };
+
+    await request('/api/admin/talent-pool/clients/partner-1/assign', {
+      user: adminUser,
+      method: 'POST',
+      body: { filter, keys: ['APPLICATION:app-0'] }
+    });
+
+    expect(prisma.__tx.clientAssignmentBatch.create.mock.calls[0][0].data.filterJson).toEqual(filter);
+  });
+
+  it('rejects an empty selection', async () => {
+    const res = await request('/api/admin/talent-pool/clients/partner-1/assign', {
+      user: adminUser,
+      method: 'POST',
+      body: { keys: [] }
+    });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('assign - consent gates cannot be bypassed by posting keys directly', () => {
+  it('skips an applicant who has not opted in', async () => {
+    prisma.application.findMany.mockResolvedValue([
+      { id: 'app-1', talentPoolOptIn: false, resumeUrl: 'drive-1', blindResumeUrl: 'blind-1' }
+    ]);
+
+    const res = await request('/api/admin/talent-pool/clients/partner-1/assign', {
+      user: adminUser,
+      method: 'POST',
+      body: { keys: ['APPLICATION:app-1'] }
+    });
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.skipped[0].reason).toMatch(/opted in/i);
+    expect(prisma.__tx.clientResumeAssignment.createMany).not.toHaveBeenCalled();
+  });
+
+  it('skips an applicant whose opt-in was never asked (null)', async () => {
+    prisma.application.findMany.mockResolvedValue([
+      { id: 'app-1', talentPoolOptIn: null, resumeUrl: 'drive-1', blindResumeUrl: 'blind-1' }
+    ]);
+    const res = await request('/api/admin/talent-pool/clients/partner-1/assign', {
+      user: adminUser,
+      method: 'POST',
+      body: { keys: ['APPLICATION:app-1'] }
+    });
+    expect((await res.json()).skipped[0].reason).toMatch(/opted in/i);
+  });
+
+  it('skips an applicant with no blind resume when the client is BLIND', async () => {
+    prisma.talentPartnerClient.findUnique.mockResolvedValue(partner('BLIND'));
+    prisma.application.findMany.mockResolvedValue([
+      { id: 'app-1', talentPoolOptIn: true, resumeUrl: 'drive-1', blindResumeUrl: null }
+    ]);
+
+    const res = await request('/api/admin/talent-pool/clients/partner-1/assign', {
+      user: adminUser,
+      method: 'POST',
+      body: { keys: ['APPLICATION:app-1'] }
+    });
+    expect((await res.json()).skipped[0].reason).toMatch(/redacted/i);
+  });
+
+  it('skips a member resume without consent', async () => {
+    prisma.memberResume.findMany.mockResolvedValue([
+      { id: 'mr-1', isCurrent: true, shareConsent: false, consentRevokedAt: null }
+    ]);
+    const res = await request('/api/admin/talent-pool/clients/partner-1/assign', {
+      user: adminUser,
+      method: 'POST',
+      body: { keys: ['MEMBER_RESUME:mr-1'] }
+    });
+    expect((await res.json()).skipped[0].reason).toMatch(/consent/i);
+  });
+
+  it('skips a member resume whose consent was withdrawn', async () => {
+    prisma.memberResume.findMany.mockResolvedValue([
+      { id: 'mr-1', isCurrent: true, shareConsent: true, consentRevokedAt: new Date() }
+    ]);
+    const res = await request('/api/admin/talent-pool/clients/partner-1/assign', {
+      user: adminUser,
+      method: 'POST',
+      body: { keys: ['MEMBER_RESUME:mr-1'] }
+    });
+    expect((await res.json()).skipped[0].reason).toMatch(/consent/i);
+  });
+
+  it('skips a superseded member resume', async () => {
+    prisma.memberResume.findMany.mockResolvedValue([
+      { id: 'mr-1', isCurrent: false, shareConsent: true, consentRevokedAt: null }
+    ]);
+    const res = await request('/api/admin/talent-pool/clients/partner-1/assign', {
+      user: adminUser,
+      method: 'POST',
+      body: { keys: ['MEMBER_RESUME:mr-1'] }
+    });
+    expect((await res.json()).skipped[0].reason).toMatch(/replaced/i);
+  });
+
+  it('skips a resume already live-assigned to this client', async () => {
+    prisma.application.findMany.mockResolvedValue([
+      { id: 'app-1', talentPoolOptIn: true, resumeUrl: 'drive-1', blindResumeUrl: 'blind-1' }
+    ]);
+    prisma.clientResumeAssignment.findMany.mockResolvedValue([
+      { applicationId: 'app-1', memberResumeId: null }
+    ]);
+
+    const res = await request('/api/admin/talent-pool/clients/partner-1/assign', {
+      user: adminUser,
+      method: 'POST',
+      body: { keys: ['APPLICATION:app-1'] }
+    });
+    expect((await res.json()).skipped[0].reason).toMatch(/already assigned/i);
+  });
+
+  it('rejects a malformed key rather than guessing', async () => {
+    const res = await request('/api/admin/talent-pool/clients/partner-1/assign', {
+      user: adminUser,
+      method: 'POST',
+      body: { keys: ['DROP TABLE users'] }
+    });
+    expect((await res.json()).skipped[0].reason).toMatch(/unrecognised/i);
+  });
+
+  it('caps a single assignment batch', async () => {
+    const keys = Array.from({ length: 501 }, (_, i) => `APPLICATION:app-${i}`);
+    const res = await request('/api/admin/talent-pool/clients/partner-1/assign', {
+      user: adminUser,
+      method: 'POST',
+      body: { keys }
+    });
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/at most 500/i);
+  });
+});
+
+describe('revocation is soft', () => {
+  it('sets revokedAt rather than deleting the row', async () => {
+    prisma.clientResumeAssignment.updateMany.mockResolvedValue({ count: 1 });
+
+    const res = await request('/api/admin/talent-pool/clients/partner-1/assignments/assign-1', {
+      user: adminUser,
+      method: 'DELETE'
+    });
+
+    expect(res.status).toBe(200);
+    const call = prisma.clientResumeAssignment.updateMany.mock.calls[0][0];
+    expect(call.data.revokedAt).toBeInstanceOf(Date);
+    expect(call.data.revokedById).toBe(adminUser.id);
+    expect(call.where).toMatchObject({ id: 'assign-1', clientId: 'partner-1', revokedAt: null });
+  });
+
+  it('404s an assignment that is not this client\'s', async () => {
+    prisma.clientResumeAssignment.updateMany.mockResolvedValue({ count: 0 });
+    const res = await request('/api/admin/talent-pool/clients/partner-1/assignments/not-mine', {
+      user: adminUser,
+      method: 'DELETE'
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it('revokes a whole batch at once', async () => {
+    prisma.clientResumeAssignment.updateMany.mockResolvedValue({ count: 12 });
+    const res = await request('/api/admin/talent-pool/clients/partner-1/batches/batch-1', {
+      user: adminUser,
+      method: 'DELETE'
+    });
+    expect((await res.json()).revoked).toBe(12);
+  });
+});

--- a/server/src/routes/users.js
+++ b/server/src/routes/users.js
@@ -157,6 +157,11 @@ router.patch('/:id/role', requireAuth, async (req, res) => {
     }
 
     // Validate role
+    // CLIENT is deliberately absent. A Talent Partner Network client must be
+    // created through POST /api/admin/talent-pool/clients, which makes the User
+    // and the TalentPartnerClient row in one transaction. Allowing the role to
+    // be set here would permit a CLIENT with no partner row - an account that
+    // can log in and then hit a confusing 403 on every portal request.
     const validRoles = ['USER', 'ADMIN', 'MEMBER'];
     if (!validRoles.includes(role)) {
       console.log('[PATCH /api/users/:id/role] Invalid role:', role);
@@ -390,6 +395,11 @@ router.post('/', requireAuth, async (req, res) => {
     }
 
     // Validate role
+    // CLIENT is deliberately absent. A Talent Partner Network client must be
+    // created through POST /api/admin/talent-pool/clients, which makes the User
+    // and the TalentPartnerClient row in one transaction. Allowing the role to
+    // be set here would permit a CLIENT with no partner row - an account that
+    // can log in and then hit a confusing 403 on every portal request.
     const validRoles = ['USER', 'ADMIN', 'MEMBER'];
     if (role && !validRoles.includes(role)) {
       return res.status(400).json({ error: 'Invalid role' });

--- a/server/src/utils/clientResumeQuery.js
+++ b/server/src/utils/clientResumeQuery.js
@@ -1,0 +1,431 @@
+// Filtering, sorting and CSV shaping for the Talent Partner Network portal.
+//
+// Pure - no prisma, no express - for the same reason clientVisibility.js is:
+// the properties that matter here are "a client can never filter or sort on a
+// field their visibility hides" and "a CSV cell can never become an Excel
+// formula", and both should be provable without a database.
+//
+// The division of labour with clientVisibility.js: that module decides what a
+// client may SEE about one assignment; this one decides what they may ASK for
+// across the set. They share a single source of truth - `visibility` - and the
+// rule below keeps them from drifting: every filter and sort key here must
+// correspond to a field projectAssignment() actually emits at that level.
+// Otherwise a BLIND client could sort by GPA and read the ordering as data,
+// which is the column leaking one bit at a time.
+
+import { VISIBILITY_LEVELS, searchableFields } from './clientVisibility.js';
+
+export const MAX_PAGE = 100;
+
+// Sorting and faceting happen in memory (see the note on sortRows), so the set
+// they run over has to be bounded. This ceiling is ~8x the entire assignable
+// universe - every opted-in application in the system is ~250 rows - so it is a
+// runaway guard, not a paging limit. When it bites, the response says so rather
+// than quietly serving a sorted prefix as if it were the whole library.
+export const MAX_MATERIALIZED = 2000;
+
+// One export is one deliberate act by a person looking at a table. A request
+// for more rows than this is a scrape, and the cap is the difference.
+export const MAX_EXPORT = 1000;
+
+const showsIdentity = (visibility) => visibility === 'BASIC' || visibility === 'FULL';
+const showsContact = (visibility) => visibility === 'FULL';
+
+export const KINDS = ['APPLICANT', 'MEMBER'];
+
+/**
+ * Which filters the UI may offer, and the server may honour, at a given level.
+ * Graduation year and major are projected at every level; gender only from
+ * BASIC; GPA only at FULL.
+ */
+export const filterableFields = (visibility) => {
+  const fields = ['kind', 'graduationYear', 'major'];
+  if (showsIdentity(visibility)) fields.push('gender');
+  if (showsContact(visibility)) fields.push('gpa');
+  return fields;
+};
+
+export const sortableFields = (visibility) => {
+  const fields = ['graduationYear', 'major', 'kind', 'assignedAt'];
+  if (showsIdentity(visibility)) fields.push('name', 'gender');
+  // Every numeric column the projection emits is sortable, not just the one the
+  // filter bar happens to offer a min/max for: a client reading a GPA in the
+  // table expects to be able to order by it.
+  if (showsContact(visibility)) fields.push('cumulativeGpa', 'majorGpa');
+  return fields;
+};
+
+export const DEFAULT_SORT = { field: 'assignedAt', dir: 'desc' };
+
+/**
+ * The spreadsheet. Column order is the reading order of the table, and the set
+ * is exactly what projectAssignment() emits at this level - so an export can
+ * never carry a field the client could not already read on screen.
+ */
+/**
+ * A short, stable handle for one row.
+ *
+ * Under BLIND there is no name, so without this a client has no way to say
+ * "the second one" to their UConsulting contact. It is a prefix of the
+ * assignment id, which the client already holds - the PDF URL is built from it
+ * - so it discloses nothing new, and it stays put across sorts and pages.
+ */
+export const referenceFor = (assignmentId) =>
+  String(assignmentId || '').replace(/-/g, '').slice(0, 8).toUpperCase();
+
+export const exportColumns = (visibility) => {
+  const cols = [{ key: 'reference', label: 'Reference' }];
+  if (showsIdentity(visibility)) {
+    cols.push({ key: 'firstName', label: 'First Name' }, { key: 'lastName', label: 'Last Name' });
+  }
+  cols.push(
+    { key: 'kindLabel', label: 'Type' },
+    { key: 'graduationYear', label: 'Graduation Year' },
+    { key: 'major1', label: 'Major' },
+    { key: 'major2', label: 'Second Major' }
+  );
+  if (showsIdentity(visibility)) cols.push({ key: 'gender', label: 'Gender' });
+  if (showsContact(visibility)) {
+    cols.push(
+      { key: 'cumulativeGpa', label: 'Cumulative GPA' },
+      { key: 'majorGpa', label: 'Major GPA' },
+      { key: 'email', label: 'Email' },
+      { key: 'phoneNumber', label: 'Phone' }
+    );
+  }
+  cols.push(
+    { key: 'assignedAtDate', label: 'Shared On' },
+    { key: 'availableLabel', label: 'Resume Available' }
+  );
+  return cols;
+};
+
+const toArray = (value) => {
+  if (value === undefined || value === null) return [];
+  const raw = Array.isArray(value) ? value : String(value).split(',');
+  const seen = new Set();
+  const out = [];
+  for (const item of raw) {
+    const s = String(item).trim();
+    if (!s) continue;
+    const key = s.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(s);
+  }
+  return out;
+};
+
+// Decimals are compared as strings so binary float rounding never decides who
+// falls on which side of a GPA cut-off - same rule as talentPoolFilters.js.
+const cleanDecimal = (value) => {
+  if (value === undefined || value === null || value === '') return null;
+  const s = String(value).trim();
+  return /^\d{1,2}(\.\d{1,2})?$/.test(s) ? s : null;
+};
+
+/**
+ * Normalize raw query params into a filter/sort/page spec, dropping anything
+ * the client's visibility does not permit.
+ *
+ * Silently dropping rather than erroring is deliberate for the visibility
+ * fields: a 400 saying "gender is not filterable for you" is itself the
+ * disclosure. Malformed input from our own UI still reports an error.
+ *
+ * @returns {{ value: object, errors: string[] }}
+ */
+export const sanitizeClientQuery = (query = {}, visibility = 'BLIND') => {
+  const level = VISIBILITY_LEVELS.includes(visibility) ? visibility : 'BLIND';
+  const errors = [];
+  const allowedFilters = new Set(filterableFields(level));
+  const allowedSorts = new Set(sortableFields(level));
+
+  const filters = {};
+
+  // One kind or the other narrows; selecting both is the same as selecting
+  // neither, so it produces no clause rather than an impossible AND.
+  const kinds = toArray(query.kind)
+    .map((k) => k.toUpperCase())
+    .filter((k) => KINDS.includes(k));
+  if (kinds.length === 1) filters.kind = kinds[0];
+
+  const graduationYear = toArray(query.graduationYear);
+  if (graduationYear.length > 0) filters.graduationYear = graduationYear;
+
+  const major = toArray(query.major);
+  if (major.length > 0) filters.major = major;
+
+  if (allowedFilters.has('gender')) {
+    const gender = toArray(query.gender);
+    if (gender.length > 0) filters.gender = gender;
+  }
+
+  if (allowedFilters.has('gpa')) {
+    const gpaMin = cleanDecimal(query.gpaMin);
+    const gpaMax = cleanDecimal(query.gpaMax);
+    if (query.gpaMin && gpaMin === null) errors.push('Minimum GPA needs a number like 3.50.');
+    if (query.gpaMax && gpaMax === null) errors.push('Maximum GPA needs a number like 3.50.');
+    if (gpaMin !== null) filters.gpaMin = gpaMin;
+    if (gpaMax !== null) filters.gpaMax = gpaMax;
+  }
+
+  const q = typeof query.q === 'string' ? query.q.trim() : '';
+
+  const sortField = allowedSorts.has(query.sort) ? query.sort : DEFAULT_SORT.field;
+  const sortDir = query.dir === 'asc' || query.dir === 'desc' ? query.dir : DEFAULT_SORT.dir;
+
+  const limit = Math.min(Math.max(parseInt(query.limit, 10) || 25, 1), MAX_PAGE);
+  const offset = Math.max(parseInt(query.offset, 10) || 0, 0);
+
+  return {
+    value: { q, filters, sort: { field: sortField, dir: sortDir }, limit, offset },
+    errors
+  };
+};
+
+// Both pools are free text off a Google Form ("Female" / "female"), and Prisma's
+// `in` has no case-insensitive mode. Same workaround as talentPoolFilters.js.
+const anyOfInsensitive = (column, values) => ({
+  OR: values.map((v) => ({ [column]: { equals: v, mode: 'insensitive' } }))
+});
+
+const majorAnyOf = (values) => ({
+  OR: values.flatMap((v) => [
+    { major1: { equals: v, mode: 'insensitive' } },
+    { major2: { equals: v, mode: 'insensitive' } }
+  ])
+});
+
+// A filter names a field on the underlying row, which lives on one of two
+// relations. Matching either is what makes "class of 2030" mean the same thing
+// for an applicant and for a member.
+const eitherPool = (clause) => ({ OR: [{ application: clause }, { memberResume: clause }] });
+
+/**
+ * Translate a sanitized filter set into the Prisma `AND` fragments that narrow
+ * a client's own assignment rows. Never includes the clientId / revokedAt
+ * scoping - the route owns that, so this function cannot widen it.
+ *
+ * @returns {{ and: object[], notes: string[] }}
+ */
+export const buildAssignmentFilters = (filters = {}) => {
+  const and = [];
+  const notes = [];
+
+  if (filters.kind === 'APPLICANT') and.push({ applicationId: { not: null } });
+  if (filters.kind === 'MEMBER') and.push({ memberResumeId: { not: null } });
+
+  if (filters.graduationYear?.length) {
+    and.push(eitherPool(anyOfInsensitive('graduationYear', filters.graduationYear)));
+  }
+  if (filters.gender?.length) {
+    and.push(eitherPool(anyOfInsensitive('gender', filters.gender)));
+  }
+  if (filters.major?.length) {
+    and.push(eitherPool(majorAnyOf(filters.major)));
+  }
+
+  const gpa = {};
+  if (filters.gpaMin) gpa.gte = filters.gpaMin;
+  if (filters.gpaMax) gpa.lte = filters.gpaMax;
+  if (Object.keys(gpa).length > 0) {
+    // Member-uploaded resumes carry no GPA, so a GPA filter necessarily drops
+    // every member row. Saying so beats letting the client read the empty
+    // member half as "no members matched".
+    and.push({ application: { cumulativeGpa: gpa } });
+    if (filters.kind !== 'APPLICANT') {
+      notes.push('Member resumes do not record a GPA, so a GPA filter shows applicants only.');
+    }
+  }
+
+  return { and, notes };
+};
+
+/**
+ * Free-text search across only the fields this visibility already exposes.
+ *
+ * The field list comes from searchableFields() in clientVisibility.js rather
+ * than being restated here, so the two cannot drift. Its rule: under BLIND a
+ * name search plus a result count is a yes/no oracle for "is this person in my
+ * set", which is deanonymization by another route.
+ */
+export const buildSearchClause = (q, visibility) => {
+  const contains = { contains: q, mode: 'insensitive' };
+  const or = [];
+  let memberNameAdded = false;
+
+  for (const field of searchableFields(visibility)) {
+    if (field === 'firstName' || field === 'lastName') {
+      or.push({ application: { [field]: contains } });
+      // A member's name lives on the related User, not on the resume row, so
+      // one clause covers both name fields.
+      if (!memberNameAdded) {
+        or.push({ memberResume: { member: { fullName: contains } } });
+        memberNameAdded = true;
+      }
+      continue;
+    }
+    or.push({ application: { [field]: contains } });
+    or.push({ memberResume: { [field]: contains } });
+  }
+
+  return { OR: or };
+};
+
+const nameOf = (dto) => [dto.firstName, dto.lastName].filter(Boolean).join(' ').trim();
+
+// A number wins over lexical ordering ("10.00" before "3.10"), but only when the
+// value really is one. Graduation year is free text off a Google Form and can
+// arrive as "Spring 2029"; coercing that to NaN would file it with the blanks
+// at the bottom instead of sorting it among the years.
+const asNumber = (value) => {
+  if (value === null || value === undefined || value === '') return null;
+  const s = String(value).trim();
+  if (!/^\d+(\.\d+)?$/.test(s)) return s;
+  return Number(s);
+};
+
+const sortValue = (dto, field) => {
+  switch (field) {
+    case 'name':
+      return nameOf(dto) || null;
+    case 'major':
+      return dto.major1 ?? null;
+    case 'kind':
+      return dto.kind ?? null;
+    case 'graduationYear':
+    case 'cumulativeGpa':
+    case 'majorGpa':
+      return asNumber(dto[field] ?? null);
+    case 'assignedAt':
+      return dto.assignedAt ? new Date(dto.assignedAt).getTime() : null;
+    default:
+      return dto[field] ?? null;
+  }
+};
+
+const isBlank = (v) => v === null || v === undefined || v === '' || Number.isNaN(v);
+
+/**
+ * Sort projected DTOs in memory.
+ *
+ * Why not `orderBy` in Prisma: an assignment points at an application OR a
+ * member resume, and there is no orderBy that interleaves two nullable to-one
+ * relations on the same column - `[{application:{...}},{memberResume:{...}}]`
+ * sorts every member row to one end on the first key. In-memory sorting over a
+ * set bounded by MAX_MATERIALIZED is the correct answer at this scale and gives
+ * the table one consistent ordering across both pools.
+ *
+ * Blanks always sort last, in both directions: a missing major is not "before
+ * A", it is absent, and burying it under the populated rows is what a reader
+ * expects from a spreadsheet.
+ */
+export const sortRows = (rows, sort = DEFAULT_SORT) => {
+  const { field, dir } = sort;
+  const factor = dir === 'asc' ? 1 : -1;
+
+  return [...rows].sort((rowA, rowB) => {
+    const a = sortValue(rowA, field);
+    const b = sortValue(rowB, field);
+    const aBlank = isBlank(a);
+    const bBlank = isBlank(b);
+
+    if (aBlank || bBlank) {
+      if (aBlank && !bBlank) return 1;
+      if (!aBlank && bBlank) return -1;
+    } else if (typeof a === 'number' && typeof b === 'number') {
+      if (a !== b) return (a - b) * factor;
+    } else {
+      const cmp = String(a).localeCompare(String(b), undefined, { sensitivity: 'base' });
+      if (cmp !== 0) return cmp * factor;
+    }
+
+    // Stable tiebreak so paging never reshuffles rows between requests.
+    return String(rowA.assignmentId).localeCompare(String(rowB.assignmentId));
+  });
+};
+
+/**
+ * Facet values for the filter bar, derived from the client's own library so the
+ * dropdowns only ever offer values that can actually return a row.
+ *
+ * Values are deduplicated case-insensitively and the first spelling wins, which
+ * keeps "Female" and "female" from appearing as two choices that each match
+ * both.
+ */
+export const buildFacets = (rows, visibility) => {
+  const collect = (pick) => {
+    const seen = new Map();
+    for (const row of rows) {
+      for (const value of pick(row)) {
+        if (value === null || value === undefined) continue;
+        const s = String(value).trim();
+        if (!s) continue;
+        const key = s.toLowerCase();
+        if (!seen.has(key)) seen.set(key, s);
+      }
+    }
+    return [...seen.values()].sort((a, b) => a.localeCompare(b));
+  };
+
+  const facets = {
+    graduationYear: collect((r) => [r.graduationYear]),
+    major: collect((r) => [r.major1, r.major2]),
+    kind: collect((r) => [r.kind])
+  };
+
+  if (showsIdentity(visibility)) {
+    facets.gender = collect((r) => [r.gender]);
+  }
+
+  return facets;
+};
+
+// A cell beginning =, +, - or @ is executed as a formula by Excel and Sheets,
+// and these cells hold applicant free text off a Google Form. Prefixing with an
+// apostrophe is the standard neutralization and survives the round trip.
+const NEUTRALIZE = /^[=+\-@\t\r]/;
+
+export const escapeCsvCell = (value) => {
+  if (value === null || value === undefined) return '';
+  let s = String(value);
+  if (NEUTRALIZE.test(s)) s = `'${s}`;
+  if (/[",\r\n]/.test(s)) s = `"${s.replace(/"/g, '""')}"`;
+  return s;
+};
+
+const csvRowValues = (dto) => ({
+  ...dto,
+  reference: referenceFor(dto.assignmentId),
+  kindLabel: dto.kind === 'MEMBER' ? 'Member' : 'Applicant',
+  availableLabel: dto.available ? 'Yes' : 'No',
+  assignedAtDate: dto.assignedAt ? new Date(dto.assignedAt).toISOString().slice(0, 10) : ''
+});
+
+/**
+ * Render projected DTOs as CSV. Takes DTOs, never raw assignment rows, so a
+ * column the projection omitted cannot reappear in the spreadsheet.
+ *
+ * CRLF line endings and a UTF-8 BOM: Excel on Windows reads a bare-LF, BOM-less
+ * file as the system codepage, which mangles every non-ASCII name in it.
+ */
+export const toCsv = (rows, visibility) => {
+  const columns = exportColumns(visibility);
+  const lines = [columns.map((c) => escapeCsvCell(c.label)).join(',')];
+  for (const dto of rows) {
+    const values = csvRowValues(dto);
+    lines.push(columns.map((c) => escapeCsvCell(values[c.key])).join(','));
+  }
+  return `\uFEFF${lines.join('\r\n')}\r\n`;
+};
+
+export const csvFilename = (organization, now) => {
+  const slug = String(organization || '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '')
+    .slice(0, 40)
+    .replace(/-$/, '');
+  const date = (now instanceof Date ? now : new Date()).toISOString().slice(0, 10);
+  return slug ? `${slug}-resumes-${date}.csv` : `resumes-${date}.csv`;
+};

--- a/server/src/utils/clientResumeQuery.test.js
+++ b/server/src/utils/clientResumeQuery.test.js
@@ -1,0 +1,339 @@
+// The assertions that matter here: a visibility level can never be widened by
+// a query parameter, and a CSV cell can never become a spreadsheet formula.
+// Both are properties of pure functions, so none of this needs a database.
+import { describe, it, expect } from 'vitest';
+import {
+  MAX_PAGE,
+  buildAssignmentFilters,
+  buildFacets,
+  buildSearchClause,
+  csvFilename,
+  escapeCsvCell,
+  exportColumns,
+  filterableFields,
+  referenceFor,
+  sanitizeClientQuery,
+  sortRows,
+  sortableFields,
+  toCsv
+} from './clientResumeQuery.js';
+
+const dto = (overrides = {}) => ({
+  assignmentId: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+  kind: 'APPLICANT',
+  assignedAt: '2026-08-01T00:00:00.000Z',
+  available: true,
+  graduationYear: '2030',
+  major1: 'Economics',
+  major2: null,
+  ...overrides
+});
+
+describe('what a visibility level may ask for', () => {
+  it('never offers gender or GPA to a blind client', () => {
+    expect(filterableFields('BLIND')).toEqual(['kind', 'graduationYear', 'major']);
+    expect(sortableFields('BLIND')).not.toContain('name');
+    expect(sortableFields('BLIND')).not.toContain('gender');
+    expect(sortableFields('BLIND')).not.toContain('cumulativeGpa');
+  });
+
+  it('adds identity at BASIC and contact at FULL', () => {
+    expect(filterableFields('BASIC')).toContain('gender');
+    expect(filterableFields('BASIC')).not.toContain('gpa');
+    expect(filterableFields('FULL')).toContain('gpa');
+    expect(sortableFields('FULL')).toContain('cumulativeGpa');
+  });
+
+  it('makes every numeric column a FULL client can read sortable', () => {
+    expect(sortableFields('FULL')).toEqual(expect.arrayContaining([
+      'graduationYear', 'cumulativeGpa', 'majorGpa'
+    ]));
+    // ...and none of them below the level that projects them.
+    expect(sortableFields('BASIC')).not.toContain('majorGpa');
+    expect(sortableFields('BLIND')).not.toContain('majorGpa');
+  });
+
+  it('drops a filter the level hides rather than honouring it', () => {
+    const { value } = sanitizeClientQuery({ gender: 'Female', gpaMin: '3.5' }, 'BLIND');
+    expect(value.filters).toEqual({});
+  });
+
+  it('drops a sort the level hides and falls back to the default', () => {
+    const { value } = sanitizeClientQuery({ sort: 'cumulativeGpa', dir: 'asc' }, 'BASIC');
+    // Ordering by a hidden column would leak it one comparison at a time.
+    expect(value.sort).toEqual({ field: 'assignedAt', dir: 'asc' });
+  });
+
+  it('treats an unknown visibility as BLIND', () => {
+    const { value } = sanitizeClientQuery({ gender: 'Female' }, 'SUPERUSER');
+    expect(value.filters).toEqual({});
+  });
+
+  it('caps the page size', () => {
+    expect(sanitizeClientQuery({ limit: '100000' }, 'FULL').value.limit).toBe(MAX_PAGE);
+    expect(sanitizeClientQuery({ limit: '-5' }, 'FULL').value.limit).toBe(1);
+    expect(sanitizeClientQuery({ offset: '-5' }, 'FULL').value.offset).toBe(0);
+  });
+
+  it('reports a malformed GPA instead of silently ignoring it', () => {
+    const { errors } = sanitizeClientQuery({ gpaMin: 'four point oh' }, 'FULL');
+    expect(errors[0]).toMatch(/Minimum GPA/);
+  });
+
+  it('accepts repeated and comma-joined values alike, de-duplicated', () => {
+    expect(sanitizeClientQuery({ graduationYear: '2029,2030,2029' }, 'BLIND').value.filters
+      .graduationYear).toEqual(['2029', '2030']);
+    expect(sanitizeClientQuery({ major: ['Econ', 'econ', ' Stats '] }, 'BLIND').value.filters
+      .major).toEqual(['Econ', 'Stats']);
+  });
+
+  it('reads both kinds selected as no kind filter at all', () => {
+    expect(sanitizeClientQuery({ kind: 'APPLICANT,MEMBER' }, 'BLIND').value.filters.kind)
+      .toBeUndefined();
+    expect(sanitizeClientQuery({ kind: 'MEMBER' }, 'BLIND').value.filters.kind).toBe('MEMBER');
+  });
+});
+
+describe('filter translation', () => {
+  it('matches a shared field against either pool', () => {
+    const { and } = buildAssignmentFilters({ graduationYear: ['2030'] });
+    const json = JSON.stringify(and);
+    // A "class of 2030" filter has to mean the same thing for an applicant and
+    // for a member, and the two live on different relations.
+    expect(json).toContain('application');
+    expect(json).toContain('memberResume');
+  });
+
+  it('compares free text case-insensitively', () => {
+    const { and } = buildAssignmentFilters({ gender: ['Female'] });
+    expect(JSON.stringify(and)).toContain('insensitive');
+  });
+
+  it('matches a major against either major column', () => {
+    const { and } = buildAssignmentFilters({ major: ['Economics'] });
+    const json = JSON.stringify(and);
+    expect(json).toContain('major1');
+    expect(json).toContain('major2');
+  });
+
+  it('narrows by kind through the foreign key, not the relation', () => {
+    expect(buildAssignmentFilters({ kind: 'MEMBER' }).and).toEqual([
+      { memberResumeId: { not: null } }
+    ]);
+  });
+
+  it('says a GPA filter excludes members rather than showing an empty member half', () => {
+    const { and, notes } = buildAssignmentFilters({ gpaMin: '3.50' });
+    expect(and).toEqual([{ application: { cumulativeGpa: { gte: '3.50' } } }]);
+    expect(notes.join(' ')).toMatch(/Member resumes do not record a GPA/);
+  });
+
+  it('stays quiet about members when the filter already excluded them', () => {
+    expect(buildAssignmentFilters({ gpaMin: '3.50', kind: 'APPLICANT' }).notes).toEqual([]);
+  });
+
+  it('compares GPA as a string so float rounding never decides a cut-off', () => {
+    const { and } = buildAssignmentFilters({ gpaMin: '3.50', gpaMax: '4.00' });
+    expect(and[0].application.cumulativeGpa).toEqual({ gte: '3.50', lte: '4.00' });
+  });
+
+  it('produces no clauses for an empty filter set', () => {
+    expect(buildAssignmentFilters({}).and).toEqual([]);
+  });
+});
+
+describe('free-text search', () => {
+  it('never reaches a name field under BLIND', () => {
+    const json = JSON.stringify(buildSearchClause('Jane', 'BLIND'));
+    // A name search plus a result count is a yes/no oracle for "is this person
+    // in my set", which is deanonymization by another route.
+    expect(json).not.toContain('firstName');
+    expect(json).not.toContain('lastName');
+    expect(json).not.toContain('fullName');
+    expect(json).toContain('major1');
+  });
+
+  it('reaches names once identity is already visible', () => {
+    const json = JSON.stringify(buildSearchClause('Jane', 'BASIC'));
+    expect(json).toContain('firstName');
+    expect(json).toContain('lastName');
+    expect(json).toContain('fullName');
+  });
+});
+
+describe('sorting', () => {
+  it('sorts blanks last in both directions', () => {
+    const rows = [
+      dto({ assignmentId: 'a', major1: 'Statistics' }),
+      dto({ assignmentId: 'b', major1: null }),
+      dto({ assignmentId: 'c', major1: 'Economics' })
+    ];
+
+    expect(sortRows(rows, { field: 'major', dir: 'asc' }).map((r) => r.assignmentId))
+      .toEqual(['c', 'a', 'b']);
+    expect(sortRows(rows, { field: 'major', dir: 'desc' }).map((r) => r.assignmentId))
+      .toEqual(['a', 'c', 'b']);
+  });
+
+  it('interleaves both pools on a shared column', () => {
+    const rows = [
+      dto({ assignmentId: 'a', kind: 'APPLICANT', graduationYear: '2030' }),
+      dto({ assignmentId: 'b', kind: 'MEMBER', graduationYear: '2028' }),
+      dto({ assignmentId: 'c', kind: 'APPLICANT', graduationYear: '2029' })
+    ];
+
+    // The reason sorting is in memory at all: no Prisma orderBy interleaves two
+    // nullable to-one relations, so members would clump at one end.
+    expect(sortRows(rows, { field: 'graduationYear', dir: 'asc' }).map((r) => r.assignmentId))
+      .toEqual(['b', 'c', 'a']);
+  });
+
+  it('sorts GPA numerically, not lexically', () => {
+    const rows = [
+      dto({ assignmentId: 'a', cumulativeGpa: '3.90' }),
+      dto({ assignmentId: 'b', cumulativeGpa: '3.10' }),
+      dto({ assignmentId: 'c', cumulativeGpa: '10.00' })
+    ];
+    expect(sortRows(rows, { field: 'cumulativeGpa', dir: 'asc' }).map((r) => r.assignmentId))
+      .toEqual(['b', 'a', 'c']);
+  });
+
+  it('sorts major GPA numerically too', () => {
+    const rows = [
+      dto({ assignmentId: 'a', majorGpa: '3.90' }),
+      dto({ assignmentId: 'b', majorGpa: '3.10' }),
+      dto({ assignmentId: 'c', majorGpa: '10.00' })
+    ];
+    expect(sortRows(rows, { field: 'majorGpa', dir: 'asc' }).map((r) => r.assignmentId))
+      .toEqual(['b', 'a', 'c']);
+  });
+
+  it('keeps a non-numeric graduation year among the years instead of with the blanks', () => {
+    // The column is free text off a Google Form. Coercing it to a number would
+    // turn "Spring 2029" into NaN, which isBlank() files at the very bottom.
+    const rows = [
+      dto({ assignmentId: 'a', graduationYear: '2030' }),
+      dto({ assignmentId: 'b', graduationYear: 'Spring 2029' }),
+      dto({ assignmentId: 'c', graduationYear: null })
+    ];
+    const order = sortRows(rows, { field: 'graduationYear', dir: 'asc' }).map((r) => r.assignmentId);
+    expect(order[order.length - 1]).toBe('c');
+    expect(order).toContain('b');
+    expect(order.indexOf('b')).toBeLessThan(order.indexOf('c'));
+  });
+
+  it('breaks ties stably so paging does not reshuffle rows', () => {
+    const rows = [
+      dto({ assignmentId: 'zzz', graduationYear: '2030' }),
+      dto({ assignmentId: 'aaa', graduationYear: '2030' })
+    ];
+    expect(sortRows(rows, { field: 'graduationYear', dir: 'asc' }).map((r) => r.assignmentId))
+      .toEqual(['aaa', 'zzz']);
+  });
+
+  it('does not mutate the array it was given', () => {
+    const rows = [dto({ assignmentId: 'b' }), dto({ assignmentId: 'a' })];
+    sortRows(rows, { field: 'assignmentId', dir: 'asc' });
+    expect(rows[0].assignmentId).toBe('b');
+  });
+});
+
+describe('facets', () => {
+  it('collapses case variants to one choice', () => {
+    const facets = buildFacets(
+      [dto({ gender: 'Female' }), dto({ gender: 'female' })],
+      'FULL'
+    );
+    expect(facets.gender).toEqual(['Female']);
+  });
+
+  it('pulls both major columns into one list', () => {
+    const facets = buildFacets(
+      [dto({ major1: 'Economics', major2: 'Statistics' })],
+      'BLIND'
+    );
+    expect(facets.major).toEqual(['Economics', 'Statistics']);
+  });
+
+  it('offers no gender facet to a blind client', () => {
+    expect(buildFacets([dto({ gender: 'Female' })], 'BLIND').gender).toBeUndefined();
+  });
+});
+
+describe('CSV', () => {
+  it('neutralizes a cell that would otherwise run as a formula', () => {
+    // These cells hold applicant free text off a Google Form, and Excel
+    // executes a leading =, +, - or @.
+    expect(escapeCsvCell('=1+1')).toBe("'=1+1");
+    expect(escapeCsvCell('-2')).toBe("'-2");
+    // Neutralized first, then quoted because the value also contains a quote.
+    expect(escapeCsvCell('+HYPERLINK("x")')).toBe('"\'+HYPERLINK(""x"")"');
+    expect(escapeCsvCell('@SUM(A1)')).toBe("'@SUM(A1)");
+    expect(escapeCsvCell('Economics')).toBe('Economics');
+  });
+
+  it('quotes separators and doubles inner quotes', () => {
+    expect(escapeCsvCell('Ruiz, Jr')).toBe('"Ruiz, Jr"');
+    expect(escapeCsvCell('She said "hi"')).toBe('"She said ""hi"""');
+    expect(escapeCsvCell('line\nbreak')).toBe('"line\nbreak"');
+  });
+
+  it('renders nothing for a missing value', () => {
+    expect(escapeCsvCell(null)).toBe('');
+    expect(escapeCsvCell(undefined)).toBe('');
+  });
+
+  it('carries only the columns the visibility already exposes', () => {
+    const blind = exportColumns('BLIND').map((c) => c.key);
+    expect(blind).not.toContain('firstName');
+    expect(blind).not.toContain('gender');
+    expect(blind).not.toContain('email');
+    expect(blind).toContain('graduationYear');
+
+    const full = exportColumns('FULL').map((c) => c.key);
+    expect(full).toEqual(expect.arrayContaining(['firstName', 'gender', 'cumulativeGpa', 'email']));
+  });
+
+  it('never emits a Drive id or a storage path', () => {
+    const csv = toCsv(
+      [dto({ pdfUrl: '/api/client/resumes/x/pdf', resumeUrl: 'drive-secret' })],
+      'FULL'
+    );
+    expect(csv).not.toContain('drive-secret');
+    expect(csv).not.toContain('pdf');
+  });
+
+  it('leads with a BOM and separates rows with CRLF so Excel reads it correctly', () => {
+    const csv = toCsv([dto()], 'BLIND');
+    expect(csv.charCodeAt(0)).toBe(0xfeff);
+    expect(csv).toContain('\r\n');
+  });
+
+  it('renders the reference, type, date and availability as a reader expects', () => {
+    const csv = toCsv([dto({ available: false, kind: 'MEMBER' })], 'BLIND');
+    const row = csv.trim().split('\r\n')[1];
+    expect(row).toContain('AAAAAAAA');
+    expect(row).toContain('Member');
+    expect(row).toContain('2026-08-01');
+    expect(row.endsWith('No')).toBe(true);
+  });
+});
+
+describe('reference and filename', () => {
+  it('derives a stable handle from the assignment id', () => {
+    expect(referenceFor('aaaaaaaa-bbbb-cccc')).toBe('AAAAAAAA');
+    expect(referenceFor(null)).toBe('');
+  });
+
+  it('slugs the organization and stamps the date', () => {
+    expect(csvFilename('Acme Recruiting, LLC', new Date('2026-08-26T12:00:00Z')))
+      .toBe('acme-recruiting-llc-resumes-2026-08-26.csv');
+  });
+
+  it('falls back when the organization slugs to nothing', () => {
+    expect(csvFilename('///', new Date('2026-08-26T12:00:00Z')))
+      .toBe('resumes-2026-08-26.csv');
+    expect(csvFilename('', new Date('2026-08-26T12:00:00Z')))
+      .toBe('resumes-2026-08-26.csv');
+  });
+});

--- a/server/src/utils/clientVisibility.js
+++ b/server/src/utils/clientVisibility.js
@@ -1,0 +1,136 @@
+// The single place that decides what a Talent Partner Network client is allowed
+// to see about a resume. Pure - no prisma, no express - so the "never leaks a
+// Drive id" property is provable in a unit test.
+//
+// Two rules that are load-bearing:
+//
+// 1. Fields above the client's visibility level are OMITTED, not set to null.
+//    A null key still tells the client the field exists and invites their code
+//    (and their next support request) to try to fill it.
+//
+// 2. resumeUrl / blindResumeUrl NEVER appear in the output, at any level. Those
+//    are Google Drive file ids, and /api/files/* is not reachable by a CLIENT
+//    anyway - a DTO carrying one would be a broken UI and a leak at the same
+//    time. The client gets an assignment-scoped proxy URL instead, and the
+//    assignment id is the security primitive: it is meaningless without a row
+//    that ties it to this client.
+
+export const VISIBILITY_LEVELS = ['BLIND', 'BASIC', 'FULL'];
+
+export const pdfUrlForAssignment = (assignmentId) =>
+  `/api/client/resumes/${assignmentId}/pdf`;
+
+const showsIdentity = (visibility) => visibility === 'BASIC' || visibility === 'FULL';
+const showsContact = (visibility) => visibility === 'FULL';
+
+/**
+ * Whether a resume can actually be rendered for this visibility level. Drives
+ * the `available` flag so the UI can say "not available" instead of handing the
+ * viewer a PDF pane that 404s.
+ */
+export const isViewable = (assignment, visibility) => {
+  if (assignment?.application) {
+    if (visibility === 'BLIND') {
+      return Boolean(assignment.application.blindResumeUrl);
+    }
+    return Boolean(assignment.application.resumeUrl);
+  }
+  if (assignment?.memberResume) {
+    // No redacted variant of a member-uploaded PDF exists.
+    return visibility !== 'BLIND';
+  }
+  return false;
+};
+
+/**
+ * Resolve which stored file this assignment should stream for a given
+ * visibility. Server-side only - the return value must never be serialized into
+ * a response.
+ *
+ * @returns {{ kind: 'drive', fileId: string } | { kind: 'local', storagePath: string } | null}
+ */
+export const resolveResumeSource = (assignment, visibility) => {
+  if (assignment?.application) {
+    const app = assignment.application;
+    const fileId = visibility === 'BLIND' ? app.blindResumeUrl : app.resumeUrl;
+    if (!fileId) return null;
+    return { kind: 'drive', fileId };
+  }
+  if (assignment?.memberResume) {
+    if (visibility === 'BLIND') return null;
+    if (!assignment.memberResume.storagePath) return null;
+    return { kind: 'local', storagePath: assignment.memberResume.storagePath };
+  }
+  return null;
+};
+
+/**
+ * Project one assignment row (with `application` or `memberResume` included)
+ * into the DTO a client receives.
+ */
+export const projectAssignment = (assignment, visibility) => {
+  const isApplicant = Boolean(assignment.application);
+  const source = isApplicant ? assignment.application : assignment.memberResume;
+
+  const dto = {
+    assignmentId: assignment.id,
+    kind: isApplicant ? 'APPLICANT' : 'MEMBER',
+    assignedAt: assignment.assignedAt,
+    pdfUrl: pdfUrlForAssignment(assignment.id),
+    available: isViewable(assignment, visibility),
+    graduationYear: source?.graduationYear ?? null,
+    major1: source?.major1 ?? null,
+    major2: source?.major2 ?? null
+  };
+
+  if (showsIdentity(visibility)) {
+    dto.gender = source?.gender ?? null;
+    if (isApplicant) {
+      dto.firstName = source?.firstName ?? null;
+      dto.lastName = source?.lastName ?? null;
+    } else {
+      // Member name lives on the related User, not on the resume row.
+      const member = assignment.memberResume?.member;
+      dto.firstName = member?.fullName ? member.fullName.split(' ')[0] : null;
+      dto.lastName = member?.fullName
+        ? member.fullName.split(' ').slice(1).join(' ') || null
+        : null;
+    }
+  }
+
+  if (showsContact(visibility)) {
+    if (isApplicant) {
+      dto.email = source?.email ?? null;
+      dto.phoneNumber = source?.phoneNumber ?? null;
+      // Decimal comes back as a Prisma Decimal; string keeps the precision the
+      // column was chosen for.
+      dto.cumulativeGpa = source?.cumulativeGpa != null ? String(source.cumulativeGpa) : null;
+      dto.majorGpa = source?.majorGpa != null ? String(source.majorGpa) : null;
+    } else {
+      // Members supply no contact details or GPA with an uploaded resume. The
+      // keys stay present so the client renders one component for both kinds.
+      dto.email = assignment.memberResume?.member?.email ?? null;
+      dto.phoneNumber = null;
+      dto.cumulativeGpa = null;
+      dto.majorGpa = null;
+    }
+  }
+
+  return dto;
+};
+
+/**
+ * Which fields a free-text search may look at for a given visibility.
+ *
+ * Under BLIND this must exclude names. If a blind client could search by name
+ * and read the result count, they would have a yes/no oracle for "is this
+ * person in my set" - which is deanonymization by another route, and it would
+ * make the whole blind mode theatre.
+ */
+export const searchableFields = (visibility) => {
+  const base = ['graduationYear', 'major1', 'major2'];
+  if (showsIdentity(visibility)) {
+    return [...base, 'firstName', 'lastName'];
+  }
+  return base;
+};

--- a/server/src/utils/clientVisibility.js
+++ b/server/src/utils/clientVisibility.js
@@ -24,16 +24,58 @@ const showsIdentity = (visibility) => visibility === 'BASIC' || visibility === '
 const showsContact = (visibility) => visibility === 'FULL';
 
 /**
+ * `Application.resumeUrl` does not hold a bare Drive file id - it holds a URL
+ * that *wraps* one, and in at least two shapes, because the value was written
+ * by different generations of the sync:
+ *
+ *   /api/files/<id>/pdf                          (236 of 251 opted-in rows)
+ *   https://uconsultingats.com/api/files/<id>/pdf (the rest)
+ *
+ * The Drive SDK takes the id alone, so handing it either of these produces a
+ * 404 from Google and a 500 from us. Everything else in the app dodges this by
+ * fetching the stored URL directly from the browser; the client portal cannot,
+ * because the whole point is that the buyer never learns the Drive id.
+ *
+ * Returns null rather than a guess when the value is unrecognizable - the
+ * caller turns that into "not available", which is the honest answer and keeps
+ * an unparsed string from reaching the Drive API.
+ */
+export const extractDriveFileId = (value) => {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+
+  // Our own proxy route, relative or absolute.
+  const proxied = trimmed.match(/\/api\/files\/([^/?#]+)/);
+  if (proxied) return decodeURIComponent(proxied[1]);
+
+  // Drive's own share links, in case a value is ever pasted in by hand.
+  const driveFile = trimmed.match(/\/file\/d\/([^/?#]+)/);
+  if (driveFile) return driveFile[1];
+  const driveQuery = trimmed.match(/[?&]id=([^&#]+)/);
+  if (driveQuery) return decodeURIComponent(driveQuery[1]);
+
+  // Already a bare id.
+  if (/^[A-Za-z0-9_-]{10,}$/.test(trimmed)) return trimmed;
+
+  return null;
+};
+
+/**
  * Whether a resume can actually be rendered for this visibility level. Drives
  * the `available` flag so the UI can say "not available" instead of handing the
  * viewer a PDF pane that 404s.
  */
 export const isViewable = (assignment, visibility) => {
   if (assignment?.application) {
-    if (visibility === 'BLIND') {
-      return Boolean(assignment.application.blindResumeUrl);
-    }
-    return Boolean(assignment.application.resumeUrl);
+    // Deliberately the same predicate the stream handler uses: a row whose
+    // stored URL we cannot parse into a file id is not viewable, and saying so
+    // in the list beats a card that opens onto a 404.
+    const stored =
+      visibility === 'BLIND'
+        ? assignment.application.blindResumeUrl
+        : assignment.application.resumeUrl;
+    return Boolean(extractDriveFileId(stored));
   }
   if (assignment?.memberResume) {
     // No redacted variant of a member-uploaded PDF exists.
@@ -52,7 +94,8 @@ export const isViewable = (assignment, visibility) => {
 export const resolveResumeSource = (assignment, visibility) => {
   if (assignment?.application) {
     const app = assignment.application;
-    const fileId = visibility === 'BLIND' ? app.blindResumeUrl : app.resumeUrl;
+    const stored = visibility === 'BLIND' ? app.blindResumeUrl : app.resumeUrl;
+    const fileId = extractDriveFileId(stored);
     if (!fileId) return null;
     return { kind: 'drive', fileId };
   }

--- a/server/src/utils/clientVisibility.test.js
+++ b/server/src/utils/clientVisibility.test.js
@@ -1,0 +1,193 @@
+import { describe, it, expect } from 'vitest';
+import {
+  projectAssignment,
+  resolveResumeSource,
+  isViewable,
+  searchableFields,
+  pdfUrlForAssignment,
+  VISIBILITY_LEVELS
+} from './clientVisibility.js';
+
+const DRIVE_REAL = 'drive-file-id-real-resume';
+const DRIVE_BLIND = 'drive-file-id-blind-resume';
+
+const applicantAssignment = (overrides = {}) => ({
+  id: 'assign-1',
+  assignedAt: new Date('2026-08-01T00:00:00.000Z'),
+  application: {
+    id: 'app-1',
+    firstName: 'Jane',
+    lastName: 'Doe',
+    email: 'jane@ucla.edu',
+    phoneNumber: '+1-310-555-0100',
+    studentId: '123456789',
+    graduationYear: '2030',
+    major1: 'Business Economics',
+    major2: null,
+    gender: 'Female',
+    cumulativeGpa: '3.85',
+    majorGpa: '3.92',
+    resumeUrl: DRIVE_REAL,
+    blindResumeUrl: DRIVE_BLIND,
+    ...overrides
+  },
+  memberResume: null
+});
+
+const memberAssignment = (overrides = {}) => ({
+  id: 'assign-2',
+  assignedAt: new Date('2026-08-02T00:00:00.000Z'),
+  application: null,
+  memberResume: {
+    id: 'mr-1',
+    storagePath: 'member-resumes/mr-1/resume.pdf',
+    graduationYear: '2027',
+    major1: 'Statistics',
+    major2: 'Economics',
+    gender: 'Other',
+    member: { fullName: 'Alex Rivera Cruz', email: 'alex@uconsulting.org' },
+    ...overrides
+  }
+});
+
+describe('projectAssignment - never leaks a file id', () => {
+  it('omits resumeUrl, blindResumeUrl and studentId at every visibility level', () => {
+    for (const visibility of VISIBILITY_LEVELS) {
+      const dto = projectAssignment(applicantAssignment(), visibility);
+      const serialized = JSON.stringify(dto);
+
+      expect(serialized).not.toContain(DRIVE_REAL);
+      expect(serialized).not.toContain(DRIVE_BLIND);
+      expect(serialized).not.toContain('/api/files/');
+      expect(dto).not.toHaveProperty('resumeUrl');
+      expect(dto).not.toHaveProperty('blindResumeUrl');
+      expect(dto).not.toHaveProperty('studentId');
+    }
+  });
+
+  it('never leaks a member storage path either', () => {
+    for (const visibility of ['BASIC', 'FULL']) {
+      const dto = projectAssignment(memberAssignment(), visibility);
+      expect(JSON.stringify(dto)).not.toContain('member-resumes/');
+      expect(dto).not.toHaveProperty('storagePath');
+    }
+  });
+
+  it('hands out an assignment-scoped proxy URL instead', () => {
+    const dto = projectAssignment(applicantAssignment(), 'FULL');
+    expect(dto.pdfUrl).toBe('/api/client/resumes/assign-1/pdf');
+    expect(pdfUrlForAssignment('x')).toBe('/api/client/resumes/x/pdf');
+  });
+});
+
+describe('projectAssignment - BLIND', () => {
+  it('omits identity keys entirely rather than nulling them', () => {
+    const dto = projectAssignment(applicantAssignment(), 'BLIND');
+
+    for (const key of ['firstName', 'lastName', 'gender', 'email', 'phoneNumber', 'cumulativeGpa', 'majorGpa']) {
+      expect(dto).not.toHaveProperty(key);
+    }
+  });
+
+  it('still exposes the non-identifying fields the client filtered on', () => {
+    const dto = projectAssignment(applicantAssignment(), 'BLIND');
+    expect(dto.graduationYear).toBe('2030');
+    expect(dto.major1).toBe('Business Economics');
+    expect(dto.available).toBe(true);
+  });
+
+  it('marks an applicant with no blind resume unavailable', () => {
+    const dto = projectAssignment(applicantAssignment({ blindResumeUrl: null }), 'BLIND');
+    expect(dto.available).toBe(false);
+  });
+
+  it('marks every member resume unavailable', () => {
+    const dto = projectAssignment(memberAssignment(), 'BLIND');
+    expect(dto.available).toBe(false);
+  });
+});
+
+describe('projectAssignment - BASIC and FULL', () => {
+  it('BASIC adds name and gender but withholds contact details and GPA', () => {
+    const dto = projectAssignment(applicantAssignment(), 'BASIC');
+    expect(dto.firstName).toBe('Jane');
+    expect(dto.lastName).toBe('Doe');
+    expect(dto.gender).toBe('Female');
+    expect(dto).not.toHaveProperty('email');
+    expect(dto).not.toHaveProperty('phoneNumber');
+    expect(dto).not.toHaveProperty('cumulativeGpa');
+  });
+
+  it('FULL adds contact details and GPA as strings', () => {
+    const dto = projectAssignment(applicantAssignment(), 'FULL');
+    expect(dto.email).toBe('jane@ucla.edu');
+    expect(dto.phoneNumber).toBe('+1-310-555-0100');
+    expect(dto.cumulativeGpa).toBe('3.85');
+    expect(typeof dto.cumulativeGpa).toBe('string');
+  });
+
+  it('gives a member row the same key set as an applicant row so one component renders both', () => {
+    const applicant = projectAssignment(applicantAssignment(), 'FULL');
+    const member = projectAssignment(memberAssignment(), 'FULL');
+    expect(Object.keys(member).sort()).toEqual(Object.keys(applicant).sort());
+  });
+
+  it('splits a member full name and nulls the fields members do not supply', () => {
+    const dto = projectAssignment(memberAssignment(), 'FULL');
+    expect(dto.firstName).toBe('Alex');
+    expect(dto.lastName).toBe('Rivera Cruz');
+    expect(dto.phoneNumber).toBeNull();
+    expect(dto.cumulativeGpa).toBeNull();
+  });
+});
+
+describe('resolveResumeSource', () => {
+  it('serves the blind file to a BLIND client and the real one otherwise', () => {
+    expect(resolveResumeSource(applicantAssignment(), 'BLIND')).toEqual({
+      kind: 'drive',
+      fileId: DRIVE_BLIND
+    });
+    for (const visibility of ['BASIC', 'FULL']) {
+      expect(resolveResumeSource(applicantAssignment(), visibility)).toEqual({
+        kind: 'drive',
+        fileId: DRIVE_REAL
+      });
+    }
+  });
+
+  it('refuses rather than falling back to the real file when no blind version exists', () => {
+    expect(resolveResumeSource(applicantAssignment({ blindResumeUrl: null }), 'BLIND')).toBeNull();
+    expect(resolveResumeSource(applicantAssignment({ blindResumeUrl: '' }), 'BLIND')).toBeNull();
+  });
+
+  it('refuses a member resume for a BLIND client', () => {
+    expect(resolveResumeSource(memberAssignment(), 'BLIND')).toBeNull();
+  });
+
+  it('returns the local path for a member resume at BASIC and FULL', () => {
+    expect(resolveResumeSource(memberAssignment(), 'BASIC')).toEqual({
+      kind: 'local',
+      storagePath: 'member-resumes/mr-1/resume.pdf'
+    });
+  });
+
+  it('returns null for an assignment with neither target', () => {
+    expect(resolveResumeSource({ id: 'x' }, 'FULL')).toBeNull();
+    expect(isViewable({ id: 'x' }, 'FULL')).toBe(false);
+  });
+});
+
+describe('searchableFields', () => {
+  it('excludes names under BLIND so result counts cannot become a name oracle', () => {
+    const fields = searchableFields('BLIND');
+    expect(fields).not.toContain('firstName');
+    expect(fields).not.toContain('lastName');
+    expect(fields).toContain('major1');
+  });
+
+  it('includes names once identity is already visible', () => {
+    for (const visibility of ['BASIC', 'FULL']) {
+      expect(searchableFields(visibility)).toContain('firstName');
+    }
+  });
+});

--- a/server/src/utils/clientVisibility.test.js
+++ b/server/src/utils/clientVisibility.test.js
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   projectAssignment,
   resolveResumeSource,
+  extractDriveFileId,
   isViewable,
   searchableFields,
   pdfUrlForAssignment,
@@ -10,6 +11,13 @@ import {
 
 const DRIVE_REAL = 'drive-file-id-real-resume';
 const DRIVE_BLIND = 'drive-file-id-blind-resume';
+
+// The fixtures store what the database actually stores. Application.resumeUrl
+// is a proxy URL wrapping the Drive id, never the bare id - an earlier version
+// of these fixtures used bare ids, which let a bug that handed the whole URL to
+// the Drive SDK pass every test and 500 in the browser.
+const RESUME_URL_REAL = `/api/files/${DRIVE_REAL}/pdf`;
+const RESUME_URL_BLIND = `/api/files/${DRIVE_BLIND}/pdf`;
 
 const applicantAssignment = (overrides = {}) => ({
   id: 'assign-1',
@@ -27,8 +35,8 @@ const applicantAssignment = (overrides = {}) => ({
     gender: 'Female',
     cumulativeGpa: '3.85',
     majorGpa: '3.92',
-    resumeUrl: DRIVE_REAL,
-    blindResumeUrl: DRIVE_BLIND,
+    resumeUrl: RESUME_URL_REAL,
+    blindResumeUrl: RESUME_URL_BLIND,
     ...overrides
   },
   memberResume: null
@@ -138,6 +146,39 @@ describe('projectAssignment - BASIC and FULL', () => {
     expect(dto.lastName).toBe('Rivera Cruz');
     expect(dto.phoneNumber).toBeNull();
     expect(dto.cumulativeGpa).toBeNull();
+  });
+});
+
+describe('extractDriveFileId', () => {
+  // Both shapes below are present in the production database today; handing
+  // either one to the Drive SDK unchanged is a 500.
+  it('unwraps the proxy URL shapes the sync actually writes', () => {
+    expect(extractDriveFileId('/api/files/1AbC_def-123/pdf')).toBe('1AbC_def-123');
+    expect(extractDriveFileId('https://uconsultingats.com/api/files/1AbC_def-123/pdf')).toBe(
+      '1AbC_def-123'
+    );
+  });
+
+  it('unwraps a hand-pasted Drive share link', () => {
+    expect(extractDriveFileId('https://drive.google.com/file/d/1AbC_def/view?usp=sharing')).toBe(
+      '1AbC_def'
+    );
+    expect(extractDriveFileId('https://drive.google.com/open?id=1AbC_def')).toBe('1AbC_def');
+  });
+
+  it('passes a bare id through', () => {
+    expect(extractDriveFileId('1AbC_def-1234567890')).toBe('1AbC_def-1234567890');
+  });
+
+  it('returns null rather than guessing at something unusable', () => {
+    for (const value of ['', '   ', null, undefined, 42, {}, 'not a url']) {
+      expect(extractDriveFileId(value)).toBeNull();
+    }
+  });
+
+  it('drives isViewable, so an unparseable URL reads as not available', () => {
+    expect(isViewable(applicantAssignment({ resumeUrl: 'not a url' }), 'BASIC')).toBe(false);
+    expect(isViewable(applicantAssignment(), 'BASIC')).toBe(true);
   });
 });
 

--- a/server/src/utils/memberResume.js
+++ b/server/src/utils/memberResume.js
@@ -1,0 +1,88 @@
+// Validation for a member-uploaded resume. Pure, in the style of
+// utils/gtkucProfile.js, so the route stays thin and the rules are testable.
+
+// Same vocabulary the application form produces, so the two pools filter alike.
+// "Prefer not to say" is stored as null rather than as a value nobody filters on.
+export const MEMBER_GENDERS = ['Male', 'Female', 'Other'];
+
+export const MAJOR_MAX_LENGTH = 120;
+
+// Application.graduationYear is a 4-digit string ("2029"). User.graduationClass
+// is free text ("Spring 2027"), which is why this is collected fresh at upload
+// rather than derived - the two would not filter alike.
+const YEAR_PATTERN = /^(19|20)\d{2}$/;
+
+const trimmed = (value, max) => {
+  if (value === null || value === undefined) return '';
+  return String(value).trim().slice(0, max);
+};
+
+/**
+ * Normalize and validate the metadata that accompanies a resume upload.
+ * Returns { value, errors }.
+ */
+export const sanitizeMemberResumeInput = (input = {}) => {
+  const errors = [];
+
+  const major1 = trimmed(input.major1, MAJOR_MAX_LENGTH);
+  const major2 = trimmed(input.major2, MAJOR_MAX_LENGTH);
+  const graduationYear = trimmed(input.graduationYear, 4);
+  const genderRaw = trimmed(input.gender, 40);
+
+  if (!major1) {
+    errors.push('Enter your major.');
+  }
+
+  if (!YEAR_PATTERN.test(graduationYear)) {
+    errors.push('Enter your graduation year as four digits, for example 2027.');
+  }
+
+  let gender = null;
+  if (genderRaw) {
+    const match = MEMBER_GENDERS.find((g) => g.toLowerCase() === genderRaw.toLowerCase());
+    if (!match) {
+      errors.push(`Gender must be one of: ${MEMBER_GENDERS.join(', ')}.`);
+    } else {
+      gender = match;
+    }
+  }
+
+  // Consent is only ever true when explicitly and unambiguously given.
+  // A missing or unparseable value means no.
+  const shareConsent = input.shareConsent === true || input.shareConsent === 'true';
+
+  return {
+    value: {
+      major1,
+      major2: major2 || null,
+      graduationYear,
+      gender,
+      shareConsent
+    },
+    errors
+  };
+};
+
+/**
+ * The row shape the member portal renders. Deliberately excludes storagePath -
+ * the member reads their own file through the endpoint, not by path.
+ */
+export const serializeMemberResume = (resume, assignedCount = 0) => {
+  if (!resume) return null;
+  return {
+    id: resume.id,
+    originalName: resume.originalName,
+    fileSize: resume.fileSize,
+    major1: resume.major1,
+    major2: resume.major2,
+    graduationYear: resume.graduationYear,
+    gender: resume.gender,
+    shareConsent: resume.shareConsent,
+    consentAt: resume.consentAt,
+    consentRevokedAt: resume.consentRevokedAt,
+    uploadedAt: resume.createdAt,
+    updatedAt: resume.updatedAt,
+    // So a member can see that their resume is actually out with partners.
+    assignedCount
+  };
+};

--- a/server/src/utils/talentPoolFilters.js
+++ b/server/src/utils/talentPoolFilters.js
@@ -1,0 +1,324 @@
+// Translates the admin assignment filter into Prisma where clauses, for both
+// the applicant pool (Application) and the member pool (MemberResume).
+//
+// Pure on purpose - no prisma import - so the consent gates and the
+// "never match everything" guards below are unit-testable without a database.
+// Same shape as utils/gtkucProfile.js: exported constants plus a sanitizer that
+// returns { value, errors } and leaves the route thin.
+//
+// Shape of the DSL:
+//   { pool: 'APPLICANTS' | 'MEMBERS' | 'BOTH',
+//     rows: [ { field: 'graduationYear', values: ['2029', '2030'] },
+//             { field: 'cumulativeGpa',  op: 'gte', value: '3.50' },
+//             { field: 'isFirstGeneration', value: true } ] }
+//
+// Rows AND together. Values within a row OR. One field per row - that is the
+// whole grammar, and it is what the builder UI produces.
+
+export const POOLS = ['APPLICANTS', 'MEMBERS', 'BOTH'];
+
+export const APPLICATION_STATUSES = [
+  'SUBMITTED',
+  'UNDER_REVIEW',
+  'ACCEPTED',
+  'REJECTED',
+  'WAITLISTED'
+];
+
+// `pool: 'both'` means the field exists on applicants and on member resumes.
+// `applicants` fields have no member equivalent - a filter using one cannot
+// match any member resume, which buildMemberResumeWhere reports rather than
+// silently returning zero rows.
+export const FILTER_FIELDS = [
+  { key: 'graduationYear', label: 'Graduation year', pool: 'both', type: 'multiText' },
+  { key: 'gender', label: 'Gender', pool: 'both', type: 'multiText' },
+  { key: 'major', label: 'Major', pool: 'both', type: 'multiText' },
+  { key: 'cycleId', label: 'Recruiting cycle', pool: 'applicants', type: 'multiId' },
+  { key: 'status', label: 'Application status', pool: 'applicants', type: 'multiId' },
+  { key: 'cumulativeGpa', label: 'Cumulative GPA', pool: 'applicants', type: 'number' },
+  { key: 'majorGpa', label: 'Major GPA', pool: 'applicants', type: 'number' },
+  { key: 'isFirstGeneration', label: 'First-generation', pool: 'applicants', type: 'bool' },
+  { key: 'isTransferStudent', label: 'Transfer student', pool: 'applicants', type: 'bool' }
+];
+
+const FIELD_BY_KEY = new Map(FILTER_FIELDS.map((f) => [f.key, f]));
+
+export const NUMBER_OPS = ['gte', 'lte'];
+
+// The preview never renders more than this, and a commit never accepts more.
+// A runaway filter therefore cannot quietly hand a client thousands of resumes.
+export const PREVIEW_CAP = 500;
+
+const isPlainObject = (v) => typeof v === 'object' && v !== null && !Array.isArray(v);
+
+const cleanStrings = (values) => {
+  if (!Array.isArray(values)) return [];
+  const seen = new Set();
+  const out = [];
+  for (const raw of values) {
+    if (raw === null || raw === undefined) continue;
+    const s = String(raw).trim();
+    if (!s) continue;
+    const key = s.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(s);
+  }
+  return out;
+};
+
+// Decimal columns are compared as strings. Passing a JS float here would let
+// binary rounding decide who is in a GPA cut-off.
+const cleanDecimal = (value) => {
+  if (value === null || value === undefined) return null;
+  const s = String(value).trim();
+  if (!/^\d{1,2}(\.\d{1,2})?$/.test(s)) return null;
+  return s;
+};
+
+/**
+ * Normalize and validate raw filter input from the admin UI.
+ * Returns { value: { pool, rows }, errors: string[] }.
+ *
+ * An empty or fully-invalid row set is an ERROR, never "match everything" -
+ * see the guard note on buildApplicantWhere.
+ */
+export const sanitizeFilterDsl = (input) => {
+  const errors = [];
+  const raw = isPlainObject(input) ? input : {};
+
+  const pool = POOLS.includes(raw.pool) ? raw.pool : 'APPLICANTS';
+
+  const rawRows = Array.isArray(raw.rows) ? raw.rows : [];
+  const rows = [];
+  const usedFields = new Set();
+
+  for (const rawRow of rawRows) {
+    if (!isPlainObject(rawRow)) continue;
+
+    const field = FIELD_BY_KEY.get(rawRow.field);
+    if (!field) {
+      if (rawRow.field) errors.push(`Unknown filter field "${rawRow.field}" was ignored.`);
+      continue;
+    }
+
+    if (usedFields.has(field.key)) {
+      errors.push(`"${field.label}" appears more than once - only the first was used.`);
+      continue;
+    }
+
+    if (field.type === 'multiText' || field.type === 'multiId') {
+      const values = cleanStrings(rawRow.values);
+      if (values.length === 0) {
+        errors.push(`Select at least one value for "${field.label}".`);
+        continue;
+      }
+      if (field.key === 'status') {
+        const bad = values.filter((v) => !APPLICATION_STATUSES.includes(v));
+        if (bad.length > 0) {
+          errors.push(`Unknown application status: ${bad.join(', ')}.`);
+          continue;
+        }
+      }
+      rows.push({ field: field.key, values });
+      usedFields.add(field.key);
+      continue;
+    }
+
+    if (field.type === 'number') {
+      const op = NUMBER_OPS.includes(rawRow.op) ? rawRow.op : 'gte';
+      const value = cleanDecimal(rawRow.value);
+      if (value === null) {
+        errors.push(`"${field.label}" needs a number like 3.50.`);
+        continue;
+      }
+      rows.push({ field: field.key, op, value });
+      usedFields.add(field.key);
+      continue;
+    }
+
+    if (field.type === 'bool') {
+      if (typeof rawRow.value !== 'boolean') {
+        errors.push(`"${field.label}" needs a yes or no.`);
+        continue;
+      }
+      rows.push({ field: field.key, value: rawRow.value });
+      usedFields.add(field.key);
+    }
+  }
+
+  if (rows.length === 0) {
+    // Deliberately an error. "No filter" must never be read as "every resume":
+    // that is the one mistake in this feature that cannot be walked back once a
+    // client has seen the rows.
+    errors.push('Add at least one filter before previewing.');
+  }
+
+  return { value: { pool, rows }, errors };
+};
+
+// Prisma's `in` has no case-insensitive mode, and both gender and major are
+// free text off a Google Form ("Female" / "female"). An OR of case-insensitive
+// equals is the only way to match them reliably.
+const anyOf = (column, values) => ({
+  OR: values.map((v) => ({ [column]: { equals: v, mode: 'insensitive' } }))
+});
+
+const majorAnyOf = (values) => ({
+  OR: values.flatMap((v) => [
+    { major1: { equals: v, mode: 'insensitive' } },
+    { major2: { equals: v, mode: 'insensitive' } }
+  ])
+});
+
+/**
+ * Build the Prisma where clause for the applicant pool.
+ *
+ * @returns {{ where: object|null, notes: string[] }} where is null when the
+ * filter cannot match any applicant.
+ */
+export const buildApplicantWhere = (dsl, { visibility = 'BLIND', activeCycleId = null } = {}) => {
+  const notes = [];
+  const rows = dsl?.rows ?? [];
+
+  if (dsl?.pool === 'MEMBERS') {
+    return { where: null, notes };
+  }
+
+  // Non-negotiable base predicates. These are not admin-controllable and are
+  // ANDed onto whatever the filter says.
+  const AND = [
+    // The consent record. An applicant who answered No, and every Fall 2025
+    // applicant who was never asked (null), is never assignable.
+    { talentPoolOptIn: true },
+    { resumeUrl: { not: '' } }
+  ];
+
+  if (visibility === 'BLIND') {
+    // A BLIND client is only ever served blindResumeUrl, so an application
+    // without one is not assignable to them at all.
+    AND.push({ blindResumeUrl: { not: null } });
+    AND.push({ blindResumeUrl: { not: '' } });
+  }
+
+  let sawCycleRow = false;
+
+  for (const row of rows) {
+    switch (row.field) {
+      case 'graduationYear':
+        AND.push(anyOf('graduationYear', row.values));
+        break;
+      case 'gender':
+        AND.push(anyOf('gender', row.values));
+        break;
+      case 'major':
+        AND.push(majorAnyOf(row.values));
+        break;
+      case 'cycleId':
+        AND.push({ cycleId: { in: row.values } });
+        sawCycleRow = true;
+        break;
+      case 'status':
+        AND.push({ status: { in: row.values } });
+        break;
+      case 'cumulativeGpa':
+      case 'majorGpa':
+        AND.push({ [row.field]: { [row.op]: row.value } });
+        break;
+      case 'isFirstGeneration':
+      case 'isTransferStudent':
+        AND.push({ [row.field]: row.value });
+        break;
+      default:
+        break;
+    }
+  }
+
+  // Without an explicit cycle row, scope to the active cycle rather than every
+  // application ever submitted - and say so, so the admin can add an explicit
+  // "all cycles" row if that is what they meant.
+  if (!sawCycleRow && activeCycleId) {
+    AND.push({ cycleId: activeCycleId });
+    notes.push('Limited to the active recruiting cycle. Add a cycle filter to widen it.');
+  }
+
+  return { where: { AND }, notes };
+};
+
+/**
+ * Build the Prisma where clause for the member resume pool.
+ *
+ * @returns {{ where: object|null, notes: string[] }} where is null when the
+ * filter cannot match any member resume - which the caller must surface rather
+ * than rendering an empty result as "nothing matched".
+ */
+export const buildMemberResumeWhere = (dsl, { visibility = 'BLIND' } = {}) => {
+  const notes = [];
+  const rows = dsl?.rows ?? [];
+
+  if (dsl?.pool === 'APPLICANTS') {
+    return { where: null, notes };
+  }
+
+  if (visibility === 'BLIND') {
+    // Applications carry a separately redacted blindResumeUrl. A member uploads
+    // one file and there is no redacted variant of it, so there is nothing a
+    // BLIND client could safely be shown.
+    notes.push('Member resumes have no redacted version, so they cannot be assigned to a blind-visibility client.');
+    return { where: null, notes };
+  }
+
+  const AND = [
+    { isCurrent: true },
+    { shareConsent: true },
+    { consentRevokedAt: null }
+  ];
+
+  const unsupported = [];
+
+  for (const row of rows) {
+    switch (row.field) {
+      case 'graduationYear':
+        AND.push(anyOf('graduationYear', row.values));
+        break;
+      case 'gender':
+        AND.push(anyOf('gender', row.values));
+        break;
+      case 'major':
+        AND.push(majorAnyOf(row.values));
+        break;
+      default: {
+        const field = FIELD_BY_KEY.get(row.field);
+        if (field) unsupported.push(field.label);
+        break;
+      }
+    }
+  }
+
+  if (unsupported.length > 0) {
+    // Naming the field matters. Silently returning zero members when an
+    // applicant-only filter is in play reads as "no members matched", which is
+    // a different and wrong conclusion.
+    notes.push(
+      `Member resumes do not record ${unsupported.join(', ')}, so no member resume can match this filter.`
+    );
+    return { where: null, notes };
+  }
+
+  return { where: { AND }, notes };
+};
+
+// Assignment keys are opaque to the client UI and are what a commit sends back.
+export const ASSIGNMENT_KEY_KINDS = ['APPLICATION', 'MEMBER_RESUME'];
+
+export const buildAssignmentKey = (kind, id) => `${kind}:${id}`;
+
+export const parseAssignmentKey = (key) => {
+  if (typeof key !== 'string') return null;
+  const idx = key.indexOf(':');
+  if (idx <= 0) return null;
+  const kind = key.slice(0, idx);
+  const id = key.slice(idx + 1).trim();
+  if (!ASSIGNMENT_KEY_KINDS.includes(kind) || !id) return null;
+  return { kind, id };
+};

--- a/server/src/utils/talentPoolFilters.js
+++ b/server/src/utils/talentPoolFilters.js
@@ -182,25 +182,30 @@ export const buildApplicantWhere = (dsl, { visibility = 'BLIND', activeCycleId =
   const rows = dsl?.rows ?? [];
 
   if (dsl?.pool === 'MEMBERS') {
-    return { where: null, notes };
+    return { where: null, filterOnlyWhere: null, gateClauses: [], notes };
   }
 
-  // Non-negotiable base predicates. These are not admin-controllable and are
-  // ANDed onto whatever the filter says.
-  const AND = [
+  // Clauses that come from the admin's filter, kept separate from the consent
+  // gates so the preview can count what each gate excluded and say so. Only
+  // `where` below is ever used to select rows for assignment - `filterOnlyWhere`
+  // exists to answer "how many did consent remove?" and nothing else.
+  const filterClauses = [{ resumeUrl: { not: '' } }];
+
+  // Non-negotiable gates. Not admin-controllable.
+  const gateClauses = [
     // The consent record. An applicant who answered No, and every Fall 2025
     // applicant who was never asked (null), is never assignable.
-    { talentPoolOptIn: true },
-    { resumeUrl: { not: '' } }
+    { talentPoolOptIn: true }
   ];
 
   if (visibility === 'BLIND') {
     // A BLIND client is only ever served blindResumeUrl, so an application
     // without one is not assignable to them at all.
-    AND.push({ blindResumeUrl: { not: null } });
-    AND.push({ blindResumeUrl: { not: '' } });
+    gateClauses.push({ blindResumeUrl: { not: null } });
+    gateClauses.push({ blindResumeUrl: { not: '' } });
   }
 
+  const AND = filterClauses;
   let sawCycleRow = false;
 
   for (const row of rows) {
@@ -242,7 +247,12 @@ export const buildApplicantWhere = (dsl, { visibility = 'BLIND', activeCycleId =
     notes.push('Limited to the active recruiting cycle. Add a cycle filter to widen it.');
   }
 
-  return { where: { AND }, notes };
+  return {
+    where: { AND: [...gateClauses, ...filterClauses] },
+    filterOnlyWhere: { AND: [...filterClauses] },
+    gateClauses,
+    notes
+  };
 };
 
 /**
@@ -257,7 +267,7 @@ export const buildMemberResumeWhere = (dsl, { visibility = 'BLIND' } = {}) => {
   const rows = dsl?.rows ?? [];
 
   if (dsl?.pool === 'APPLICANTS') {
-    return { where: null, notes };
+    return { where: null, filterOnlyWhere: null, gateClauses: [], notes };
   }
 
   if (visibility === 'BLIND') {
@@ -265,15 +275,13 @@ export const buildMemberResumeWhere = (dsl, { visibility = 'BLIND' } = {}) => {
     // one file and there is no redacted variant of it, so there is nothing a
     // BLIND client could safely be shown.
     notes.push('Member resumes have no redacted version, so they cannot be assigned to a blind-visibility client.');
-    return { where: null, notes };
+    return { where: null, filterOnlyWhere: null, gateClauses: [], notes };
   }
 
-  const AND = [
-    { isCurrent: true },
-    { shareConsent: true },
-    { consentRevokedAt: null }
-  ];
+  const filterClauses = [{ isCurrent: true }];
+  const gateClauses = [{ shareConsent: true }, { consentRevokedAt: null }];
 
+  const AND = filterClauses;
   const unsupported = [];
 
   for (const row of rows) {
@@ -302,10 +310,15 @@ export const buildMemberResumeWhere = (dsl, { visibility = 'BLIND' } = {}) => {
     notes.push(
       `Member resumes do not record ${unsupported.join(', ')}, so no member resume can match this filter.`
     );
-    return { where: null, notes };
+    return { where: null, filterOnlyWhere: null, gateClauses: [], notes };
   }
 
-  return { where: { AND }, notes };
+  return {
+    where: { AND: [...gateClauses, ...filterClauses] },
+    filterOnlyWhere: { AND: [...filterClauses] },
+    gateClauses,
+    notes
+  };
 };
 
 // Assignment keys are opaque to the client UI and are what a commit sends back.

--- a/server/src/utils/talentPoolFilters.test.js
+++ b/server/src/utils/talentPoolFilters.test.js
@@ -1,0 +1,246 @@
+import { describe, it, expect } from 'vitest';
+import {
+  sanitizeFilterDsl,
+  buildApplicantWhere,
+  buildMemberResumeWhere,
+  parseAssignmentKey,
+  buildAssignmentKey,
+  PREVIEW_CAP
+} from './talentPoolFilters.js';
+
+const dsl = (rows, pool = 'APPLICANTS') => ({ pool, rows });
+
+// Pull the predicate for a given column out of the AND array.
+const findClause = (where, predicate) => where.AND.find(predicate);
+
+describe('sanitizeFilterDsl', () => {
+  it('keeps a well-formed multi-value row and dedupes case-insensitively', () => {
+    const { value, errors } = sanitizeFilterDsl({
+      pool: 'BOTH',
+      rows: [{ field: 'graduationYear', values: ['2029', ' 2030 ', '2029'] }]
+    });
+    expect(errors).toEqual([]);
+    expect(value.pool).toBe('BOTH');
+    expect(value.rows).toEqual([{ field: 'graduationYear', values: ['2029', '2030'] }]);
+  });
+
+  it('errors rather than matching everything when there are no rows', () => {
+    const { value, errors } = sanitizeFilterDsl({ pool: 'APPLICANTS', rows: [] });
+    expect(value.rows).toEqual([]);
+    expect(errors).toContain('Add at least one filter before previewing.');
+  });
+
+  it('errors when every row is an unknown field, instead of falling back to an empty filter', () => {
+    const { value, errors } = sanitizeFilterDsl({
+      rows: [{ field: 'salaryExpectation', values: ['high'] }]
+    });
+    expect(value.rows).toEqual([]);
+    expect(errors).toContain('Add at least one filter before previewing.');
+    expect(errors.some((e) => e.includes('salaryExpectation'))).toBe(true);
+  });
+
+  it('rejects a garbage GPA rather than coercing it', () => {
+    const { errors } = sanitizeFilterDsl({
+      rows: [{ field: 'cumulativeGpa', op: 'gte', value: 'four point oh' }]
+    });
+    expect(errors.some((e) => e.includes('Cumulative GPA'))).toBe(true);
+  });
+
+  it('keeps GPA as a string so binary rounding never decides a cut-off', () => {
+    const { value } = sanitizeFilterDsl({
+      rows: [{ field: 'cumulativeGpa', op: 'gte', value: 3.5 }]
+    });
+    expect(value.rows[0]).toEqual({ field: 'cumulativeGpa', op: 'gte', value: '3.5' });
+    expect(typeof value.rows[0].value).toBe('string');
+  });
+
+  it('rejects an unknown application status', () => {
+    const { errors } = sanitizeFilterDsl({
+      rows: [{ field: 'status', values: ['PROMOTED'] }]
+    });
+    expect(errors.some((e) => e.includes('PROMOTED'))).toBe(true);
+  });
+
+  it('requires a real boolean for boolean fields', () => {
+    const { errors } = sanitizeFilterDsl({
+      rows: [{ field: 'isFirstGeneration', value: 'yes' }]
+    });
+    expect(errors.some((e) => e.includes('First-generation'))).toBe(true);
+  });
+
+  it('ignores a duplicated field rather than silently ANDing two of them', () => {
+    const { value, errors } = sanitizeFilterDsl({
+      rows: [
+        { field: 'gender', values: ['Female'] },
+        { field: 'gender', values: ['Male'] }
+      ]
+    });
+    expect(value.rows).toHaveLength(1);
+    expect(value.rows[0].values).toEqual(['Female']);
+    expect(errors.some((e) => e.includes('more than once'))).toBe(true);
+  });
+});
+
+describe('buildApplicantWhere - consent is not optional', () => {
+  it('always requires talentPoolOptIn true', () => {
+    const { where } = buildApplicantWhere(dsl([{ field: 'gender', values: ['Female'] }]));
+    expect(where.AND).toContainEqual({ talentPoolOptIn: true });
+  });
+
+  it('requires it even when the filter mentions nothing else', () => {
+    const { where } = buildApplicantWhere(dsl([{ field: 'graduationYear', values: ['2030'] }]));
+    expect(where.AND).toContainEqual({ talentPoolOptIn: true });
+    expect(where.AND).toContainEqual({ resumeUrl: { not: '' } });
+  });
+
+  it('additionally requires a blind resume for a BLIND client', () => {
+    const { where } = buildApplicantWhere(dsl([{ field: 'gender', values: ['Female'] }]), {
+      visibility: 'BLIND'
+    });
+    expect(where.AND).toContainEqual({ blindResumeUrl: { not: null } });
+    expect(where.AND).toContainEqual({ blindResumeUrl: { not: '' } });
+  });
+
+  it('does not require a blind resume for BASIC or FULL', () => {
+    for (const visibility of ['BASIC', 'FULL']) {
+      const { where } = buildApplicantWhere(dsl([{ field: 'gender', values: ['Female'] }]), {
+        visibility
+      });
+      expect(where.AND).not.toContainEqual({ blindResumeUrl: { not: null } });
+    }
+  });
+});
+
+describe('buildApplicantWhere - field mapping', () => {
+  it('ORs values within a row, case-insensitively, because gender is free-form form text', () => {
+    const { where } = buildApplicantWhere(dsl([{ field: 'gender', values: ['Female', 'Other'] }]));
+    const clause = findClause(where, (c) => c.OR?.[0]?.gender);
+    expect(clause).toEqual({
+      OR: [
+        { gender: { equals: 'Female', mode: 'insensitive' } },
+        { gender: { equals: 'Other', mode: 'insensitive' } }
+      ]
+    });
+  });
+
+  it('expands a major row across major1 and major2', () => {
+    const { where } = buildApplicantWhere(dsl([{ field: 'major', values: ['Economics'] }]));
+    const clause = findClause(where, (c) => c.OR?.some((o) => o.major1 || o.major2));
+    expect(clause.OR).toEqual([
+      { major1: { equals: 'Economics', mode: 'insensitive' } },
+      { major2: { equals: 'Economics', mode: 'insensitive' } }
+    ]);
+  });
+
+  it('ANDs separate rows together', () => {
+    const { where } = buildApplicantWhere(
+      dsl([
+        { field: 'graduationYear', values: ['2030'] },
+        { field: 'gender', values: ['Female'] },
+        { field: 'cumulativeGpa', op: 'gte', value: '3.50' }
+      ])
+    );
+    expect(where.AND).toContainEqual({ cumulativeGpa: { gte: '3.50' } });
+    expect(where.AND.filter((c) => c.OR).length).toBe(2);
+  });
+
+  it('passes booleans through as equality', () => {
+    const { where } = buildApplicantWhere(dsl([{ field: 'isFirstGeneration', value: true }]));
+    expect(where.AND).toContainEqual({ isFirstGeneration: true });
+  });
+
+  it('defaults to the active cycle and says so when no cycle row is given', () => {
+    const { where, notes } = buildApplicantWhere(dsl([{ field: 'gender', values: ['Female'] }]), {
+      activeCycleId: 'cycle-1'
+    });
+    expect(where.AND).toContainEqual({ cycleId: 'cycle-1' });
+    expect(notes.join(' ')).toMatch(/active recruiting cycle/i);
+  });
+
+  it('respects an explicit cycle row and drops the default', () => {
+    const { where, notes } = buildApplicantWhere(
+      dsl([{ field: 'cycleId', values: ['cycle-a', 'cycle-b'] }]),
+      { activeCycleId: 'cycle-1' }
+    );
+    expect(where.AND).toContainEqual({ cycleId: { in: ['cycle-a', 'cycle-b'] } });
+    expect(where.AND).not.toContainEqual({ cycleId: 'cycle-1' });
+    expect(notes).toEqual([]);
+  });
+
+  it('matches nothing when the pool is members-only', () => {
+    const { where } = buildApplicantWhere(dsl([{ field: 'gender', values: ['Female'] }], 'MEMBERS'));
+    expect(where).toBeNull();
+  });
+});
+
+describe('buildMemberResumeWhere', () => {
+  it('always requires current, consented, non-withdrawn rows', () => {
+    const { where } = buildMemberResumeWhere(
+      dsl([{ field: 'gender', values: ['Female'] }], 'MEMBERS'),
+      { visibility: 'BASIC' }
+    );
+    expect(where.AND).toContainEqual({ isCurrent: true });
+    expect(where.AND).toContainEqual({ shareConsent: true });
+    expect(where.AND).toContainEqual({ consentRevokedAt: null });
+  });
+
+  it('matches nothing for a BLIND client and explains why', () => {
+    const { where, notes } = buildMemberResumeWhere(
+      dsl([{ field: 'gender', values: ['Female'] }], 'MEMBERS'),
+      { visibility: 'BLIND' }
+    );
+    expect(where).toBeNull();
+    expect(notes.join(' ')).toMatch(/no redacted version/i);
+  });
+
+  it('names the applicant-only field instead of silently returning zero members', () => {
+    const { where, notes } = buildMemberResumeWhere(
+      dsl(
+        [
+          { field: 'gender', values: ['Female'] },
+          { field: 'cumulativeGpa', op: 'gte', value: '3.50' }
+        ],
+        'BOTH'
+      ),
+      { visibility: 'FULL' }
+    );
+    expect(where).toBeNull();
+    expect(notes.join(' ')).toMatch(/Cumulative GPA/);
+    expect(notes.join(' ')).toMatch(/do not record/i);
+  });
+
+  it('matches nothing when the pool is applicants-only', () => {
+    const { where } = buildMemberResumeWhere(
+      dsl([{ field: 'gender', values: ['Female'] }], 'APPLICANTS'),
+      { visibility: 'FULL' }
+    );
+    expect(where).toBeNull();
+  });
+});
+
+describe('assignment keys', () => {
+  it('round-trips', () => {
+    expect(parseAssignmentKey(buildAssignmentKey('APPLICATION', 'abc-123'))).toEqual({
+      kind: 'APPLICATION',
+      id: 'abc-123'
+    });
+  });
+
+  it('survives an id containing a colon', () => {
+    expect(parseAssignmentKey('MEMBER_RESUME:a:b')).toEqual({ kind: 'MEMBER_RESUME', id: 'a:b' });
+  });
+
+  it('rejects unknown kinds, empty ids and non-strings', () => {
+    expect(parseAssignmentKey('USER:abc')).toBeNull();
+    expect(parseAssignmentKey('APPLICATION:')).toBeNull();
+    expect(parseAssignmentKey(':abc')).toBeNull();
+    expect(parseAssignmentKey(null)).toBeNull();
+    expect(parseAssignmentKey({ kind: 'APPLICATION' })).toBeNull();
+  });
+});
+
+describe('caps', () => {
+  it('bounds preview and commit size', () => {
+    expect(PREVIEW_CAP).toBe(500);
+  });
+});


### PR DESCRIPTION
Builds the missing half of the Talent Partner Network: a `CLIENT` user role with
its own minimal UI and a single page listing resumes an admin has explicitly
assigned, plus the admin tooling to create clients and assign resumes by filter.

Main already had the front half — `Application.talentPoolOptIn` on the application
form, and a read-only `/talent-pool` page whose "Registered clients" stat card was
a literal placeholder reading *"There is no client user role yet."* This fills that in.

## On consent

`talentPoolOptIn` is the consent record and this treats it as a hard gate, not a
default. An applicant resume is assignable **only** when they answered Yes.
Applicants who answered No, and the entire Fall 2025 cohort who were never asked
(`null`), are never assignable — 483 rows that stay permanently out of the pool.
Members get a parallel opt-in at upload, and withdrawing it revokes every live
assignment in the same transaction.

Against the live database that means **251 of 777 applications are assignable**.
The preview reports the exclusions rather than quietly narrowing the result.

## Scope

| Area | Decision |
|---|---|
| Vocabulary | Role `CLIENT`; admin UI as tabs on the existing `/talent-pool` page |
| Assignment | **Snapshot** — preview resolves the filter to rows, commit takes explicit ids and never re-runs the filter |
| Visibility | Per-client `BLIND` │ `BASIC` │ `FULL`, controlling the DTO |
| Login | Admin-set password, no self-signup, no password reset |
| Downloads | View-only inline stream; no download control, no Drive id ever leaves the server |
| Filters | Rows AND together, values within a row OR |
| Revocation | Soft, matching the `deactivatedAt` house convention |
| Account expiry | None — reuses `User.isActive` |

## Containment

A `CLIENT` bearer token must reach nothing but the portal. Route files including
`candidate.js`, `public.js`, `files.js`, and `users.js` mount bare `requireAuth`
with no role gate, so patching per-file would be a denylist by omission — the next
route file added is a hole, and nothing fails when it appears.

One global middleware instead (`externalContainment.js`), mounted before the route
mounts. It falls through to `next()` for anything that is not a confirmed CLIENT,
so **a 401 never becomes a 403**, and allows only `/api/client/*` plus login,
verify, and health. It shares `requireAuth`'s existing user cache via an extracted
`resolveUserFromRequest`, so the cost for existing roles is zero extra queries.

The one hole it cannot close is `POST /api/auth/forgot-password`, which is
unauthenticated and so has no role to check — guarded inside the handler, which
returns the same generic response for a CLIENT without minting a token.

## Three constraints Prisma cannot express

Written as SQL, each with a `// NOTE:` at the corresponding model:

- **One live resume per member** — `CREATE UNIQUE INDEX ... ON member_resumes(memberId) WHERE isCurrent`. Re-uploading demotes the old row rather than mutating it; without this, "snapshot" is false for members.
- **No duplicate live assignment** — Postgres treats NULLs as distinct, so a plain UNIQUE over the two nullable target columns would not stop one. Partial indexes over live rows do, while leaving revoke-then-reassign legal.
- **Exactly one target** — `CHECK (num_nonnulls(applicationId, memberResumeId) = 1)`.

## Migrations

Two files, hand-written and re-runnable per CLAUDE.md, because `prisma migrate dev`
is broken in this repo (stale `DIRECT_URL` password). The enum value is split into
its own migration: Postgres forbids *using* a new enum value in the transaction that
added it, and while today's DDL doesn't reference the literal, the moment anyone adds
a `WHERE role = 'CLIENT'` backfill it would break confusingly.

**Already applied to the live Supabase instance** via the session-pooler recipe and
verified: `{ client_role: 1, portal_tables: 5, partial_unique_indexes: 3, check_constraint: 1 }`.

## Verification

Server **349 passing** (2 pre-existing `offerLetter` failures, unrelated — they
assert Supabase is *unconfigured* and fail whenever a real `.env` exists, in this
branch and on main alike). Client tests and `vite build` pass.

The security tests are the ones worth reading:

- `externalContainment.test.js` — a CLIENT token 403s across `/api/users`, `/api/files/*`, `/api/applications`, `/api/admin/*`, `/api/member/*`; ADMIN, MEMBER and USER tokens are unaffected on every one of those paths; no token still yields 401.
- `client.routes.test.js` — another client's `assignmentId` → 404 and `getFileStream` is never called; revoked → 404; BLIND with no redacted resume → 404 with the *non-blind* id never passed to Drive.
- `clientVisibility.test.js` — at every level, the serialized DTO contains no `resumeUrl`, no `/api/files/`, no `studentId`.
- `talentPoolAdmin.routes.test.js` — the snapshot test: a filter matching 10 plus `keys` of 2 creates exactly 2 assignments.

Verified end to end against the live database as a real CLIENT account: 250 assigned
resumes list and stream (a genuine 220KB PDF, `Content-Disposition: inline`,
`Cache-Control: no-store`), the JSON is clean of Drive ids and storage paths, an
unowned assignment id returns 404, and `/api/users` returns 403.

## Known limits, stated plainly

**"View-only" is deterrence, not prevention.** The blob is in the buyer's browser;
Ctrl+P and DevTools→Network still work. This buys friction and a log, not control.
If genuine prevention is ever contractually required, the answer is server-side
PDF→per-page images with a per-client watermark — `cases.js` already implements
exactly that pipeline. Worth telling the buyer plainly what this is.

**Fall 2025 applicants are permanently out of the pool** under strict opt-in, since
they were never asked. Re-asking them is a follow-up, deliberately out of scope.

**Two filter DSLs now exist** — `masterCommunications.js` has `resolveRecipients`
for messaging. Different vocabulary, different target; not worth unifying, but
worth knowing before someone assumes they're the same thing.

## Testing this by hand

One gotcha that will otherwise look like a bug: the active cycle (Fall 2026) has
**zero applications** — every opted-in applicant is in Winter 2026. The filter
defaults to the active cycle, so a default preview correctly returns 0 matches.
Add an explicit `Recruiting cycle = Winter 2026` row. The UI does say so, but it
is easy to miss.

`server/scripts/` carries read-only helpers for this: `tpn-testdata-report.mjs`
(what is assignable right now), `verify-tpn-schema.mjs`, `tpn-probe-pdf.mjs`
(resolves every assignment and pulls one file from Drive), and
`tpn-smoke-client.mjs <port>` (full portal round-trip including the leak checks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ADFrG5hKdBHUUWvte4aVKb
