### PR TITLE
Let existing applicants replace their resume

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,6 +116,7 @@ The system follows a **recruiting cycle-based workflow**:
 - `/api/applications` - Application CRUD and review
 - `/api/review-teams` - Review team management and scoring
 - `/api/files` - File upload/download via Google Drive
+- `/api/resume-uploads` - Candidate self-service resume replacement + version history
 - `/api/interview-resources` - Interview prep materials
 - `/api` (public) - Public endpoints (event RSVPs, meeting signups)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,6 +163,7 @@ The system follows a **recruiting cycle-based workflow**:
 - `/api/applications` - Application CRUD and review
 - `/api/review-teams` - Review team management and scoring
 - `/api/files` - File upload/download via Google Drive
+- `/api/resume-uploads` - Candidate self-service resume replacement + version history
 - `/api/interview-resources` - Interview prep materials
 - `/api` (public) - Public endpoints (event RSVPs, meeting signups)
 

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -36,6 +36,7 @@ import CandidateEvents from './pages/CandidateEvents';
 import MemberEvents from './pages/MemberEvents';
 import CandidateApplications from './pages/CandidateApplications';
 import CandidateGTKUC from './pages/CandidateGTKUC';
+import ApplicantInformation from './pages/ApplicantInformation';
 import InterviewPreparation from './pages/InterviewPreparation';
 import InterviewDetail from './pages/InterviewDetail';
 import CoffeeChatsPublic from './pages/CoffeeChatsPublic';
@@ -329,6 +330,15 @@ const AppRoutes = () => {
         }
       />
       
+      <Route
+        path="/applicant-information"
+        element={
+          <ProtectedRoute>
+            <ApplicantInformation />
+          </ProtectedRoute>
+        }
+      />
+
       <Route
         path="/interview-prep"
         element={

--- a/client/src/components/CandidateLayout.jsx
+++ b/client/src/components/CandidateLayout.jsx
@@ -11,6 +11,7 @@ import {
   AcademicCapIcon,
   LightBulbIcon,
   UserGroupIcon,
+  PencilSquareIcon,
 } from '@heroicons/react/24/outline';
 import UConsultingLogo from './UConsultingLogo';
 import FeatureRequestModal from './FeatureRequestModal';
@@ -38,6 +39,7 @@ const CandidateLayout = ({ children }) => {
   const navigation = [
     { name: 'Dashboard', href: '/', icon: HomeIcon },
     { name: 'Applications', href: '/applications', icon: DocumentTextIcon },
+    { name: 'Applicant Information', href: '/applicant-information', icon: PencilSquareIcon },
     { name: 'Events', href: '/events', icon: CalendarDaysIcon },
     { name: 'Get to Know UC', href: '/get-to-know-uc', icon: UserGroupIcon },
     { name: 'Recruitment Resources', href: '/interview-prep', icon: AcademicCapIcon },

--- a/client/src/components/DocumentGradingModal.jsx
+++ b/client/src/components/DocumentGradingModal.jsx
@@ -32,6 +32,7 @@ import {
 import { useAuth } from '../context/AuthContext';
 import { useIsMobile } from '../hooks/useResponsive';
 import apiClient from '../utils/api';
+import { toSameOriginDocumentUrl } from '../utils/documentUrl';
 
 const DocumentGradingModal = ({ open, onClose, application, documentType }) => {
   const { user, token } = useAuth();
@@ -251,15 +252,7 @@ const DocumentGradingModal = ({ open, onClose, application, documentType }) => {
 
       setPreviewLoading(true);
 
-      // Normalize URL: strip any localhost or production prefixes to make it relative
-      let fileUrl = documentUrl;
-      const prefixesToStrip = ['http://localhost:3001', 'http://localhost:5173', 'https://uconsultingats.com', 'https://www.uconsultingats.com'];
-      for (const prefix of prefixesToStrip) {
-        if (fileUrl.startsWith(prefix)) {
-          fileUrl = fileUrl.replace(prefix, '');
-          break;
-        }
-      }
+      const fileUrl = toSameOriginDocumentUrl(documentUrl);
 
       try {
         const resp = await fetch(fileUrl, {

--- a/client/src/components/DocumentPreviewModal.jsx
+++ b/client/src/components/DocumentPreviewModal.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState, useRef } from 'react';
-import apiClient from '../utils/api';
 import { useAuth } from '../context/AuthContext';
 import { useIsMobile } from '../hooks/useResponsive';
+import { toSameOriginDocumentUrl } from '../utils/documentUrl';
 
 const overlayStyle = {
   position: 'fixed',
@@ -43,8 +43,6 @@ export default function DocumentPreviewModal({ src, kind, title, onClose }) {
   const { token } = useAuth();
   const isMobile = useIsMobile();
   
-  console.log('DocumentPreviewModal props:', { src, kind, title, onClose });
-
   useEffect(() => {
     const onKey = (e) => {
       if (e.key === 'Escape') onClose?.();
@@ -57,21 +55,18 @@ export default function DocumentPreviewModal({ src, kind, title, onClose }) {
     let localUrl;
     const load = async () => {
       try {
-        console.log('Loading document from:', src);
-        console.log('Using token:', token ? 'Present' : 'Missing');
-        const resp = await fetch(src, {
+        const fetchUrl = toSameOriginDocumentUrl(src);
+        const resp = await fetch(fetchUrl, {
           headers: {
             Authorization: `Bearer ${token}`,
           },
         });
-        console.log('Fetch response:', resp.status, resp.statusText);
         if (!resp.ok) {
           const txt = await resp.text();
           console.error('Fetch error:', txt);
           throw new Error(`${resp.status} ${resp.statusText} - ${txt}`);
         }
         const blob = await resp.blob();
-        console.log('Blob created:', blob.size, 'bytes', 'type:', blob.type);
 
         localUrl = URL.createObjectURL(blob);
         setBlobUrl(localUrl);

--- a/client/src/components/ResumeReuploadSection.jsx
+++ b/client/src/components/ResumeReuploadSection.jsx
@@ -1,0 +1,182 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import apiClient from '../utils/api';
+
+const formatDateTime = (value) =>
+  new Date(value).toLocaleString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+
+const formatDeadline = (isoDeadline, label) => {
+  if (isoDeadline) {
+    return new Date(isoDeadline).toLocaleDateString('en-US', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    });
+  }
+  // Older cycles store the deadline as free text ("Oct 4th, Morning"); show it
+  // as written rather than pretending it is a date.
+  return label;
+};
+
+const formatSize = (bytes) => {
+  if (!bytes) return null;
+  const mb = bytes / (1024 * 1024);
+  return mb >= 0.1 ? `${mb.toFixed(1)} MB` : `${Math.max(1, Math.round(bytes / 1024))} KB`;
+};
+
+/**
+ * Lets an applicant swap in a new resume PDF for an application they already
+ * submitted, and shows every version that has been on the application so they
+ * can see exactly what reviewers are looking at.
+ *
+ * `onReplaced` is called with the new resume URL so the surrounding view can
+ * repoint its own "View Resume" link.
+ */
+export default function ResumeReuploadSection({ applicationId, onPreview, onReplaced }) {
+  const [state, setState] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState('');
+  const [file, setFile] = useState(null);
+  const [uploading, setUploading] = useState(false);
+  const [uploadError, setUploadError] = useState('');
+  const [confirmation, setConfirmation] = useState('');
+  const fileInputRef = useRef(null);
+
+  const load = useCallback(async () => {
+    try {
+      setLoading(true);
+      setLoadError('');
+      setState(await apiClient.get(`/resume-uploads/applications/${applicationId}`));
+    } catch (e) {
+      setLoadError(e.message || 'Failed to load your resume history');
+    } finally {
+      setLoading(false);
+    }
+  }, [applicationId]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const handleSelect = (event) => {
+    const selected = event.target.files?.[0] || null;
+    setUploadError('');
+    setConfirmation('');
+
+    if (selected && selected.type !== 'application/pdf') {
+      setFile(null);
+      setUploadError('Your resume must be a PDF.');
+      return;
+    }
+    if (selected && state?.maxBytes && selected.size > state.maxBytes) {
+      setFile(null);
+      setUploadError(`That file is larger than ${Math.round(state.maxBytes / (1024 * 1024))}MB.`);
+      return;
+    }
+    setFile(selected);
+  };
+
+  const handleUpload = async () => {
+    if (!file) return;
+    setUploading(true);
+    setUploadError('');
+    setConfirmation('');
+
+    try {
+      const body = new FormData();
+      body.append('resume', file);
+      const result = await apiClient.post(`/resume-uploads/applications/${applicationId}`, body);
+
+      setState((previous) => ({
+        ...previous,
+        currentResumeUrl: result.currentResumeUrl,
+        versions: result.versions,
+      }));
+      setConfirmation(result.message || 'Your resume has been updated.');
+      setFile(null);
+      if (fileInputRef.current) fileInputRef.current.value = '';
+      onReplaced?.(result.currentResumeUrl);
+    } catch (e) {
+      setUploadError(e.message || 'Failed to upload your resume');
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  if (loading) return <div className="resume-reupload"><p className="resume-reupload-note">Loading resume history…</p></div>;
+  if (loadError) return <div className="resume-reupload"><p className="resume-reupload-error">{loadError}</p></div>;
+  if (!state) return null;
+
+  const deadline = formatDeadline(state.deadline, state.deadlineLabel);
+  const versions = [...(state.versions || [])].reverse();
+
+  return (
+    <div className="resume-reupload">
+      <h5 className="resume-reupload-title">Replace your resume</h5>
+
+      {state.canReplace ? (
+        <>
+          <p className="resume-reupload-note">
+            Uploading a new PDF replaces the resume reviewers see. Your previous versions are kept below.
+            {deadline ? ` You can make changes until ${deadline}.` : ''}
+          </p>
+
+          <div className="resume-reupload-controls">
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept="application/pdf,.pdf"
+              onChange={handleSelect}
+              disabled={uploading}
+              aria-label="Choose a new resume PDF"
+            />
+            <button
+              type="button"
+              className="document-link"
+              onClick={handleUpload}
+              disabled={!file || uploading}
+            >
+              {uploading ? 'Uploading…' : 'Upload new resume'}
+            </button>
+          </div>
+        </>
+      ) : (
+        <p className="resume-reupload-note">{state.reason}</p>
+      )}
+
+      {uploadError && <p className="resume-reupload-error">{uploadError}</p>}
+      {confirmation && <p className="resume-reupload-success">{confirmation}</p>}
+
+      {versions.length > 0 && (
+        <ul className="resume-version-list">
+          {versions.map((version) => (
+            <li key={version.id || 'original'} className="resume-version">
+              <div className="resume-version-meta">
+                <span className="resume-version-label">
+                  {version.originalName || (version.replacedByCandidate ? 'Uploaded resume' : 'Submitted with your application')}
+                  {version.isCurrent && <span className="resume-version-current">Current</span>}
+                </span>
+                <span className="resume-version-date">
+                  {formatDateTime(version.uploadedAt)}
+                  {formatSize(version.sizeBytes) ? ` · ${formatSize(version.sizeBytes)}` : ''}
+                </span>
+              </div>
+              <button
+                type="button"
+                className="document-link"
+                onClick={() => onPreview?.(version.url, version.isCurrent ? 'Resume (current)' : 'Resume (previous version)')}
+              >
+                View
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/client/src/components/ResumeReuploadSection.jsx
+++ b/client/src/components/ResumeReuploadSection.jsx
@@ -117,8 +117,6 @@ export default function ResumeReuploadSection({ applicationId, onPreview, onRepl
 
   return (
     <div className="resume-reupload">
-      <h5 className="resume-reupload-title">Replace your resume</h5>
-
       {state.canReplace ? (
         <>
           <p className="resume-reupload-note">

--- a/client/src/components/ResumeReuploadSection.test.jsx
+++ b/client/src/components/ResumeReuploadSection.test.jsx
@@ -1,0 +1,127 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ResumeReuploadSection from './ResumeReuploadSection';
+import api from '../utils/api';
+
+vi.mock('../utils/api', () => ({
+  default: { get: vi.fn(), post: vi.fn() },
+}));
+
+const MAX_BYTES = 10 * 1024 * 1024;
+
+const openState = {
+  applicationId: 'app-1',
+  currentResumeUrl: '/api/files/drive-1/pdf',
+  maxBytes: MAX_BYTES,
+  canReplace: true,
+  reason: null,
+  deadline: '2026-10-04T23:59:59.999Z',
+  deadlineLabel: '2026-10-04',
+  versions: [
+    {
+      id: null,
+      url: '/api/files/drive-1/pdf',
+      originalName: null,
+      sizeBytes: null,
+      uploadedAt: '2026-09-01T12:00:00.000Z',
+      replacedByCandidate: false,
+      isCurrent: true,
+    },
+  ],
+};
+
+const pdf = (name = 'new-resume.pdf') =>
+  new File([new Uint8Array([0x25, 0x50, 0x44, 0x46, 0x2d])], name, { type: 'application/pdf' });
+
+describe('ResumeReuploadSection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    api.get.mockResolvedValue(openState);
+  });
+
+  it('offers an upload with the deadline spelled out when the window is open', async () => {
+    render(<ResumeReuploadSection applicationId="app-1" />);
+
+    await waitFor(() => expect(screen.getByText(/You can make changes until/)).toBeInTheDocument());
+    expect(screen.getByText(/October 4, 2026/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Upload new resume' })).toBeDisabled();
+    expect(screen.getByText('Current')).toBeInTheDocument();
+  });
+
+  it('explains why replacement is closed instead of showing a file picker', async () => {
+    api.get.mockResolvedValue({
+      ...openState,
+      canReplace: false,
+      reason: 'The resume deadline for Fall 2026 has passed.',
+    });
+
+    render(<ResumeReuploadSection applicationId="app-1" />);
+
+    await waitFor(() =>
+      expect(screen.getByText('The resume deadline for Fall 2026 has passed.')).toBeInTheDocument()
+    );
+    expect(screen.queryByLabelText('Choose a new resume PDF')).not.toBeInTheDocument();
+  });
+
+  it('uploads the chosen PDF and hands the new URL back to the parent', async () => {
+    const onReplaced = vi.fn();
+    api.post.mockResolvedValue({
+      message: 'Your resume has been updated.',
+      currentResumeUrl: '/api/resume-uploads/v2/file',
+      versions: [
+        { ...openState.versions[0], id: 'v1', isCurrent: false },
+        {
+          id: 'v2',
+          url: '/api/resume-uploads/v2/file',
+          originalName: 'new-resume.pdf',
+          sizeBytes: 1024,
+          uploadedAt: '2026-09-20T12:00:00.000Z',
+          replacedByCandidate: true,
+          isCurrent: true,
+        },
+      ],
+    });
+
+    render(<ResumeReuploadSection applicationId="app-1" onReplaced={onReplaced} />);
+    await waitFor(() => expect(screen.getByLabelText('Choose a new resume PDF')).toBeInTheDocument());
+
+    await userEvent.upload(screen.getByLabelText('Choose a new resume PDF'), pdf());
+    await userEvent.click(screen.getByRole('button', { name: 'Upload new resume' }));
+
+    await waitFor(() => expect(onReplaced).toHaveBeenCalledWith('/api/resume-uploads/v2/file'));
+    expect(api.post).toHaveBeenCalledWith('/resume-uploads/applications/app-1', expect.any(FormData));
+    expect(screen.getByText('Your resume has been updated.')).toBeInTheDocument();
+    expect(screen.getByText('new-resume.pdf')).toBeInTheDocument();
+  });
+
+  it('rejects a non-PDF before it reaches the server', async () => {
+    render(<ResumeReuploadSection applicationId="app-1" />);
+    await waitFor(() => expect(screen.getByLabelText('Choose a new resume PDF')).toBeInTheDocument());
+
+    // Fired directly rather than through userEvent.upload: that helper honours
+    // the `accept` attribute, but a real browser lets someone pick "All files"
+    // and hand the input anything, which is exactly what this guard is for.
+    fireEvent.change(screen.getByLabelText('Choose a new resume PDF'), {
+      target: { files: [new File(['x'], 'resume.png', { type: 'image/png' })] },
+    });
+
+    expect(screen.getByText('Your resume must be a PDF.')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Upload new resume' })).toBeDisabled();
+    expect(api.post).not.toHaveBeenCalled();
+  });
+
+  it('surfaces an upload failure without clearing the history', async () => {
+    api.post.mockRejectedValue(new Error('The resume deadline for Fall 2026 has passed. (Status: 403)'));
+
+    render(<ResumeReuploadSection applicationId="app-1" />);
+    await waitFor(() => expect(screen.getByLabelText('Choose a new resume PDF')).toBeInTheDocument());
+
+    await userEvent.upload(screen.getByLabelText('Choose a new resume PDF'), pdf());
+    await userEvent.click(screen.getByRole('button', { name: 'Upload new resume' }));
+
+    await waitFor(() => expect(screen.getByText(/deadline for Fall 2026 has passed/)).toBeInTheDocument());
+    expect(screen.getByText('Current')).toBeInTheDocument();
+  });
+});

--- a/client/src/pages/ApplicantInformation.jsx
+++ b/client/src/pages/ApplicantInformation.jsx
@@ -1,0 +1,361 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import apiClient from '../utils/api';
+import AccessControl from '../components/AccessControl';
+import DocumentPreviewModal from '../components/DocumentPreviewModal';
+import ResumeReuploadSection from '../components/ResumeReuploadSection';
+import '../styles/ApplicantInformation.css';
+
+// The fields a candidate may correct themselves, in the order they are shown.
+// `email` and `studentId` are absent on purpose — they are the identifiers the
+// server matches an application to its applicant on, so they are displayed
+// read-only and changed by an admin. The server enforces this independently;
+// this list only decides what gets rendered.
+const SECTIONS = [
+  {
+    title: 'Personal details',
+    fields: [
+      { name: 'firstName', label: 'First name', type: 'text', required: true },
+      { name: 'lastName', label: 'Last name', type: 'text', required: true },
+      { name: 'phoneNumber', label: 'Phone number', type: 'tel', required: true },
+      { name: 'gender', label: 'Gender', type: 'text', hint: 'Optional' },
+    ],
+  },
+  {
+    title: 'Academic details',
+    fields: [
+      { name: 'graduationYear', label: 'Graduation year', type: 'text', required: true },
+      { name: 'major1', label: 'Primary major', type: 'text', required: true },
+      { name: 'major2', label: 'Second major', type: 'text', hint: 'Optional' },
+      {
+        name: 'cumulativeGpa',
+        label: 'Cumulative GPA',
+        type: 'number',
+        required: true,
+        step: '0.01',
+        min: '0',
+        max: '5',
+      },
+      {
+        name: 'majorGpa',
+        label: 'Major GPA',
+        type: 'number',
+        hint: 'Optional',
+        step: '0.01',
+        min: '0',
+        max: '5',
+      },
+    ],
+  },
+  {
+    title: 'Background',
+    fields: [
+      { name: 'isTransferStudent', label: 'Are you a transfer student?', type: 'boolean' },
+      {
+        name: 'priorCollegeYears',
+        label: 'Years at your prior college',
+        type: 'text',
+        hint: 'Optional',
+        // Only meaningful for a transfer student, and the server nulls it out
+        // when transfer status is turned off.
+        dependsOn: 'isTransferStudent',
+      },
+      { name: 'isFirstGeneration', label: 'Are you a first-generation college student?', type: 'boolean' },
+    ],
+  },
+];
+
+const EDITABLE_NAMES = SECTIONS.flatMap((section) => section.fields.map((field) => field.name));
+
+// Inputs are controlled, so every value has to be a string (or a boolean for the
+// yes/no fields) — null would make React treat the input as uncontrolled.
+function toFormState(application) {
+  const state = {};
+  for (const name of EDITABLE_NAMES) {
+    const value = application[name];
+    state[name] = typeof value === 'boolean' ? value : value === null || value === undefined ? '' : String(value);
+  }
+  return state;
+}
+
+function changedFields(form, baseline) {
+  return Object.fromEntries(Object.entries(form).filter(([name, value]) => value !== baseline[name]));
+}
+
+export default function ApplicantInformation() {
+  const [applications, setApplications] = useState([]);
+  const [selectedId, setSelectedId] = useState(null);
+  const [record, setRecord] = useState(null);
+  const [form, setForm] = useState(null);
+  const [baseline, setBaseline] = useState(null);
+
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState('');
+  const [confirmation, setConfirmation] = useState('');
+  const [preview, setPreview] = useState({ open: false, src: '', title: '' });
+
+  // Which application to edit. A candidate can have one per cycle, so prefer the
+  // one still open, then the most recent.
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const data = await apiClient.get('/applications/my-applications');
+        if (cancelled) return;
+        const list = data?.applications || data || [];
+        setApplications(list);
+        const active = list.find((a) => a.cycle?.isActive);
+        const newest = [...list].sort(
+          (a, b) => new Date(b.submittedAt) - new Date(a.submittedAt)
+        )[0];
+        setSelectedId((active || newest)?.id ?? null);
+        if (list.length === 0) setLoading(false);
+      } catch (e) {
+        if (cancelled) return;
+        // A candidate with no application yet gets a 404 from this endpoint;
+        // that is an empty state, not a failure.
+        const noApplication =
+          e.message?.includes('User not found or no studentId associated') ||
+          e.message?.includes('Candidate not found for this user');
+        if (!noApplication) setLoadError(e.message || 'Failed to load your applications');
+        setApplications([]);
+        setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const loadRecord = useCallback(async (applicationId) => {
+    setLoading(true);
+    setLoadError('');
+    setConfirmation('');
+    setSaveError('');
+    try {
+      const data = await apiClient.get(`/applicant-info/applications/${applicationId}`);
+      setRecord(data);
+      const initial = toFormState(data);
+      setForm(initial);
+      setBaseline(initial);
+    } catch (e) {
+      setLoadError(e.message || 'Failed to load your information');
+      setRecord(null);
+      setForm(null);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (selectedId) loadRecord(selectedId);
+  }, [selectedId, loadRecord]);
+
+  const dirty = useMemo(
+    () => (form && baseline ? Object.keys(changedFields(form, baseline)).length > 0 : false),
+    [form, baseline]
+  );
+
+  const setField = (name, value) => {
+    setConfirmation('');
+    setSaveError('');
+    setForm((current) => ({ ...current, [name]: value }));
+  };
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    if (!dirty || saving) return;
+
+    setSaving(true);
+    setSaveError('');
+    setConfirmation('');
+    try {
+      const result = await apiClient.patch(
+        `/applicant-info/applications/${selectedId}`,
+        changedFields(form, baseline)
+      );
+      const updated = result.application;
+      setRecord(updated);
+      const next = toFormState(updated);
+      setForm(next);
+      setBaseline(next);
+      setConfirmation(result.message || 'Your information has been updated.');
+    } catch (e) {
+      setSaveError(e.message || 'Failed to update your information');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleReset = () => {
+    setForm(baseline);
+    setSaveError('');
+    setConfirmation('');
+  };
+
+  const renderField = (field) => {
+    const value = form[field.name];
+
+    if (field.type === 'boolean') {
+      return (
+        <div className="applicant-field" key={field.name}>
+          <span className="applicant-label">{field.label}</span>
+          <div className="applicant-radio-group" role="radiogroup" aria-label={field.label}>
+            {[
+              { label: 'Yes', selected: value === true },
+              { label: 'No', selected: value === false },
+            ].map((option) => (
+              <label key={option.label} className="applicant-radio">
+                <input
+                  type="radio"
+                  name={field.name}
+                  checked={option.selected}
+                  onChange={() => setField(field.name, option.label === 'Yes')}
+                  disabled={saving}
+                />
+                {option.label}
+              </label>
+            ))}
+          </div>
+        </div>
+      );
+    }
+
+    // Prior college years is only asked of transfer students.
+    if (field.dependsOn && form[field.dependsOn] !== true) return null;
+
+    return (
+      <div className="applicant-field" key={field.name}>
+        <label className="applicant-label" htmlFor={`field-${field.name}`}>
+          {field.label}
+          {field.required && <span className="applicant-required" aria-hidden="true"> *</span>}
+          {field.hint && <span className="applicant-hint"> ({field.hint})</span>}
+        </label>
+        <input
+          id={`field-${field.name}`}
+          className="applicant-input"
+          type={field.type}
+          value={value}
+          step={field.step}
+          min={field.min}
+          max={field.max}
+          required={field.required}
+          disabled={saving}
+          onChange={(e) => setField(field.name, e.target.value)}
+        />
+      </div>
+    );
+  };
+
+  return (
+    <AccessControl allowedRoles={['USER']}>
+      <div className="applicant-info-container">
+        <header className="applicant-info-header">
+          <h1>Update Applicant Information</h1>
+          <p>
+            Keep your application details current. Changes are visible to the recruitment team
+            straight away.
+          </p>
+        </header>
+
+        {applications.length > 1 && (
+          <div className="applicant-cycle-picker">
+            <label className="applicant-label" htmlFor="application-select">
+              Application
+            </label>
+            <select
+              id="application-select"
+              className="applicant-input"
+              value={selectedId || ''}
+              onChange={(e) => setSelectedId(e.target.value)}
+              disabled={saving}
+            >
+              {applications.map((application) => (
+                <option key={application.id} value={application.id}>
+                  {application.cycle?.name || 'Application'}
+                  {application.cycle?.isActive ? ' (current)' : ''}
+                </option>
+              ))}
+            </select>
+          </div>
+        )}
+
+        {loading && <p className="applicant-note">Loading your information…</p>}
+        {!loading && loadError && <p className="applicant-error">{loadError}</p>}
+        {!loading && !loadError && applications.length === 0 && (
+          <p className="applicant-note">
+            You do not have an application yet. Once you apply, you can update your details here.
+          </p>
+        )}
+
+        {!loading && !loadError && record && form && (
+          <>
+            <form className="applicant-card" onSubmit={handleSubmit}>
+              <section className="applicant-section">
+                <h2 className="applicant-section-title">Identity</h2>
+                <p className="applicant-note">
+                  Your email and student ID identify your application to the recruitment team and
+                  cannot be changed here. Contact us if either one is wrong.
+                </p>
+                <div className="applicant-grid">
+                  <div className="applicant-field">
+                    <span className="applicant-label">Email</span>
+                    <span className="applicant-readonly">{record.email}</span>
+                  </div>
+                  <div className="applicant-field">
+                    <span className="applicant-label">Student ID</span>
+                    <span className="applicant-readonly">{record.studentId}</span>
+                  </div>
+                </div>
+              </section>
+
+              {SECTIONS.map((section) => (
+                <section className="applicant-section" key={section.title}>
+                  <h2 className="applicant-section-title">{section.title}</h2>
+                  <div className="applicant-grid">{section.fields.map(renderField)}</div>
+                </section>
+              ))}
+
+              {saveError && <p className="applicant-error">{saveError}</p>}
+              {confirmation && <p className="applicant-success">{confirmation}</p>}
+
+              <div className="applicant-actions">
+                <button type="submit" className="applicant-save" disabled={!dirty || saving}>
+                  {saving ? 'Saving…' : 'Save changes'}
+                </button>
+                <button
+                  type="button"
+                  className="applicant-cancel"
+                  onClick={handleReset}
+                  disabled={!dirty || saving}
+                >
+                  Discard changes
+                </button>
+              </div>
+            </form>
+
+            <div className="applicant-card">
+              <section className="applicant-section">
+                <h2 className="applicant-section-title">Resume</h2>
+                <ResumeReuploadSection
+                  applicationId={selectedId}
+                  onPreview={(src, title) => setPreview({ open: true, src, title })}
+                />
+              </section>
+            </div>
+          </>
+        )}
+
+        {preview.open && (
+          <DocumentPreviewModal
+            src={preview.src}
+            kind="pdf"
+            title={preview.title}
+            onClose={() => setPreview({ open: false, src: '', title: '' })}
+          />
+        )}
+      </div>
+    </AccessControl>
+  );
+}

--- a/client/src/pages/ApplicantInformation.test.jsx
+++ b/client/src/pages/ApplicantInformation.test.jsx
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import ApplicantInformation from './ApplicantInformation';
+import apiClient from '../utils/api';
+
+vi.mock('../components/AccessControl', () => ({ default: ({ children }) => children }));
+vi.mock('../components/DocumentPreviewModal', () => ({ default: () => null }));
+vi.mock('../components/ResumeReuploadSection', () => ({
+  default: ({ applicationId }) => <div data-testid="resume-section">{applicationId}</div>,
+}));
+
+const APPLICATION = {
+  id: 'app-1',
+  email: 'cand@example.com',
+  studentId: '405123456',
+  firstName: 'Cand',
+  lastName: 'Idate',
+  phoneNumber: '860-555-0100',
+  graduationYear: '2028',
+  major1: 'Finance',
+  major2: null,
+  cumulativeGpa: 3.85,
+  majorGpa: null,
+  isTransferStudent: false,
+  priorCollegeYears: null,
+  gender: null,
+  isFirstGeneration: false,
+  status: 'SUBMITTED',
+  currentRound: '1',
+  submittedAt: '2026-09-01T12:00:00.000Z',
+  cycle: { id: 'cycle-1', name: 'Fall 2026', isActive: true },
+};
+
+const renderPage = () => render(<MemoryRouter><ApplicantInformation /></MemoryRouter>);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  apiClient.token = 'test-token';
+  apiClient.get = vi.fn((endpoint) => {
+    if (endpoint === '/applications/my-applications') {
+      return Promise.resolve([{ id: 'app-1', submittedAt: APPLICATION.submittedAt, cycle: APPLICATION.cycle }]);
+    }
+    if (endpoint === '/applicant-info/applications/app-1') return Promise.resolve({ ...APPLICATION });
+    return Promise.resolve([]);
+  });
+  apiClient.patch = vi.fn(() =>
+    Promise.resolve({ message: 'Your information has been updated.', application: { ...APPLICATION, phoneNumber: '860-555-0199' } })
+  );
+});
+
+describe('ApplicantInformation', () => {
+  it('loads the applicant details into the form', async () => {
+    renderPage();
+    await waitFor(() => expect(screen.getByLabelText(/First name/)).toHaveValue('Cand'));
+    expect(screen.getByLabelText(/Phone number/)).toHaveValue('860-555-0100');
+    expect(screen.getByLabelText(/Cumulative GPA/)).toHaveValue(3.85);
+  });
+
+  it('shows email and student ID as read-only text, not inputs', async () => {
+    renderPage();
+    await waitFor(() => expect(screen.getByText('cand@example.com')).toBeInTheDocument());
+    expect(screen.getByText('405123456')).toBeInTheDocument();
+    expect(screen.queryByLabelText(/Email/)).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(/Student ID/)).not.toBeInTheDocument();
+  });
+
+  it('keeps save disabled until something actually changes', async () => {
+    renderPage();
+    await waitFor(() => expect(screen.getByLabelText(/First name/)).toBeInTheDocument());
+    const save = screen.getByRole('button', { name: /Save changes/ });
+    expect(save).toBeDisabled();
+
+    fireEvent.change(screen.getByLabelText(/Phone number/), { target: { value: '860-555-0199' } });
+    expect(save).toBeEnabled();
+  });
+
+  it('sends only the fields that changed', async () => {
+    renderPage();
+    await waitFor(() => expect(screen.getByLabelText(/Phone number/)).toBeInTheDocument());
+
+    fireEvent.change(screen.getByLabelText(/Phone number/), { target: { value: '860-555-0199' } });
+    fireEvent.click(screen.getByRole('button', { name: /Save changes/ }));
+
+    await waitFor(() => expect(apiClient.patch).toHaveBeenCalledWith(
+      '/applicant-info/applications/app-1',
+      { phoneNumber: '860-555-0199' }
+    ));
+  });
+
+  it('confirms a successful save and re-disables the button', async () => {
+    renderPage();
+    await waitFor(() => expect(screen.getByLabelText(/Phone number/)).toBeInTheDocument());
+
+    fireEvent.change(screen.getByLabelText(/Phone number/), { target: { value: '860-555-0199' } });
+    fireEvent.click(screen.getByRole('button', { name: /Save changes/ }));
+
+    await waitFor(() => expect(screen.getByText(/Your information has been updated/)).toBeInTheDocument());
+    expect(screen.getByRole('button', { name: /Save changes/ })).toBeDisabled();
+  });
+
+  it('restores the loaded values when changes are discarded', async () => {
+    renderPage();
+    await waitFor(() => expect(screen.getByLabelText(/Phone number/)).toBeInTheDocument());
+
+    fireEvent.change(screen.getByLabelText(/Phone number/), { target: { value: '860-555-0199' } });
+    fireEvent.click(screen.getByRole('button', { name: /Discard changes/ }));
+
+    expect(screen.getByLabelText(/Phone number/)).toHaveValue('860-555-0100');
+    expect(apiClient.patch).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a rejection from the server without losing what was typed', async () => {
+    apiClient.patch = vi.fn(() => Promise.reject(new Error('Phone number must be 40 characters or fewer.')));
+    renderPage();
+    await waitFor(() => expect(screen.getByLabelText(/Phone number/)).toBeInTheDocument());
+
+    fireEvent.change(screen.getByLabelText(/Phone number/), { target: { value: '860-555-0199' } });
+    fireEvent.click(screen.getByRole('button', { name: /Save changes/ }));
+
+    await waitFor(() => expect(screen.getByText(/40 characters or fewer/)).toBeInTheDocument());
+    expect(screen.getByLabelText(/Phone number/)).toHaveValue('860-555-0199');
+  });
+
+  // The number input carries max="5", so an out-of-range GPA is stopped by the
+  // browser and never reaches the server. The server validates it anyway.
+  it('bounds the GPA inputs client-side', async () => {
+    renderPage();
+    await waitFor(() => expect(screen.getByLabelText(/Cumulative GPA/)).toBeInTheDocument());
+    expect(screen.getByLabelText(/Cumulative GPA/)).toHaveAttribute('max', '5');
+    expect(screen.getByLabelText(/Major GPA/)).toHaveAttribute('max', '5');
+  });
+
+  // Only asked of transfer students, so it should not be on screen otherwise.
+  it('reveals prior college years only for a transfer student', async () => {
+    renderPage();
+    await waitFor(() => expect(screen.getByLabelText(/First name/)).toBeInTheDocument());
+    expect(screen.queryByLabelText(/Years at your prior college/)).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getAllByRole('radio', { name: 'Yes' })[0]);
+    expect(screen.getByLabelText(/Years at your prior college/)).toBeInTheDocument();
+  });
+
+  it('renders the resume section for the selected application', async () => {
+    renderPage();
+    await waitFor(() => expect(screen.getByTestId('resume-section')).toHaveTextContent('app-1'));
+  });
+
+  it('shows an empty state when the candidate has no application', async () => {
+    apiClient.get = vi.fn(() => Promise.reject(new Error('User not found or no studentId associated')));
+    renderPage();
+    await waitFor(() => expect(screen.getByText(/do not have an application yet/)).toBeInTheDocument());
+  });
+});

--- a/client/src/pages/CandidateApplications.jsx
+++ b/client/src/pages/CandidateApplications.jsx
@@ -3,11 +3,10 @@ import { useAuth } from '../context/AuthContext';
 import apiClient from '../utils/api';
 import DocumentPreviewModal from '../components/DocumentPreviewModal';
 import AccessControl from '../components/AccessControl';
-import ResumeReuploadSection from '../components/ResumeReuploadSection';
 import '../styles/CandidateApplications.css';
 
 // Application Detail Modal Component
-function ApplicationDetailModal({ application, isOpen, onClose, onResumeReplaced }) {
+function ApplicationDetailModal({ application, isOpen, onClose }) {
   const [preview, setPreview] = useState({ open: false, src: '', kind: 'pdf', title: '' });
 
   if (!isOpen || !application) return null;
@@ -216,17 +215,6 @@ function ApplicationDetailModal({ application, isOpen, onClose, onResumeReplaced
                   </div>
                 )}
               </div>
-
-              <ResumeReuploadSection
-                applicationId={application.id}
-                onPreview={(src, title) => setPreview({
-                  open: true,
-                  src,
-                  kind: 'pdf',
-                  title: `${application.firstName} ${application.lastName} – ${title}`,
-                })}
-                onReplaced={onResumeReplaced}
-              />
             </div>
 
 
@@ -286,15 +274,6 @@ export default function CandidateApplications() {
 
   // The upload response carries the new URL, so repoint the open modal and the
   // cached list rather than refetching everything.
-  const handleResumeReplaced = (resumeUrl) => {
-    setSelectedApplication((current) => (current ? { ...current, resumeUrl } : current));
-    setApplications((current) =>
-      current.map((application) =>
-        application.id === selectedApplication?.id ? { ...application, resumeUrl } : application
-      )
-    );
-  };
-
   useEffect(() => {
     fetchApplications();
   }, []);
@@ -377,7 +356,6 @@ export default function CandidateApplications() {
         application={selectedApplication}
         isOpen={isModalOpen}
         onClose={closeModal}
-        onResumeReplaced={handleResumeReplaced}
       />
     </div>
     </AccessControl>

--- a/client/src/pages/CandidateApplications.jsx
+++ b/client/src/pages/CandidateApplications.jsx
@@ -3,10 +3,11 @@ import { useAuth } from '../context/AuthContext';
 import apiClient from '../utils/api';
 import DocumentPreviewModal from '../components/DocumentPreviewModal';
 import AccessControl from '../components/AccessControl';
+import ResumeReuploadSection from '../components/ResumeReuploadSection';
 import '../styles/CandidateApplications.css';
 
 // Application Detail Modal Component
-function ApplicationDetailModal({ application, isOpen, onClose }) {
+function ApplicationDetailModal({ application, isOpen, onClose, onResumeReplaced }) {
   const [preview, setPreview] = useState({ open: false, src: '', kind: 'pdf', title: '' });
 
   if (!isOpen || !application) return null;
@@ -215,6 +216,17 @@ function ApplicationDetailModal({ application, isOpen, onClose }) {
                   </div>
                 )}
               </div>
+
+              <ResumeReuploadSection
+                applicationId={application.id}
+                onPreview={(src, title) => setPreview({
+                  open: true,
+                  src,
+                  kind: 'pdf',
+                  title: `${application.firstName} ${application.lastName} – ${title}`,
+                })}
+                onReplaced={onResumeReplaced}
+              />
             </div>
 
 
@@ -270,6 +282,17 @@ export default function CandidateApplications() {
   const closeModal = () => {
     setIsModalOpen(false);
     setSelectedApplication(null);
+  };
+
+  // The upload response carries the new URL, so repoint the open modal and the
+  // cached list rather than refetching everything.
+  const handleResumeReplaced = (resumeUrl) => {
+    setSelectedApplication((current) => (current ? { ...current, resumeUrl } : current));
+    setApplications((current) =>
+      current.map((application) =>
+        application.id === selectedApplication?.id ? { ...application, resumeUrl } : application
+      )
+    );
   };
 
   useEffect(() => {
@@ -354,6 +377,7 @@ export default function CandidateApplications() {
         application={selectedApplication}
         isOpen={isModalOpen}
         onClose={closeModal}
+        onResumeReplaced={handleResumeReplaced}
       />
     </div>
     </AccessControl>

--- a/client/src/styles/ApplicantInformation.css
+++ b/client/src/styles/ApplicantInformation.css
@@ -1,0 +1,283 @@
+.applicant-info-container {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.applicant-info-header h1 {
+  margin: 0 0 0.5rem 0;
+  font-size: 1.75rem;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.applicant-info-header p {
+  margin: 0 0 1.5rem 0;
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+
+.applicant-cycle-picker {
+  margin-bottom: 1.5rem;
+  max-width: 22rem;
+}
+
+.applicant-card {
+  background-color: var(--surface-color, #fff);
+  border: 1px solid var(--border-light);
+  border-radius: var(--border-radius);
+  padding: 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.applicant-section + .applicant-section {
+  margin-top: 2rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--border-light);
+}
+
+.applicant-section-title {
+  margin: 0 0 1rem 0;
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.applicant-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.25rem;
+}
+
+.applicant-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+  min-width: 0;
+}
+
+.applicant-label {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--text-primary);
+}
+
+.applicant-required {
+  color: #b91c1c;
+}
+
+.applicant-hint {
+  font-weight: 400;
+  color: var(--text-secondary);
+}
+
+.applicant-input {
+  padding: 0.5rem 0.625rem;
+  border: 1px solid var(--border-light);
+  border-radius: var(--border-radius);
+  background-color: var(--surface-color, #fff);
+  color: var(--text-primary);
+  font-size: 0.9375rem;
+  font-family: inherit;
+  width: 100%;
+}
+
+.applicant-input:focus {
+  outline: 2px solid var(--primary-color);
+  outline-offset: -1px;
+}
+
+.applicant-input:disabled {
+  opacity: 0.6;
+}
+
+.applicant-readonly {
+  padding: 0.5rem 0;
+  font-size: 0.9375rem;
+  color: var(--text-secondary);
+  overflow-wrap: anywhere;
+}
+
+.applicant-radio-group {
+  display: flex;
+  gap: 1.25rem;
+  padding-top: 0.25rem;
+}
+
+.applicant-radio {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  font-size: 0.9375rem;
+  color: var(--text-primary);
+  cursor: pointer;
+}
+
+.applicant-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 2rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--border-light);
+}
+
+.applicant-save,
+.applicant-cancel {
+  padding: 0.5rem 1.25rem;
+  border-radius: var(--border-radius);
+  font-size: 0.9375rem;
+  font-weight: 500;
+  font-family: inherit;
+  cursor: pointer;
+}
+
+.applicant-save {
+  border: 1px solid var(--primary-color);
+  background-color: var(--primary-color);
+  color: #fff;
+}
+
+.applicant-cancel {
+  border: 1px solid var(--border-light);
+  background-color: transparent;
+  color: var(--text-primary);
+}
+
+.applicant-save:disabled,
+.applicant-cancel:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.applicant-note {
+  margin: 0 0 1rem 0;
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+
+.applicant-error {
+  margin: 1rem 0 0 0;
+  font-size: 0.875rem;
+  color: #991b1b;
+}
+
+.applicant-success {
+  margin: 1rem 0 0 0;
+  font-size: 0.875rem;
+  color: #065f46;
+}
+
+/* Resume replacement. These moved here with the ResumeReuploadSection when it
+   left the applications page; the component still owns the markup. */
+.resume-reupload-note {
+  margin: 0 0 0.75rem 0;
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+
+.resume-reupload-error {
+  margin: 0.5rem 0 0 0;
+  font-size: 0.875rem;
+  color: #991b1b;
+}
+
+.resume-reupload-success {
+  margin: 0.5rem 0 0 0;
+  font-size: 0.875rem;
+  color: #065f46;
+}
+
+.resume-reupload-controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.resume-version-list {
+  list-style: none;
+  margin: 1rem 0 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.resume-version {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.625rem 0.75rem;
+  border: 1px solid var(--border-light);
+  border-radius: var(--border-radius);
+}
+
+.resume-version-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+  min-width: 0;
+}
+
+.resume-version-label {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--text-primary);
+  overflow-wrap: anywhere;
+}
+
+.resume-version-current {
+  margin-left: 0.5rem;
+  padding: 0.125rem 0.5rem;
+  border-radius: 999px;
+  background-color: #d1fae5;
+  color: #065f46;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.resume-version-date {
+  font-size: 0.8125rem;
+  color: var(--text-secondary);
+}
+
+/* The resume section reuses .document-link from the applications page for its
+   View / Upload buttons; keep a local definition so this page does not depend
+   on that stylesheet being loaded. */
+.applicant-info-container .document-link {
+  padding: 0.375rem 0.75rem;
+  border: 1px solid var(--primary-color);
+  border-radius: var(--border-radius);
+  background-color: transparent;
+  color: var(--primary-color);
+  font-size: 0.875rem;
+  font-family: inherit;
+  cursor: pointer;
+}
+
+.applicant-info-container .document-link:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+@media (max-width: 768px) {
+  .applicant-info-container {
+    padding: 1rem;
+  }
+
+  .applicant-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .resume-version {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.5rem;
+  }
+}

--- a/client/src/styles/CandidateApplications.css
+++ b/client/src/styles/CandidateApplications.css
@@ -348,96 +348,6 @@
   color: var(--primary-color);
 }
 
-/* Resume replacement */
-.resume-reupload {
-  margin-top: 1.5rem;
-  padding-top: 1.25rem;
-  border-top: 1px solid var(--border-light);
-}
-
-.resume-reupload-title {
-  margin: 0 0 0.5rem 0;
-  font-size: 1rem;
-  font-weight: 600;
-  color: var(--text-primary);
-}
-
-.resume-reupload-note {
-  margin: 0 0 0.75rem 0;
-  font-size: 0.875rem;
-  color: var(--text-secondary);
-  line-height: 1.5;
-}
-
-.resume-reupload-error {
-  margin: 0.5rem 0 0 0;
-  font-size: 0.875rem;
-  color: #991b1b;
-}
-
-.resume-reupload-success {
-  margin: 0.5rem 0 0 0;
-  font-size: 0.875rem;
-  color: #065f46;
-}
-
-.resume-reupload-controls {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 0.75rem;
-}
-
-.resume-version-list {
-  list-style: none;
-  margin: 1rem 0 0 0;
-  padding: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-}
-
-.resume-version {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
-  padding: 0.625rem 0.75rem;
-  border: 1px solid var(--border-light);
-  border-radius: var(--border-radius);
-}
-
-.resume-version-meta {
-  display: flex;
-  flex-direction: column;
-  gap: 0.125rem;
-  min-width: 0;
-}
-
-.resume-version-label {
-  font-size: 0.875rem;
-  font-weight: 500;
-  color: var(--text-primary);
-  overflow-wrap: anywhere;
-}
-
-.resume-version-current {
-  margin-left: 0.5rem;
-  padding: 0.125rem 0.5rem;
-  border-radius: 999px;
-  background-color: #d1fae5;
-  color: #065f46;
-  font-size: 0.6875rem;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
-}
-
-.resume-version-date {
-  font-size: 0.8125rem;
-  color: var(--text-secondary);
-}
-
 /* Responsive Design */
 @media (max-width: 768px) {
   .candidate-applications-container {
@@ -473,12 +383,6 @@
 
   .documents-grid {
     grid-template-columns: 1fr;
-  }
-
-  .resume-version {
-    flex-direction: column;
-    align-items: stretch;
-    gap: 0.5rem;
   }
 
   .overview-header {

--- a/client/src/styles/CandidateApplications.css
+++ b/client/src/styles/CandidateApplications.css
@@ -338,7 +338,105 @@
   background-color: var(--primary-color);
   color: var(--text-white);}
 
+.document-link:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
 
+.document-link:disabled:hover {
+  background-color: transparent;
+  color: var(--primary-color);
+}
+
+/* Resume replacement */
+.resume-reupload {
+  margin-top: 1.5rem;
+  padding-top: 1.25rem;
+  border-top: 1px solid var(--border-light);
+}
+
+.resume-reupload-title {
+  margin: 0 0 0.5rem 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.resume-reupload-note {
+  margin: 0 0 0.75rem 0;
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+
+.resume-reupload-error {
+  margin: 0.5rem 0 0 0;
+  font-size: 0.875rem;
+  color: #991b1b;
+}
+
+.resume-reupload-success {
+  margin: 0.5rem 0 0 0;
+  font-size: 0.875rem;
+  color: #065f46;
+}
+
+.resume-reupload-controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.resume-version-list {
+  list-style: none;
+  margin: 1rem 0 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.resume-version {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.625rem 0.75rem;
+  border: 1px solid var(--border-light);
+  border-radius: var(--border-radius);
+}
+
+.resume-version-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+  min-width: 0;
+}
+
+.resume-version-label {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--text-primary);
+  overflow-wrap: anywhere;
+}
+
+.resume-version-current {
+  margin-left: 0.5rem;
+  padding: 0.125rem 0.5rem;
+  border-radius: 999px;
+  background-color: #d1fae5;
+  color: #065f46;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.resume-version-date {
+  font-size: 0.8125rem;
+  color: var(--text-secondary);
+}
 
 /* Responsive Design */
 @media (max-width: 768px) {
@@ -375,6 +473,12 @@
 
   .documents-grid {
     grid-template-columns: 1fr;
+  }
+
+  .resume-version {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.5rem;
   }
 
   .overview-header {

--- a/client/src/utils/documentUrl.js
+++ b/client/src/utils/documentUrl.js
@@ -1,0 +1,36 @@
+// Document URLs (`Application.resumeUrl`, `coverLetterUrl`, `videoUrl`,
+// `headshotUrl`) are stored as whole strings, and historically some rows were
+// written with an absolute origin baked in — production rows point at
+// https://uconsultingats.com, older local rows at http://localhost:3001. Served
+// from a different origin than the one that wrote them, fetching such a URL is
+// a cross-origin request the API does not permit, and the browser blocks it at
+// preflight:
+//
+//   Access to fetch at 'https://uconsultingats.com/api/files/<id>/pdf' from
+//   origin 'http://localhost:5173' has been blocked by CORS policy
+//
+// Every endpoint that serves one of our documents lives under `/api` on the
+// same origin as the app, so reducing the URL to a path lets the current origin
+// (Vite's dev proxy, or the deployed host) route it. Matching on the path
+// rather than a list of known hostnames keeps preview and staging origins
+// working without an edit here.
+//
+// Anything that is not one of our own `/api` paths — a Google Drive link, say —
+// is returned untouched, because it genuinely does live somewhere else.
+export function toSameOriginDocumentUrl(url) {
+  if (typeof url !== 'string' || url.trim() === '') return url;
+
+  let parsed;
+  try {
+    // The base makes already-relative URLs parse; it is discarded below.
+    parsed = new URL(url, window.location.origin);
+  } catch {
+    return url;
+  }
+
+  if (parsed.pathname !== '/api' && !parsed.pathname.startsWith('/api/')) return url;
+
+  return `${parsed.pathname}${parsed.search}${parsed.hash}`;
+}
+
+export default toSameOriginDocumentUrl;

--- a/client/src/utils/documentUrl.test.js
+++ b/client/src/utils/documentUrl.test.js
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { toSameOriginDocumentUrl } from './documentUrl';
+
+describe('toSameOriginDocumentUrl', () => {
+  it('strips the production origin from a stored document URL', () => {
+    expect(
+      toSameOriginDocumentUrl('https://uconsultingats.com/api/files/1nQ5mdh/pdf')
+    ).toBe('/api/files/1nQ5mdh/pdf');
+  });
+
+  it('strips a www production origin', () => {
+    expect(
+      toSameOriginDocumentUrl('https://www.uconsultingats.com/api/files/abc/image')
+    ).toBe('/api/files/abc/image');
+  });
+
+  it('strips a localhost API origin', () => {
+    expect(
+      toSameOriginDocumentUrl('http://localhost:3001/api/resume-uploads/xyz/file')
+    ).toBe('/api/resume-uploads/xyz/file');
+  });
+
+  // The hostname list this replaced would have missed these entirely.
+  it('strips an origin it has never seen before', () => {
+    expect(
+      toSameOriginDocumentUrl('https://uc-ats-pr-123.onrender.com/api/files/abc/pdf')
+    ).toBe('/api/files/abc/pdf');
+  });
+
+  it('leaves an already-relative API path alone', () => {
+    expect(toSameOriginDocumentUrl('/api/files/abc/pdf')).toBe('/api/files/abc/pdf');
+  });
+
+  it('preserves the query string and hash', () => {
+    expect(
+      toSameOriginDocumentUrl('https://uconsultingats.com/api/files/abc/pdf?v=2#page=3')
+    ).toBe('/api/files/abc/pdf?v=2#page=3');
+  });
+
+  it('leaves a third-party URL absolute', () => {
+    const drive = 'https://drive.google.com/file/d/1nQ5mdh/view';
+    expect(toSameOriginDocumentUrl(drive)).toBe(drive);
+  });
+
+  it('does not treat a path that merely starts with "api" as ours', () => {
+    const other = 'https://example.com/apiary/files/abc';
+    expect(toSameOriginDocumentUrl(other)).toBe(other);
+  });
+
+  it('passes through empty and non-string values untouched', () => {
+    expect(toSameOriginDocumentUrl('')).toBe('');
+    expect(toSameOriginDocumentUrl(null)).toBe(null);
+    expect(toSameOriginDocumentUrl(undefined)).toBe(undefined);
+  });
+});

--- a/server/prisma/migrations/20260826000000_add_resume_uploads/migration.sql
+++ b/server/prisma/migrations/20260826000000_add_resume_uploads/migration.sql
@@ -1,0 +1,49 @@
+-- Version history for application resumes. Candidates can replace their own
+-- resume until the cycle's resume deadline; every version is kept so a score
+-- recorded against an earlier resume can still be traced back to the file the
+-- reviewer actually read.
+--
+-- Written to be re-runnable: `prisma db execute` has no transaction wrapper of
+-- its own (see CLAUDE.md, "Applying a migration"), so a half-applied file has
+-- to be safe to replay.
+
+CREATE TABLE IF NOT EXISTS "resume_uploads" (
+    "id" TEXT NOT NULL,
+    -- NULL when the file is not ours: the resume an application arrived with
+    -- lives in Google Drive, uploaded through the application form.
+    "storagePath" TEXT,
+    "sourceUrl" TEXT NOT NULL,
+    "originalName" TEXT,
+    "sizeBytes" INTEGER,
+    "applicationId" TEXT NOT NULL,
+    "uploadedById" TEXT,
+    "uploadedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    -- Set when a newer upload takes over. The row with NULL is the version
+    -- applications."resumeUrl" currently points at.
+    "supersededAt" TIMESTAMP(3),
+
+    CONSTRAINT "resume_uploads_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX IF NOT EXISTS "resume_uploads_applicationId_uploadedAt_idx"
+    ON "resume_uploads"("applicationId", "uploadedAt");
+
+DO $$
+BEGIN
+    ALTER TABLE "resume_uploads"
+        ADD CONSTRAINT "resume_uploads_applicationId_fkey"
+        FOREIGN KEY ("applicationId") REFERENCES "applications"("id")
+        ON DELETE CASCADE ON UPDATE CASCADE;
+EXCEPTION
+    WHEN duplicate_object THEN NULL;
+END $$;
+
+DO $$
+BEGIN
+    ALTER TABLE "resume_uploads"
+        ADD CONSTRAINT "resume_uploads_uploadedById_fkey"
+        FOREIGN KEY ("uploadedById") REFERENCES "users"("id")
+        ON DELETE SET NULL ON UPDATE CASCADE;
+EXCEPTION
+    WHEN duplicate_object THEN NULL;
+END $$;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -49,6 +49,7 @@ model User {
   caseAssignments            CaseAssignment[]                @relation("CaseAssigner")
   gtkucProfile               MemberGtkucProfile?
   createdCycles              RecruitingCycle[]               @relation("RecruitingCycleCreator")
+  resumeUploads              ResumeUpload[]                  @relation("ResumeUploader")
 
   @@map("users")
 }
@@ -118,8 +119,37 @@ model Application {
   flaggedDocuments      FlaggedDocument[]
   interviewEvaluations  InterviewEvaluation[]
   caseAssignments       CaseAssignment[]
+  resumeUploads         ResumeUpload[]
 
   @@map("applications")
+}
+
+// One row per version of an application's resume, newest last. Candidates may
+// replace their own resume until the cycle's `resumeDeadline` passes, and
+// reviewers grade whatever `Application.resumeUrl` pointed at, so the version
+// that was actually scored has to stay recoverable.
+//
+// `storagePath` is null for the resume the application arrived with: that file
+// lives in Google Drive (uploaded through the application form), not in our
+// storage directory. `sourceUrl` records what `Application.resumeUrl` held for
+// this version, which is what the client fetches to view it either way.
+model ResumeUpload {
+  id            String      @id @default(uuid())
+  applicationId String
+  storagePath   String?
+  sourceUrl     String
+  originalName  String?
+  sizeBytes     Int?
+  uploadedById  String?
+  uploadedAt    DateTime    @default(now())
+  // Set when a newer upload takes over. Exactly one row per application should
+  // have this null — the version `Application.resumeUrl` currently points at.
+  supersededAt  DateTime?
+  application   Application @relation(fields: [applicationId], references: [id], onDelete: Cascade)
+  uploadedBy    User?       @relation("ResumeUploader", fields: [uploadedById], references: [id])
+
+  @@index([applicationId, uploadedAt])
+  @@map("resume_uploads")
 }
 
 model RecruitingCycle {

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -858,6 +858,15 @@ enum UserRole {
   USER
   ADMIN
   MEMBER
+  // Added to the shared database by the client resume portal work
+  // (migration 20260825130100_add_client_resume_portal), whose migration file
+  // lives on that branch and arrives here at merge — which is why there is no
+  // migration for this value on this branch. It is declared anyway because
+  // Prisma refuses to deserialize a row carrying an enum value the schema does
+  // not know, so reading ANY user fails outright once a single CLIENT row
+  // exists ("Value 'CLIENT' not found in enum 'UserRole'"), not just that row.
+  // Nothing on this branch grants or acts on the role.
+  CLIENT
 }
 
 enum ApplicationStatus {

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -20,6 +20,7 @@ import interviewResourcesRoutes from './routes/interviewResources.js';
 import memberRoutes from './routes/member.js';
 import candidateRoutes from './routes/candidate.js';
 import casesRoutes from './routes/cases.js';
+import resumeUploadsRoutes from './routes/resumeUploads.js';
 import conversationsRoutes from './routes/conversations.js';
 import { requireAuth, requireAdmin } from './middleware/auth.js';
 import featureRequestRoutes from './routes/featureRequests.js';
@@ -71,6 +72,7 @@ app.use('/api/member', memberRoutes);
 app.use('/api/conversations', conversationsRoutes);
 app.use('/api/feature-requests', featureRequestRoutes);
 app.use('/api/cases', casesRoutes);
+app.use('/api/resume-uploads', resumeUploadsRoutes);
 app.use('/api', candidateRoutes);
 app.use('/api', publicRoutes);
 

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -21,6 +21,7 @@ import memberRoutes from './routes/member.js';
 import candidateRoutes from './routes/candidate.js';
 import casesRoutes from './routes/cases.js';
 import resumeUploadsRoutes from './routes/resumeUploads.js';
+import applicantInfoRoutes from './routes/applicantInfo.js';
 import conversationsRoutes from './routes/conversations.js';
 import { requireAuth, requireAdmin } from './middleware/auth.js';
 import featureRequestRoutes from './routes/featureRequests.js';
@@ -73,6 +74,7 @@ app.use('/api/conversations', conversationsRoutes);
 app.use('/api/feature-requests', featureRequestRoutes);
 app.use('/api/cases', casesRoutes);
 app.use('/api/resume-uploads', resumeUploadsRoutes);
+app.use('/api/applicant-info', applicantInfoRoutes);
 app.use('/api', candidateRoutes);
 app.use('/api', publicRoutes);
 

--- a/server/src/routes/applicantInfo.js
+++ b/server/src/routes/applicantInfo.js
@@ -1,0 +1,187 @@
+import express from 'express';
+import prisma from '../prismaClient.js';
+import { requireAuth } from '../middleware/auth.js';
+import { isOwnedBy } from '../utils/applicationOwnership.js';
+
+const router = express.Router();
+
+// Candidate self-service editing of the details they submitted on the
+// application form.
+//
+// `email` and `studentId` are deliberately NOT editable. They are the two keys
+// isOwnedBy() matches on, so a candidate who could change them could point their
+// account at somebody else's application. Admins change those through
+// EditCandidateModal, where the change is a deliberate staff action.
+//
+// Documents are not handled here either — the resume has its own versioned
+// endpoint (routes/resumeUploads.js), and headshot/cover letter/video are still
+// whatever the form delivered.
+export const EDITABLE_FIELDS = [
+  'firstName',
+  'lastName',
+  'phoneNumber',
+  'graduationYear',
+  'major1',
+  'major2',
+  'cumulativeGpa',
+  'majorGpa',
+  'isTransferStudent',
+  'priorCollegeYears',
+  'gender',
+  'isFirstGeneration',
+];
+
+// Identity and process fields the page shows so a candidate can confirm what we
+// have, but cannot change.
+const READ_ONLY_FIELDS = ['id', 'email', 'studentId', 'status', 'currentRound', 'submittedAt'];
+
+const applicationSelect = {
+  ...Object.fromEntries([...EDITABLE_FIELDS, ...READ_ONLY_FIELDS].map((field) => [field, true])),
+  candidate: { select: { email: true, studentId: true } },
+  cycle: { select: { id: true, name: true, isActive: true } },
+};
+
+class ValidationError extends Error {}
+
+const text = (max, { required }) => (value, label) => {
+  if (value === null || value === undefined || String(value).trim() === '') {
+    if (required) throw new ValidationError(`${label} is required.`);
+    return null;
+  }
+  const trimmed = String(value).trim();
+  if (trimmed.length > max) throw new ValidationError(`${label} must be ${max} characters or fewer.`);
+  return trimmed;
+};
+
+const bool = (value, label) => {
+  if (typeof value === 'boolean') return value;
+  if (value === 'true') return true;
+  if (value === 'false') return false;
+  throw new ValidationError(`${label} must be yes or no.`);
+};
+
+// GPAs are Decimal(3, 2), so anything at or above 10 does not fit the column at
+// all. The 0–5 bound is the useful check: it catches a percentage typed into a
+// GPA box while still allowing the weighted scales that run past 4.0.
+const gpa = ({ required }) => (value, label) => {
+  if (value === null || value === undefined || String(value).trim() === '') {
+    if (required) throw new ValidationError(`${label} is required.`);
+    return null;
+  }
+  const parsed = Number(String(value).trim());
+  if (!Number.isFinite(parsed)) throw new ValidationError(`${label} must be a number.`);
+  if (parsed < 0 || parsed > 5) throw new ValidationError(`${label} must be between 0.00 and 5.00.`);
+  return Math.round(parsed * 100) / 100;
+};
+
+const VALIDATORS = {
+  firstName: text(100, { required: true }),
+  lastName: text(100, { required: true }),
+  phoneNumber: text(40, { required: true }),
+  graduationYear: text(10, { required: true }),
+  major1: text(100, { required: true }),
+  major2: text(100, { required: false }),
+  cumulativeGpa: gpa({ required: true }),
+  majorGpa: gpa({ required: false }),
+  isTransferStudent: bool,
+  priorCollegeYears: text(50, { required: false }),
+  gender: text(50, { required: false }),
+  isFirstGeneration: bool,
+};
+
+const LABELS = {
+  firstName: 'First name',
+  lastName: 'Last name',
+  phoneNumber: 'Phone number',
+  graduationYear: 'Graduation year',
+  major1: 'Primary major',
+  major2: 'Second major',
+  cumulativeGpa: 'Cumulative GPA',
+  majorGpa: 'Major GPA',
+  isTransferStudent: 'Transfer student',
+  priorCollegeYears: 'Prior college years',
+  gender: 'Gender',
+  isFirstGeneration: 'First-generation student',
+};
+
+// Decimal columns come back as Prisma Decimal objects, which serialize to JSON
+// as an object rather than a number; the form needs a plain value to put in an
+// input.
+function serialize(application) {
+  return {
+    ...application,
+    cumulativeGpa: application.cumulativeGpa === null ? null : Number(application.cumulativeGpa),
+    majorGpa: application.majorGpa === null ? null : Number(application.majorGpa),
+    editableFields: EDITABLE_FIELDS,
+  };
+}
+
+async function loadOwned(req, res) {
+  const application = await prisma.application.findUnique({
+    where: { id: req.params.applicationId },
+    select: applicationSelect,
+  });
+
+  if (!application) {
+    res.status(404).json({ error: 'Application not found' });
+    return null;
+  }
+  // Staff are not given an exception here: this endpoint exists so a candidate
+  // can correct their own record, and admin edits belong on the admin surface.
+  if (!isOwnedBy(application, req.user)) {
+    res.status(403).json({ error: 'Only the applicant can update this information.' });
+    return null;
+  }
+  return application;
+}
+
+// GET /api/applicant-info/applications/:applicationId
+router.get('/applications/:applicationId', requireAuth, async (req, res) => {
+  try {
+    const application = await loadOwned(req, res);
+    if (!application) return;
+    res.json(serialize(application));
+  } catch (error) {
+    console.error('[GET /api/applicant-info/applications/:applicationId]', error);
+    res.status(500).json({ error: 'Failed to load your information' });
+  }
+});
+
+// PATCH /api/applicant-info/applications/:applicationId
+// Accepts any subset of EDITABLE_FIELDS. Unknown keys are ignored rather than
+// rejected so that a field added to the form later cannot be smuggled through
+// this endpoint before anyone has decided it is candidate-editable.
+router.patch('/applications/:applicationId', requireAuth, async (req, res) => {
+  try {
+    const application = await loadOwned(req, res);
+    if (!application) return;
+
+    const data = {};
+    for (const field of EDITABLE_FIELDS) {
+      if (!Object.prototype.hasOwnProperty.call(req.body || {}, field)) continue;
+      data[field] = VALIDATORS[field](req.body[field], LABELS[field]);
+    }
+
+    if (Object.keys(data).length === 0) {
+      return res.status(400).json({ error: 'No changes were submitted.' });
+    }
+
+    // A transfer student who says they are no longer one should not keep a
+    // stale "prior college years" answer hanging off the record.
+    if (data.isTransferStudent === false) data.priorCollegeYears = null;
+
+    const updated = await prisma.application.update({
+      where: { id: application.id },
+      data,
+      select: applicationSelect,
+    });
+
+    res.json({ message: 'Your information has been updated.', application: serialize(updated) });
+  } catch (error) {
+    if (error instanceof ValidationError) return res.status(400).json({ error: error.message });
+    console.error('[PATCH /api/applicant-info/applications/:applicationId]', error);
+    res.status(500).json({ error: 'Failed to update your information' });
+  }
+});
+
+export default router;

--- a/server/src/routes/applicantInfo.routes.test.js
+++ b/server/src/routes/applicantInfo.routes.test.js
@@ -1,0 +1,254 @@
+// Route-level coverage for candidate self-service editing of their applicant
+// information: ownership, which fields are writable, and validation.
+import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest';
+import express from 'express';
+import jwt from 'jsonwebtoken';
+import prisma from '../prismaClient.js';
+import applicantInfoRoutes, { EDITABLE_FIELDS } from './applicantInfo.js';
+
+vi.mock('../prismaClient.js', () => ({
+  default: {
+    user: { findUnique: vi.fn() },
+    application: { findUnique: vi.fn(), update: vi.fn() },
+  },
+}));
+
+const candidateUser = {
+  id: 'user-1',
+  role: 'USER',
+  isActive: true,
+  email: 'cand@example.com',
+  fullName: 'Cand Idate',
+  studentId: '405123456',
+};
+const otherCandidate = {
+  id: 'user-2',
+  role: 'USER',
+  isActive: true,
+  email: 'other@example.com',
+  fullName: 'Other Person',
+  studentId: '405999999',
+};
+const adminUser = {
+  id: 'admin-1',
+  role: 'ADMIN',
+  isActive: true,
+  email: 'admin@example.com',
+  fullName: 'Admin One',
+  studentId: null,
+};
+
+const application = (overrides = {}) => ({
+  id: 'app-1',
+  email: candidateUser.email,
+  studentId: candidateUser.studentId,
+  firstName: 'Cand',
+  lastName: 'Idate',
+  phoneNumber: '860-555-0100',
+  graduationYear: '2028',
+  major1: 'Finance',
+  major2: null,
+  cumulativeGpa: 3.85,
+  majorGpa: null,
+  isTransferStudent: false,
+  priorCollegeYears: null,
+  gender: null,
+  isFirstGeneration: false,
+  status: 'SUBMITTED',
+  currentRound: '1',
+  submittedAt: new Date('2026-09-01T12:00:00Z'),
+  candidate: { email: candidateUser.email, studentId: candidateUser.studentId },
+  cycle: { id: 'cycle-1', name: 'Fall 2026', isActive: true },
+  ...overrides,
+});
+
+const tokenFor = (user) => jwt.sign({ userId: user.id }, process.env.JWT_SECRET);
+
+let server;
+let port;
+
+const request = (path, { user, method = 'GET', body } = {}) => {
+  const headers = {};
+  if (user) headers.Authorization = `Bearer ${tokenFor(user)}`;
+  if (body !== undefined) headers['Content-Type'] = 'application/json';
+  return fetch(`http://localhost:${port}${path}`, {
+    method,
+    headers,
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+};
+
+const patch = (body, user = candidateUser) =>
+  request('/api/applicant-info/applications/app-1', { user, method: 'PATCH', body });
+
+beforeAll(async () => {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/applicant-info', applicantInfoRoutes);
+  server = app.listen(0);
+  await new Promise((resolve) => server.on('listening', resolve));
+  port = server.address().port;
+});
+
+afterAll(async () => {
+  await new Promise((resolve) => server.close(resolve));
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  prisma.user.findUnique.mockImplementation(({ where: { id } }) =>
+    [candidateUser, otherCandidate, adminUser].find((u) => u.id === id) || null
+  );
+  prisma.application.findUnique.mockResolvedValue(application());
+  prisma.application.update.mockImplementation(({ data }) =>
+    Promise.resolve(application(data))
+  );
+});
+
+describe('GET /api/applicant-info/applications/:applicationId', () => {
+  it('returns the applicant information to the owner', async () => {
+    const res = await request('/api/applicant-info/applications/app-1', { user: candidateUser });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.firstName).toBe('Cand');
+    expect(body.email).toBe(candidateUser.email);
+  });
+
+  it('serializes GPA as a plain number the form can use', async () => {
+    const res = await request('/api/applicant-info/applications/app-1', { user: candidateUser });
+    const body = await res.json();
+    expect(body.cumulativeGpa).toBe(3.85);
+    expect(typeof body.cumulativeGpa).toBe('number');
+  });
+
+  it('refuses a candidate who does not own the application', async () => {
+    const res = await request('/api/applicant-info/applications/app-1', { user: otherCandidate });
+    expect(res.status).toBe(403);
+  });
+
+  it('404s an application that does not exist', async () => {
+    prisma.application.findUnique.mockResolvedValue(null);
+    const res = await request('/api/applicant-info/applications/app-1', { user: candidateUser });
+    expect(res.status).toBe(404);
+  });
+
+  it('requires authentication', async () => {
+    const res = await request('/api/applicant-info/applications/app-1');
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('PATCH /api/applicant-info/applications/:applicationId', () => {
+  it('updates an editable field', async () => {
+    const res = await patch({ phoneNumber: '860-555-0199' });
+    expect(res.status).toBe(200);
+    expect(prisma.application.update).toHaveBeenCalledWith(
+      expect.objectContaining({ data: { phoneNumber: '860-555-0199' } })
+    );
+  });
+
+  it('accepts a partial update without disturbing untouched fields', async () => {
+    await patch({ major1: 'Economics' });
+    const { data } = prisma.application.update.mock.calls[0][0];
+    expect(Object.keys(data)).toEqual(['major1']);
+  });
+
+  it('trims surrounding whitespace', async () => {
+    await patch({ firstName: '  Candace  ' });
+    expect(prisma.application.update.mock.calls[0][0].data.firstName).toBe('Candace');
+  });
+
+  // The whole reason these two are excluded: they are the ownership keys.
+  it('ignores an attempt to change the email', async () => {
+    const res = await patch({ email: 'attacker@example.com', phoneNumber: '860-555-0111' });
+    expect(res.status).toBe(200);
+    const { data } = prisma.application.update.mock.calls[0][0];
+    expect(data).not.toHaveProperty('email');
+  });
+
+  it('ignores an attempt to change the student ID', async () => {
+    await patch({ studentId: '405999999', phoneNumber: '860-555-0111' });
+    const { data } = prisma.application.update.mock.calls[0][0];
+    expect(data).not.toHaveProperty('studentId');
+  });
+
+  it('ignores non-editable process fields like status', async () => {
+    await patch({ status: 'ACCEPTED', resumeUrl: '/evil.pdf', phoneNumber: '860-555-0111' });
+    const { data } = prisma.application.update.mock.calls[0][0];
+    expect(data).not.toHaveProperty('status');
+    expect(data).not.toHaveProperty('resumeUrl');
+  });
+
+  it('rejects a payload with nothing editable in it', async () => {
+    const res = await patch({ email: 'attacker@example.com' });
+    expect(res.status).toBe(400);
+    expect(prisma.application.update).not.toHaveBeenCalled();
+  });
+
+  it('refuses a candidate who does not own the application', async () => {
+    const res = await patch({ phoneNumber: '860-555-0199' }, otherCandidate);
+    expect(res.status).toBe(403);
+    expect(prisma.application.update).not.toHaveBeenCalled();
+  });
+
+  it('refuses an admin too — staff edits belong on the admin surface', async () => {
+    const res = await patch({ phoneNumber: '860-555-0199' }, adminUser);
+    expect(res.status).toBe(403);
+  });
+
+  it('rejects a required field cleared to empty', async () => {
+    const res = await patch({ firstName: '   ' });
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/First name is required/);
+  });
+
+  it('allows an optional field to be cleared to null', async () => {
+    await patch({ major2: '' });
+    expect(prisma.application.update.mock.calls[0][0].data.major2).toBeNull();
+  });
+
+  it('rejects a GPA outside the plausible range', async () => {
+    const res = await patch({ cumulativeGpa: '385' });
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/between 0.00 and 5.00/);
+  });
+
+  it('rejects a GPA that is not a number', async () => {
+    const res = await patch({ cumulativeGpa: 'very good' });
+    expect(res.status).toBe(400);
+  });
+
+  it('rounds a GPA to the two decimals the column stores', async () => {
+    await patch({ cumulativeGpa: '3.856' });
+    expect(prisma.application.update.mock.calls[0][0].data.cumulativeGpa).toBe(3.86);
+  });
+
+  it('accepts a weighted GPA above 4.0', async () => {
+    const res = await patch({ cumulativeGpa: '4.3' });
+    expect(res.status).toBe(200);
+  });
+
+  it('rejects a non-boolean for a yes/no field', async () => {
+    const res = await patch({ isTransferStudent: 'maybe' });
+    expect(res.status).toBe(400);
+  });
+
+  it('clears prior college years when transfer status is turned off', async () => {
+    prisma.application.findUnique.mockResolvedValue(
+      application({ isTransferStudent: true, priorCollegeYears: '2' })
+    );
+    await patch({ isTransferStudent: false });
+    expect(prisma.application.update.mock.calls[0][0].data.priorCollegeYears).toBeNull();
+  });
+
+  it('rejects a value longer than the column allows', async () => {
+    const res = await patch({ firstName: 'x'.repeat(101) });
+    expect(res.status).toBe(400);
+  });
+
+  it('exposes exactly the fields the page is allowed to edit', () => {
+    expect(EDITABLE_FIELDS).not.toContain('email');
+    expect(EDITABLE_FIELDS).not.toContain('studentId');
+    expect(EDITABLE_FIELDS).toContain('phoneNumber');
+  });
+});

--- a/server/src/routes/resumeUploads.js
+++ b/server/src/routes/resumeUploads.js
@@ -8,6 +8,7 @@ import { fileURLToPath } from 'url';
 import { dirname } from 'path';
 import prisma from '../prismaClient.js';
 import { requireAuth } from '../middleware/auth.js';
+import { isOwnedBy, isStaff } from '../utils/applicationOwnership.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -42,28 +43,6 @@ const applicationWithOwnership = {
   candidate: { select: { email: true, studentId: true } },
   cycle: { select: { id: true, name: true, isActive: true, resumeDeadline: true } },
 };
-
-// A candidate owns an application when it carries their student ID or email, or
-// hangs off a Candidate record matching either. Mirrors the ownership test in
-// files.js — applications predate the User account that later claims them, so
-// there is no foreign key to lean on.
-function isOwnedBy(application, user) {
-  if (!user) return false;
-
-  const emails = [application.email, application.candidate?.email]
-    .filter(Boolean)
-    .map((value) => value.toLowerCase());
-  if (user.email && emails.includes(user.email.toLowerCase())) return true;
-
-  const studentIds = [application.studentId, application.candidate?.studentId]
-    .filter(Boolean)
-    .map(String);
-  if (user.studentId && studentIds.includes(String(user.studentId))) return true;
-
-  return false;
-}
-
-const isStaff = (user) => user?.role === 'ADMIN' || user?.role === 'MEMBER';
 
 // `RecruitingCycle.resumeDeadline` is a free-text column. Cycles created through
 // the timeline bootstrap store an ISO date (YYYY-MM-DD); older rows can hold

--- a/server/src/routes/resumeUploads.js
+++ b/server/src/routes/resumeUploads.js
@@ -1,0 +1,353 @@
+import express from 'express';
+import multer from 'multer';
+import path from 'path';
+import fs from 'fs';
+import fsPromises from 'fs/promises';
+import crypto from 'crypto';
+import { fileURLToPath } from 'url';
+import { dirname } from 'path';
+import prisma from '../prismaClient.js';
+import { requireAuth } from '../middleware/auth.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const router = express.Router();
+
+// Replacement resumes are held next to case files, OUTSIDE the statically served
+// `uploads/` directory, so the only way to read one is through the authorized
+// proxy at the bottom of this file.
+const STORAGE_DIR = path.join(__dirname, '../../storage');
+const RESUME_ROOT = path.join(STORAGE_DIR, 'resumes');
+
+export const MAX_RESUME_BYTES = 10 * 1024 * 1024;
+
+// Kept in memory so nothing lands on disk until the deadline and ownership
+// checks have passed and the row it belongs to has an id.
+const resumeUpload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: MAX_RESUME_BYTES, files: 1 },
+  fileFilter(req, file, cb) {
+    if (file.mimetype === 'application/pdf') cb(null, true);
+    else cb(new Error('Your resume must be a PDF'));
+  },
+});
+
+const applicationWithOwnership = {
+  id: true,
+  email: true,
+  studentId: true,
+  resumeUrl: true,
+  submittedAt: true,
+  candidate: { select: { email: true, studentId: true } },
+  cycle: { select: { id: true, name: true, isActive: true, resumeDeadline: true } },
+};
+
+// A candidate owns an application when it carries their student ID or email, or
+// hangs off a Candidate record matching either. Mirrors the ownership test in
+// files.js — applications predate the User account that later claims them, so
+// there is no foreign key to lean on.
+function isOwnedBy(application, user) {
+  if (!user) return false;
+
+  const emails = [application.email, application.candidate?.email]
+    .filter(Boolean)
+    .map((value) => value.toLowerCase());
+  if (user.email && emails.includes(user.email.toLowerCase())) return true;
+
+  const studentIds = [application.studentId, application.candidate?.studentId]
+    .filter(Boolean)
+    .map(String);
+  if (user.studentId && studentIds.includes(String(user.studentId))) return true;
+
+  return false;
+}
+
+const isStaff = (user) => user?.role === 'ADMIN' || user?.role === 'MEMBER';
+
+// `RecruitingCycle.resumeDeadline` is a free-text column. Cycles created through
+// the timeline bootstrap store an ISO date (YYYY-MM-DD); older rows can hold
+// prose like "Oct 4th, Morning". A parseable date closes the window at the end
+// of that day in server time; anything unparseable is treated as "no deadline
+// recorded" rather than locking candidates out over a formatting quirk.
+export function resumeDeadlineAt(cycle) {
+  const raw = cycle?.resumeDeadline?.trim();
+  if (!raw) return null;
+
+  const isoDay = /^(\d{4})-(\d{2})-(\d{2})$/.exec(raw);
+  if (isoDay) {
+    const [, year, month, day] = isoDay;
+    return new Date(Number(year), Number(month) - 1, Number(day), 23, 59, 59, 999);
+  }
+
+  const parsed = new Date(raw);
+  if (Number.isNaN(parsed.getTime())) {
+    console.warn(
+      `[resume-uploads] Cycle ${cycle.id} has an unparseable resumeDeadline (${JSON.stringify(raw)}); treating the replacement window as open.`
+    );
+    return null;
+  }
+  return parsed;
+}
+
+// Whether THIS user may replace THIS application's resume right now, and why not
+// when they may not. The reason is candidate-facing copy.
+export function replacementWindow(application, user, now = new Date()) {
+  const deadline = resumeDeadlineAt(application.cycle);
+  const base = { deadline, deadlineLabel: application.cycle?.resumeDeadline || null };
+
+  if (!isOwnedBy(application, user)) {
+    return { ...base, canReplace: false, reason: 'Only the applicant can replace this resume.' };
+  }
+  if (!application.cycle) {
+    return { ...base, canReplace: false, reason: 'This application is not attached to a recruiting cycle.' };
+  }
+  if (!application.cycle.isActive) {
+    return {
+      ...base,
+      canReplace: false,
+      reason: `${application.cycle.name} has closed, so its documents can no longer be changed.`,
+    };
+  }
+  if (deadline && now.getTime() > deadline.getTime()) {
+    return {
+      ...base,
+      canReplace: false,
+      reason: `The resume deadline for ${application.cycle.name} has passed.`,
+    };
+  }
+  return { ...base, canReplace: true, reason: null };
+}
+
+// An application that has never been replaced has no rows: its one and only
+// version is the file the application form delivered. Represent that implicitly
+// rather than backfilling every historical application.
+function buildVersions(application, rows) {
+  if (rows.length === 0) {
+    if (!application.resumeUrl) return [];
+    return [
+      {
+        id: null,
+        url: application.resumeUrl,
+        originalName: null,
+        sizeBytes: null,
+        uploadedAt: application.submittedAt,
+        replacedByCandidate: false,
+        isCurrent: true,
+      },
+    ];
+  }
+
+  return rows.map((row) => ({
+    id: row.id,
+    url: row.sourceUrl,
+    originalName: row.originalName,
+    sizeBytes: row.sizeBytes,
+    uploadedAt: row.uploadedAt,
+    replacedByCandidate: Boolean(row.storagePath),
+    isCurrent: row.supersededAt === null,
+  }));
+}
+
+const versionRows = (applicationId) =>
+  prisma.resumeUpload.findMany({
+    where: { applicationId },
+    orderBy: { uploadedAt: 'asc' },
+  });
+
+async function loadApplication(res, applicationId, user) {
+  const application = await prisma.application.findUnique({
+    where: { id: applicationId },
+    select: applicationWithOwnership,
+  });
+
+  if (!application) {
+    res.status(404).json({ error: 'Application not found' });
+    return null;
+  }
+  if (!isOwnedBy(application, user) && !isStaff(user)) {
+    res.status(403).json({ error: 'Forbidden' });
+    return null;
+  }
+  return application;
+}
+
+// GET /api/resume-uploads/applications/:applicationId
+// Every version of this application's resume, plus whether the viewer may add
+// another one. Readable by the applicant and by staff.
+router.get('/applications/:applicationId', requireAuth, async (req, res) => {
+  try {
+    const application = await loadApplication(res, req.params.applicationId, req.user);
+    if (!application) return;
+
+    const rows = await versionRows(application.id);
+    const window = replacementWindow(application, req.user);
+
+    res.json({
+      applicationId: application.id,
+      currentResumeUrl: application.resumeUrl,
+      maxBytes: MAX_RESUME_BYTES,
+      canReplace: window.canReplace,
+      reason: window.reason,
+      deadline: window.deadline ? window.deadline.toISOString() : null,
+      deadlineLabel: window.deadlineLabel,
+      versions: buildVersions(application, rows),
+    });
+  } catch (error) {
+    console.error('[GET /api/resume-uploads/applications/:applicationId]', error);
+    res.status(500).json({ error: 'Failed to load resume history' });
+  }
+});
+
+// POST /api/resume-uploads/applications/:applicationId
+// Replace the resume on an application with a freshly uploaded PDF. Candidates
+// only: staff replacing an applicant's documents is deliberately not a thing.
+router.post(
+  '/applications/:applicationId',
+  requireAuth,
+  resumeUpload.single('resume'),
+  async (req, res) => {
+    let writtenPath = null;
+    try {
+      const application = await prisma.application.findUnique({
+        where: { id: req.params.applicationId },
+        select: applicationWithOwnership,
+      });
+      if (!application) return res.status(404).json({ error: 'Application not found' });
+
+      // Ownership is checked before the window so staff get "not yours", not a
+      // deadline message about someone else's application.
+      if (!isOwnedBy(application, req.user)) {
+        return res.status(403).json({ error: 'Only the applicant can replace this resume.' });
+      }
+
+      const window = replacementWindow(application, req.user);
+      if (!window.canReplace) return res.status(403).json({ error: window.reason });
+
+      if (!req.file) return res.status(400).json({ error: 'No resume file was uploaded' });
+      // Trust the bytes, not the declared content type.
+      if (!req.file.buffer.subarray(0, 5).equals(Buffer.from('%PDF-'))) {
+        return res.status(400).json({ error: 'That file is not a readable PDF' });
+      }
+
+      const uploadId = crypto.randomUUID();
+      const relativePath = path.posix.join('resumes', application.id, `${uploadId}.pdf`);
+      const absolutePath = path.join(STORAGE_DIR, relativePath);
+      const servedUrl = `/api/resume-uploads/${uploadId}/file`;
+
+      await fsPromises.mkdir(path.dirname(absolutePath), { recursive: true });
+      await fsPromises.writeFile(absolutePath, req.file.buffer);
+      writtenPath = absolutePath;
+
+      const existing = await versionRows(application.id);
+      const now = new Date();
+
+      await prisma.$transaction([
+        // First replacement: capture the resume being replaced, so the file a
+        // reviewer scored stays reachable even though it lives in Drive.
+        ...(existing.length === 0 && application.resumeUrl
+          ? [
+              prisma.resumeUpload.create({
+                data: {
+                  applicationId: application.id,
+                  storagePath: null,
+                  sourceUrl: application.resumeUrl,
+                  uploadedAt: application.submittedAt,
+                  supersededAt: now,
+                },
+              }),
+            ]
+          : []),
+        prisma.resumeUpload.updateMany({
+          where: { applicationId: application.id, supersededAt: null },
+          data: { supersededAt: now },
+        }),
+        prisma.resumeUpload.create({
+          data: {
+            id: uploadId,
+            applicationId: application.id,
+            storagePath: relativePath,
+            sourceUrl: servedUrl,
+            originalName: req.file.originalname || null,
+            sizeBytes: req.file.size,
+            uploadedById: req.user.id,
+            uploadedAt: now,
+          },
+        }),
+        prisma.application.update({
+          where: { id: application.id },
+          data: {
+            resumeUrl: servedUrl,
+            // The anonymized copy was derived from the resume just replaced.
+            blindResumeUrl: null,
+          },
+        }),
+      ]);
+
+      const rows = await versionRows(application.id);
+      res.status(201).json({
+        message: 'Your resume has been updated.',
+        currentResumeUrl: servedUrl,
+        versions: buildVersions({ ...application, resumeUrl: servedUrl }, rows),
+      });
+    } catch (error) {
+      // Don't leave an orphaned file behind if the database write failed.
+      if (writtenPath) await fsPromises.unlink(writtenPath).catch(() => {});
+      console.error('[POST /api/resume-uploads/applications/:applicationId]', error);
+      res.status(500).json({ error: 'Failed to upload resume' });
+    }
+  }
+);
+
+// GET /api/resume-uploads/:uploadId/file
+// The only way a stored replacement resume is served. Applicant or staff.
+router.get('/:uploadId/file', requireAuth, async (req, res) => {
+  try {
+    const upload = await prisma.resumeUpload.findUnique({
+      where: { id: req.params.uploadId },
+      select: {
+        storagePath: true,
+        originalName: true,
+        application: { select: applicationWithOwnership },
+      },
+    });
+
+    if (!upload || !upload.storagePath) return res.status(404).json({ error: 'Resume not found' });
+    if (!isOwnedBy(upload.application, req.user) && !isStaff(req.user)) {
+      return res.status(403).json({ error: 'Forbidden' });
+    }
+
+    const absolutePath = path.join(STORAGE_DIR, upload.storagePath);
+    // Defensive: the path comes from the database, but a traversal in it would
+    // otherwise hand out arbitrary files.
+    if (!absolutePath.startsWith(RESUME_ROOT + path.sep)) {
+      return res.status(400).json({ error: 'Invalid path' });
+    }
+    if (!fs.existsSync(absolutePath)) return res.status(404).json({ error: 'Resume file not found' });
+
+    res.setHeader('Content-Type', 'application/pdf');
+    res.setHeader('Content-Disposition', 'inline');
+    res.setHeader('Cache-Control', 'private, max-age=3600');
+    fs.createReadStream(absolutePath).pipe(res);
+  } catch (error) {
+    console.error('[GET /api/resume-uploads/:uploadId/file]', error);
+    res.status(500).json({ error: 'Failed to serve resume' });
+  }
+});
+
+// Multer rejects oversized files and non-PDFs before any handler runs; without
+// this they surface as a generic 500.
+router.use((err, req, res, next) => {
+  if (err instanceof multer.MulterError) {
+    if (err.code === 'LIMIT_FILE_SIZE') {
+      return res.status(413).json({
+        error: `Your resume must be smaller than ${Math.round(MAX_RESUME_BYTES / (1024 * 1024))}MB`,
+      });
+    }
+    return res.status(400).json({ error: err.message });
+  }
+  if (err) return res.status(400).json({ error: err.message || 'Upload failed' });
+  next();
+});
+
+export default router;

--- a/server/src/routes/resumeUploads.routes.test.js
+++ b/server/src/routes/resumeUploads.routes.test.js
@@ -1,0 +1,331 @@
+// Route-level coverage for candidate resume replacement: ownership, the
+// deadline/active-cycle window, PDF validation, and the version history that
+// keeps the file a reviewer actually scored reachable after a swap.
+import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest';
+import express from 'express';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import jwt from 'jsonwebtoken';
+import prisma from '../prismaClient.js';
+import resumeUploadRoutes, { resumeDeadlineAt, replacementWindow } from './resumeUploads.js';
+
+// The upload path genuinely writes to server/storage; the successful cases below
+// leave real files behind, so this is torn down at the end of the run.
+const STORAGE_DIR = path.join(path.dirname(fileURLToPath(import.meta.url)), '../../storage');
+
+vi.mock('../prismaClient.js', () => ({
+  default: {
+    user: { findUnique: vi.fn() },
+    application: { findUnique: vi.fn(), update: vi.fn() },
+    resumeUpload: { findMany: vi.fn(), findUnique: vi.fn(), create: vi.fn(), updateMany: vi.fn() },
+    $transaction: vi.fn((ops) => Promise.all(ops)),
+  },
+}));
+
+const candidateUser = {
+  id: 'user-1',
+  role: 'USER',
+  isActive: true,
+  email: 'cand@example.com',
+  fullName: 'Cand Idate',
+  studentId: '405123456',
+};
+const otherCandidate = {
+  id: 'user-2',
+  role: 'USER',
+  isActive: true,
+  email: 'other@example.com',
+  fullName: 'Other Person',
+  studentId: '405999999',
+};
+const memberUser = {
+  id: 'member-1',
+  role: 'MEMBER',
+  isActive: true,
+  email: 'member@example.com',
+  fullName: 'Member One',
+  studentId: null,
+};
+
+// Far enough out that the window stays open without freezing the clock.
+const openDeadline = `${new Date().getFullYear() + 5}-10-04`;
+
+const application = (overrides = {}) => ({
+  id: 'app-1',
+  email: candidateUser.email,
+  studentId: candidateUser.studentId,
+  resumeUrl: '/api/files/drive-file-1/pdf',
+  submittedAt: new Date('2026-09-01T12:00:00Z'),
+  candidate: { email: candidateUser.email, studentId: candidateUser.studentId },
+  cycle: { id: 'cycle-1', name: 'Fall 2026', isActive: true, resumeDeadline: openDeadline },
+  ...overrides,
+});
+
+const tokenFor = (user) => jwt.sign({ userId: user.id }, process.env.JWT_SECRET);
+
+let server;
+let port;
+
+const request = (path, { user, method = 'GET' } = {}) => {
+  const headers = {};
+  if (user) headers.Authorization = `Bearer ${tokenFor(user)}`;
+  return fetch(`http://localhost:${port}${path}`, { method, headers });
+};
+
+// A minimal but genuinely PDF-signed payload, so the magic-byte check passes.
+const pdfBytes = () => new Blob([Buffer.from('%PDF-1.4\n%fake resume\n')], { type: 'application/pdf' });
+
+const upload = (path, { user, blob = pdfBytes(), filename = 'resume.pdf' } = {}) => {
+  const body = new FormData();
+  body.append('resume', blob, filename);
+  const headers = {};
+  if (user) headers.Authorization = `Bearer ${tokenFor(user)}`;
+  return fetch(`http://localhost:${port}${path}`, { method: 'POST', headers, body });
+};
+
+beforeAll(async () => {
+  const app = express();
+  app.use('/api/resume-uploads', resumeUploadRoutes);
+  server = app.listen(0);
+  await new Promise((resolve) => server.on('listening', resolve));
+  port = server.address().port;
+});
+
+afterAll(async () => {
+  await new Promise((resolve) => server.close(resolve));
+  fs.rmSync(path.join(STORAGE_DIR, 'resumes', 'app-1'), { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  prisma.user.findUnique.mockImplementation(({ where: { id } }) =>
+    [candidateUser, otherCandidate, memberUser].find((u) => u.id === id) || null
+  );
+  prisma.application.findUnique.mockResolvedValue(application());
+  prisma.resumeUpload.findMany.mockResolvedValue([]);
+  prisma.resumeUpload.create.mockImplementation(({ data }) => Promise.resolve({ ...data }));
+  prisma.resumeUpload.updateMany.mockResolvedValue({ count: 0 });
+  prisma.application.update.mockResolvedValue({});
+});
+
+describe('resume deadline parsing', () => {
+  it('closes an ISO deadline at the end of that day, not at midnight', () => {
+    const deadline = resumeDeadlineAt({ id: 'c', resumeDeadline: '2026-10-04' });
+    expect(deadline.getFullYear()).toBe(2026);
+    expect(deadline.getMonth()).toBe(9);
+    expect(deadline.getDate()).toBe(4);
+    expect(deadline.getHours()).toBe(23);
+  });
+
+  it('treats legacy free-text deadlines as no deadline rather than locking candidates out', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(resumeDeadlineAt({ id: 'c', resumeDeadline: 'Oct 4th, Morning' })).toBeNull();
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it('treats a null or blank deadline as no deadline', () => {
+    expect(resumeDeadlineAt({ id: 'c', resumeDeadline: null })).toBeNull();
+    expect(resumeDeadlineAt({ id: 'c', resumeDeadline: '   ' })).toBeNull();
+  });
+});
+
+describe('replacement window', () => {
+  it('is open for the applicant before the deadline', () => {
+    expect(replacementWindow(application(), candidateUser).canReplace).toBe(true);
+  });
+
+  it('closes once the deadline has passed', () => {
+    const window = replacementWindow(
+      application({ cycle: { id: 'c', name: 'Fall 2026', isActive: true, resumeDeadline: '2026-10-04' } }),
+      candidateUser,
+      new Date('2026-10-05T00:00:01')
+    );
+    expect(window.canReplace).toBe(false);
+    expect(window.reason).toMatch(/deadline/i);
+  });
+
+  it('closes for a cycle that is no longer active', () => {
+    const window = replacementWindow(
+      application({ cycle: { id: 'c', name: 'Fall 2025', isActive: false, resumeDeadline: openDeadline } }),
+      candidateUser
+    );
+    expect(window.canReplace).toBe(false);
+    expect(window.reason).toMatch(/closed/i);
+  });
+
+  it('matches an applicant by student ID when the emails differ', () => {
+    const window = replacementWindow(
+      application({ email: 'old-address@example.com', candidate: null }),
+      candidateUser
+    );
+    expect(window.canReplace).toBe(true);
+  });
+});
+
+describe('GET /api/resume-uploads/applications/:applicationId', () => {
+  it('rejects unauthenticated requests', async () => {
+    const res = await request('/api/resume-uploads/applications/app-1');
+    expect(res.status).toBe(401);
+  });
+
+  it('refuses to show one candidate another candidate\'s resume history', async () => {
+    const res = await request('/api/resume-uploads/applications/app-1', { user: otherCandidate });
+    expect(res.status).toBe(403);
+  });
+
+  it('reports the single implicit version for an application never replaced', async () => {
+    const res = await request('/api/resume-uploads/applications/app-1', { user: candidateUser });
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.canReplace).toBe(true);
+    expect(body.versions).toHaveLength(1);
+    expect(body.versions[0]).toMatchObject({
+      id: null,
+      url: '/api/files/drive-file-1/pdf',
+      isCurrent: true,
+      replacedByCandidate: false,
+    });
+  });
+
+  it('lets staff read the history but not replace the resume', async () => {
+    const res = await request('/api/resume-uploads/applications/app-1', { user: memberUser });
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.canReplace).toBe(false);
+    expect(body.reason).toMatch(/only the applicant/i);
+  });
+
+  it('404s on an application that does not exist', async () => {
+    prisma.application.findUnique.mockResolvedValue(null);
+    const res = await request('/api/resume-uploads/applications/nope', { user: candidateUser });
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('POST /api/resume-uploads/applications/:applicationId', () => {
+  it('stores the new resume, supersedes the old one, and repoints the application', async () => {
+    const res = await upload('/api/resume-uploads/applications/app-1', { user: candidateUser });
+    const body = await res.json();
+
+    expect(res.status).toBe(201);
+
+    // The resume being replaced is captured first, so a score recorded against
+    // the Drive-hosted original still resolves to a file.
+    const captured = prisma.resumeUpload.create.mock.calls[0][0].data;
+    expect(captured).toMatchObject({
+      applicationId: 'app-1',
+      storagePath: null,
+      sourceUrl: '/api/files/drive-file-1/pdf',
+    });
+    expect(captured.supersededAt).toBeInstanceOf(Date);
+
+    expect(prisma.resumeUpload.updateMany).toHaveBeenCalledWith({
+      where: { applicationId: 'app-1', supersededAt: null },
+      data: { supersededAt: expect.any(Date) },
+    });
+
+    const created = prisma.resumeUpload.create.mock.calls[1][0].data;
+    expect(created.storagePath).toMatch(/^resumes\/app-1\/[0-9a-f-]+\.pdf$/);
+    expect(created.originalName).toBe('resume.pdf');
+    expect(created.uploadedById).toBe(candidateUser.id);
+
+    expect(prisma.application.update).toHaveBeenCalledWith({
+      where: { id: 'app-1' },
+      data: { resumeUrl: created.sourceUrl, blindResumeUrl: null },
+    });
+    expect(body.currentResumeUrl).toBe(created.sourceUrl);
+
+    // The bytes really landed where the row says they did.
+    expect(fs.existsSync(path.join(STORAGE_DIR, created.storagePath))).toBe(true);
+  });
+
+  it('does not re-capture the original once a version history exists', async () => {
+    prisma.resumeUpload.findMany.mockResolvedValue([
+      {
+        id: 'v1',
+        applicationId: 'app-1',
+        storagePath: null,
+        sourceUrl: '/api/files/drive-file-1/pdf',
+        uploadedAt: new Date('2026-09-01T12:00:00Z'),
+        supersededAt: new Date('2026-09-10T12:00:00Z'),
+        originalName: null,
+        sizeBytes: null,
+      },
+    ]);
+
+    const res = await upload('/api/resume-uploads/applications/app-1', { user: candidateUser });
+    expect(res.status).toBe(201);
+    expect(prisma.resumeUpload.create).toHaveBeenCalledTimes(1);
+  });
+
+  it('refuses an upload from anyone but the applicant', async () => {
+    const [other, staff] = await Promise.all([
+      upload('/api/resume-uploads/applications/app-1', { user: otherCandidate }),
+      upload('/api/resume-uploads/applications/app-1', { user: memberUser }),
+    ]);
+
+    expect([other.status, staff.status]).toEqual([403, 403]);
+    expect(prisma.application.update).not.toHaveBeenCalled();
+  });
+
+  it('refuses an upload after the deadline has passed', async () => {
+    prisma.application.findUnique.mockResolvedValue(
+      application({ cycle: { id: 'c', name: 'Fall 2026', isActive: true, resumeDeadline: '2020-10-04' } })
+    );
+
+    const res = await upload('/api/resume-uploads/applications/app-1', { user: candidateUser });
+    expect(res.status).toBe(403);
+    expect((await res.json()).error).toMatch(/deadline/i);
+    expect(prisma.application.update).not.toHaveBeenCalled();
+  });
+
+  it('refuses a file that is not really a PDF', async () => {
+    const res = await upload('/api/resume-uploads/applications/app-1', {
+      user: candidateUser,
+      blob: new Blob([Buffer.from('PK\x03\x04 not a pdf')], { type: 'application/pdf' }),
+    });
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/not a readable pdf/i);
+    expect(prisma.application.update).not.toHaveBeenCalled();
+  });
+
+  it('refuses a non-PDF content type outright', async () => {
+    const res = await upload('/api/resume-uploads/applications/app-1', {
+      user: candidateUser,
+      blob: new Blob([Buffer.from('hello')], { type: 'image/png' }),
+      filename: 'resume.png',
+    });
+
+    expect(res.status).toBe(400);
+    expect(prisma.application.update).not.toHaveBeenCalled();
+  });
+});
+
+describe('GET /api/resume-uploads/:uploadId/file', () => {
+  it('refuses to serve one candidate another candidate\'s stored resume', async () => {
+    prisma.resumeUpload.findUnique.mockResolvedValue({
+      storagePath: 'resumes/app-1/v2.pdf',
+      originalName: 'resume.pdf',
+      application: application(),
+    });
+
+    const res = await request('/api/resume-uploads/v2/file', { user: otherCandidate });
+    expect(res.status).toBe(403);
+  });
+
+  it('404s for a version whose file lives in Drive rather than our storage', async () => {
+    prisma.resumeUpload.findUnique.mockResolvedValue({
+      storagePath: null,
+      originalName: null,
+      application: application(),
+    });
+
+    const res = await request('/api/resume-uploads/v1/file', { user: candidateUser });
+    expect(res.status).toBe(404);
+  });
+});

--- a/server/src/utils/applicationOwnership.js
+++ b/server/src/utils/applicationOwnership.js
@@ -1,0 +1,29 @@
+// Who owns an application, and who is staff.
+//
+// Applications arrive from the Google Form before the applicant has an account,
+// so there is no foreign key from Application to User to lean on. Ownership is
+// therefore matched on the two identifiers the form collects: student ID and
+// email, either directly on the Application row or on the Candidate it was
+// linked to during sync.
+//
+// This lives here rather than in a route because more than one candidate
+// self-service endpoint depends on it (resume replacement, applicant info), and
+// the whole point is that they agree on the answer.
+
+export function isOwnedBy(application, user) {
+  if (!user) return false;
+
+  const emails = [application.email, application.candidate?.email]
+    .filter(Boolean)
+    .map((value) => value.toLowerCase());
+  if (user.email && emails.includes(user.email.toLowerCase())) return true;
+
+  const studentIds = [application.studentId, application.candidate?.studentId]
+    .filter(Boolean)
+    .map(String);
+  if (user.studentId && studentIds.includes(String(user.studentId))) return true;
+
+  return false;
+}
+
+export const isStaff = (user) => user?.role === 'ADMIN' || user?.role === 'MEMBER';


### PR DESCRIPTION
## What

Applicants had no way to change a resume after submitting — the only path into `Application.resumeUrl` was the Google Forms sync. This adds a self-service replace flow under **My Applications → Documents & Links**, plus the version history that makes it safe to swap a document reviewers are actively scoring.

## How it works

`/api/resume-uploads` exposes three endpoints:

| | |
|---|---|
| `GET /applications/:id` | every version of the resume + whether the viewer may add another |
| `POST /applications/:id` | upload a replacement PDF (10MB cap) |
| `GET /:uploadId/file` | stream a stored version |

Files land in `server/storage/resumes/` next to case PDFs — **outside** the statically served `uploads/` directory — so the authorized proxy is the only way to read one. Uploads are held in memory until the window and ownership checks pass, and the bytes are checked for a `%PDF-` signature rather than trusting the declared content type.

### Who may replace, and when

- **The applicant only**, matched by student ID or email the way `files.js` does it. Applications predate the User account that later claims them, so there is no foreign key to lean on.
- **The cycle must still be active.**
- **`RecruitingCycle.resumeDeadline` must not have passed.** That column is free text: bootstrap-created cycles store `YYYY-MM-DD` (closed at end of day), while older rows hold prose like `"Oct 4th, Morning"`. An unparseable value is treated as *no deadline recorded* and logged, rather than locking candidates out over a formatting quirk.

Staff can read the history but not upload — replacing an applicant's documents on their behalf is deliberately not a thing here.

### Version history

The new `resume_uploads` table keeps every version. On the first replacement the *outgoing* resume is captured first, so a `ResumeScore` recorded against the original Drive-hosted file still resolves to that file. `blindResumeUrl` is cleared on replace, because the anonymized copy was derived from the resume being replaced.

Staff read paths are untouched: every resume viewer (`ApplicationDetail`, `DocumentGradingModal`, `ResumeGradingModal`, `AdminAssignedInterviews`) already fetches `resumeUrl` with a bearer token rather than parsing a Drive id out of it, so the new URL shape works unchanged.

## Before this merges

1. **The migration has not been applied.** `20260826000000_add_resume_uploads` is written to be re-runnable — apply it with the session-pooler steps in CLAUDE.md while `DIRECT_URL` is broken, then `prisma migrate resolve --applied`.
2. **Storage needs a persistent disk.** `render.yaml` declares none, so on Render these files are lost on redeploy. Fine for PR previews; production needs a disk mounted at `server/storage` (case PDFs have the same exposure today).

## Testing

- 20 new server route tests: ownership, deadline/active-cycle window, PDF validation, the capture-the-original-on-first-replace behavior, and cross-candidate access denial.
- 5 new client component tests: open vs. closed window, upload round-trip, non-PDF rejection, failure surfacing.
- Full client suite 230/230; client build clean.
- Server suite 251/254 — the 3 failures are in `offerLetter.test.js` (Supabase/sharp environment) and fail identically on a stashed baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DTkzdzPpE311WSpYiWe2wm
