### PR TITLE
Members: Talent Partner Network page, login reminder, and admin visibility

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -43,6 +43,7 @@ import InterviewPreparation from './pages/InterviewPreparation';
 import InterviewDetail from './pages/InterviewDetail';
 import CoffeeChatsPublic from './pages/CoffeeChatsPublic';
 import MemberMeetingSlots from './pages/MemberMeetingSlots';
+import MemberTalentNetwork from './pages/MemberTalentNetwork';
 import AdminMeetingSlots from './pages/AdminMeetingSlots';
 import ReleaseNotes from './pages/ReleaseNotes';
 import CandidateList from './pages/CandidateList';
@@ -514,6 +515,15 @@ const AppRoutes = () => {
       {/* Public meeting signup page */}
       <Route path="/meet" element={<CoffeeChatsPublic />} />
       {/* Member meeting slots management */}
+      <Route
+        path="/member/talent-network"
+        element={
+          <ProtectedRoute>
+            <MemberTalentNetwork />
+          </ProtectedRoute>
+        }
+      />
+
       <Route
         path="/member/meeting-slots"
         element={

--- a/client/src/components/Layout.jsx
+++ b/client/src/components/Layout.jsx
@@ -26,6 +26,7 @@ import {
 import UConsultingLogo from './UConsultingLogo';
 import MessageAdminModal from './MessageAdminModal';
 import FeatureRequestModal from './FeatureRequestModal';
+import MemberTalentNetworkPrompt from './MemberTalentNetworkPrompt';
 import MemberAvatar from './MemberAvatar';
 import ThemeToggle from './ThemeToggle';
 import '../styles/Layout.css';
@@ -57,6 +58,7 @@ const Layout = ({ children }) => {
       { name: 'Assigned Interviews', href: '/assigned-interviews', icon: UserGroupIcon2 },
       { name: 'Applications', href: '/candidates', icon: DocumentTextIcon },
       { name: 'Get to Know UC', href: '/member/meeting-slots', icon: ChatBubbleLeftRightIcon },
+      { name: 'Talent Network', href: '/member/talent-network', icon: BriefcaseIcon },
       { name: 'Message an Admin', href: '#', icon: ChatBubbleOvalLeftEllipsisIcon, isAction: true },
     ] : user?.role === 'ADMIN' ? [
       { name: 'Applications', href: '/application-list', icon: DocumentTextIcon },
@@ -226,6 +228,9 @@ const Layout = ({ children }) => {
         open={featureRequestOpen}
         onClose={() => setFeatureRequestOpen(false)}
       />
+      {/* Decides for itself whether to show - it is a no-op for anyone who is
+          not a member, and for a member who already has a resume. */}
+      <MemberTalentNetworkPrompt />
     </div>
   );
 };

--- a/client/src/components/MemberResumeCard.jsx
+++ b/client/src/components/MemberResumeCard.jsx
@@ -1,23 +1,28 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import {
   Alert,
+  Box,
   Button,
   Card,
   CardContent,
-  Checkbox,
   Chip,
   Divider,
   FormControl,
   FormControlLabel,
+  FormLabel,
   Grid,
   InputLabel,
   MenuItem,
+  Radio,
+  RadioGroup,
   Select,
   Stack,
   TextField,
   Typography,
 } from '@mui/material';
 import apiClient from '../utils/api';
+import { MAJOR_OPTIONS, OTHER_MAJOR } from '../utils/majors';
+import { GRADUATION_YEARS } from '../utils/graduationYears';
 import DocumentPreviewModal from './DocumentPreviewModal';
 
 // A member's own resume for the Talent Partner Network, plus the consent that
@@ -31,12 +36,14 @@ const MemberResumeCard = () => {
   const [genders, setGenders] = useState([]);
   const [form, setForm] = useState(emptyForm);
   const [file, setFile] = useState(null);
-  const [consent, setConsent] = useState(false);
+  const [consent, setConsent] = useState('');
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState('');
   const [success, setSuccess] = useState('');
   const [previewOpen, setPreviewOpen] = useState(false);
+  const [major1Other, setMajor1Other] = useState('');
+  const [major2Other, setMajor2Other] = useState('');
 
   const load = useCallback(async () => {
     try {
@@ -44,12 +51,22 @@ const MemberResumeCard = () => {
       setResume(data.resume);
       setGenders(data.genders || []);
       if (data.resume) {
+        // A stored major that is not one of the options came from "Other" -
+        // members who filled this in when it was a free-text field are the
+        // common case, and dropping their answer on load would be worse than
+        // the typo the dropdown exists to prevent.
+        const bucket = (value) =>
+          MAJOR_OPTIONS.includes(value) ? value : value ? OTHER_MAJOR : '';
+
         setForm({
-          major1: data.resume.major1 || '',
-          major2: data.resume.major2 || '',
+          major1: bucket(data.resume.major1),
+          major2: bucket(data.resume.major2),
           graduationYear: data.resume.graduationYear || '',
           gender: data.resume.gender || '',
         });
+        setMajor1Other(MAJOR_OPTIONS.includes(data.resume.major1) ? '' : data.resume.major1 || '');
+        setMajor2Other(MAJOR_OPTIONS.includes(data.resume.major2) ? '' : data.resume.major2 || '');
+        setConsent(String(Boolean(data.resume.shareConsent)));
       }
     } catch (err) {
       setError(err.message || 'Failed to load your resume');
@@ -63,17 +80,45 @@ const MemberResumeCard = () => {
   }, [load]);
 
   const upload = async () => {
-    if (!file) return;
+    if (!file) {
+      setError('Attach your resume as a PDF.');
+      return;
+    }
+
+    // Caught here rather than at the server so the file selection survives -
+    // a rejected upload that also cleared the chosen PDF would make a typo
+    // cost two steps to fix.
+    if (form.major1 === OTHER_MAJOR && !major1Other.trim()) {
+      setError('Type your major.');
+      return;
+    }
+    if (form.major2 === OTHER_MAJOR && !major2Other.trim()) {
+      setError('Type your second major, or choose one from the list.');
+      return;
+    }
+
+    if (!form.graduationYear) {
+      setError('Choose your graduation year.');
+      return;
+    }
+
+    if (consent !== 'true' && consent !== 'false') {
+      setError('Choose whether we may share your resume with partner organizations.');
+      return;
+    }
+
     setSaving(true);
     setError('');
     try {
       const body = new FormData();
       body.append('resume', file);
-      body.append('major1', form.major1);
-      body.append('major2', form.major2);
+      // The sentinel never leaves this component - what is stored is the typed
+      // major, so it filters alongside every other major in the pool.
+      body.append('major1', form.major1 === OTHER_MAJOR ? major1Other.trim() : form.major1);
+      body.append('major2', form.major2 === OTHER_MAJOR ? major2Other.trim() : form.major2);
       body.append('graduationYear', form.graduationYear);
       body.append('gender', form.gender);
-      body.append('shareConsent', String(consent));
+      body.append('shareConsent', consent);
 
       await apiClient.post('/member/resume', body);
       setFile(null);
@@ -172,39 +217,86 @@ const MemberResumeCard = () => {
 
         <Grid container spacing={2} sx={{ mt: 0 }}>
           <Grid size={{ xs: 12, sm: 6 }}>
-            <TextField
-              fullWidth
-              size="small"
-              required
-              label="Major"
-              value={form.major1}
-              onChange={(e) => setForm({ ...form, major1: e.target.value })}
-            />
+            <FormControl fullWidth size="small" required>
+              <InputLabel id="member-major1-label">Major</InputLabel>
+              <Select
+                labelId="member-major1-label"
+                id="member-major1"
+                value={form.major1}
+                label="Major"
+                onChange={(e) => setForm({ ...form, major1: e.target.value })}
+              >
+                {MAJOR_OPTIONS.map((m) => (
+                  <MenuItem key={m} value={m}>{m}</MenuItem>
+                ))}
+                <MenuItem value={OTHER_MAJOR}>Other</MenuItem>
+              </Select>
+            </FormControl>
           </Grid>
+          {form.major1 === OTHER_MAJOR && (
+            <Grid size={{ xs: 12, sm: 6 }}>
+              <TextField
+                fullWidth
+                size="small"
+                required
+                label="Your major"
+                value={major1Other}
+                onChange={(e) => setMajor1Other(e.target.value)}
+              />
+            </Grid>
+          )}
           <Grid size={{ xs: 12, sm: 6 }}>
-            <TextField
-              fullWidth
-              size="small"
-              label="Second major (optional)"
-              value={form.major2}
-              onChange={(e) => setForm({ ...form, major2: e.target.value })}
-            />
+            <FormControl fullWidth size="small">
+              <InputLabel id="member-major2-label">Second major (optional)</InputLabel>
+              <Select
+                labelId="member-major2-label"
+                id="member-major2"
+                value={form.major2}
+                label="Second major (optional)"
+                onChange={(e) => setForm({ ...form, major2: e.target.value })}
+              >
+                <MenuItem value="">None</MenuItem>
+                {MAJOR_OPTIONS.map((m) => (
+                  <MenuItem key={m} value={m}>{m}</MenuItem>
+                ))}
+                <MenuItem value={OTHER_MAJOR}>Other</MenuItem>
+              </Select>
+            </FormControl>
           </Grid>
+          {form.major2 === OTHER_MAJOR && (
+            <Grid size={{ xs: 12, sm: 6 }}>
+              <TextField
+                fullWidth
+                size="small"
+                required
+                label="Your second major"
+                value={major2Other}
+                onChange={(e) => setMajor2Other(e.target.value)}
+              />
+            </Grid>
+          )}
           <Grid size={{ xs: 12, sm: 6 }}>
-            <TextField
-              fullWidth
-              size="small"
-              required
-              label="Graduation year"
-              placeholder="2027"
-              value={form.graduationYear}
-              onChange={(e) => setForm({ ...form, graduationYear: e.target.value })}
-            />
+            <FormControl fullWidth size="small" required>
+              <InputLabel id="member-graduation-year-label">Graduation year</InputLabel>
+              <Select
+                labelId="member-graduation-year-label"
+                id="member-graduation-year"
+                value={form.graduationYear}
+                label="Graduation year"
+                onChange={(e) => setForm({ ...form, graduationYear: e.target.value })}
+              >
+                {GRADUATION_YEARS.map((year) => (
+                  <MenuItem key={year} value={year}>{year}</MenuItem>
+                ))}
+              </Select>
+            </FormControl>
           </Grid>
           <Grid size={{ xs: 12, sm: 6 }}>
             <FormControl fullWidth size="small">
-              <InputLabel>Gender (optional)</InputLabel>
+              <InputLabel id="member-gender-label">Gender (optional)</InputLabel>
               <Select
+                labelId="member-gender-label"
+                id="member-gender"
                 value={form.gender}
                 label="Gender (optional)"
                 onChange={(e) => setForm({ ...form, gender: e.target.value })}
@@ -220,21 +312,45 @@ const MemberResumeCard = () => {
           </Grid>
         </Grid>
 
-        <Stack spacing={1} sx={{ mt: 2 }}>
-          <Button variant="outlined" component="label" size="small" sx={{ alignSelf: 'flex-start' }}>
-            {file ? file.name : 'Choose PDF'}
-            <input
-              hidden
-              type="file"
-              accept="application/pdf"
-              onChange={(e) => setFile(e.target.files?.[0] || null)}
-            />
-          </Button>
+        <Stack spacing={2} sx={{ mt: 3 }}>
+          <Box>
+            <FormLabel required>Resume (PDF)</FormLabel>
+            <Box sx={{ mt: 1 }}>
+              <Button variant="outlined" component="label" size="small">
+                {file ? 'Choose a different file' : 'Choose PDF'}
+                <input
+                  hidden
+                  type="file"
+                  accept="application/pdf"
+                  onChange={(e) => setFile(e.target.files?.[0] || null)}
+                />
+              </Button>
+              {file && (
+                <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+                  {file.name}
+                </Typography>
+              )}
+            </Box>
+          </Box>
 
-          <FormControlLabel
-            control={<Checkbox checked={consent} onChange={(e) => setConsent(e.target.checked)} />}
-            label="My resume may be shared with UConsulting's partner organizations"
-          />
+          {/* Asked as a required yes/no with neither preselected, matching the
+              candidate onboarding form. A checkbox cannot tell "no" apart from
+              "did not answer", and reading the second as permission is how a
+              resume reaches a company on an answer nobody gave. */}
+          <FormControl required>
+            <FormLabel>
+              May we share your resume with UConsulting&apos;s partner organizations?
+            </FormLabel>
+            <RadioGroup
+              row
+              value={consent}
+              onChange={(e) => setConsent(e.target.value)}
+              sx={{ mt: 0.5 }}
+            >
+              <FormControlLabel value="true" control={<Radio size="small" />} label="Yes" />
+              <FormControlLabel value="false" control={<Radio size="small" />} label="No" />
+            </RadioGroup>
+          </FormControl>
 
           <Button
             variant="contained"

--- a/client/src/components/MemberResumeCard.jsx
+++ b/client/src/components/MemberResumeCard.jsx
@@ -171,7 +171,7 @@ const MemberResumeCard = () => {
         )}
 
         <Grid container spacing={2} sx={{ mt: 0 }}>
-          <Grid item xs={12} sm={6}>
+          <Grid size={{ xs: 12, sm: 6 }}>
             <TextField
               fullWidth
               size="small"
@@ -181,7 +181,7 @@ const MemberResumeCard = () => {
               onChange={(e) => setForm({ ...form, major1: e.target.value })}
             />
           </Grid>
-          <Grid item xs={12} sm={6}>
+          <Grid size={{ xs: 12, sm: 6 }}>
             <TextField
               fullWidth
               size="small"
@@ -190,7 +190,7 @@ const MemberResumeCard = () => {
               onChange={(e) => setForm({ ...form, major2: e.target.value })}
             />
           </Grid>
-          <Grid item xs={12} sm={6}>
+          <Grid size={{ xs: 12, sm: 6 }}>
             <TextField
               fullWidth
               size="small"
@@ -201,7 +201,7 @@ const MemberResumeCard = () => {
               onChange={(e) => setForm({ ...form, graduationYear: e.target.value })}
             />
           </Grid>
-          <Grid item xs={12} sm={6}>
+          <Grid size={{ xs: 12, sm: 6 }}>
             <FormControl fullWidth size="small">
               <InputLabel>Gender (optional)</InputLabel>
               <Select

--- a/client/src/components/MemberResumeCard.test.jsx
+++ b/client/src/components/MemberResumeCard.test.jsx
@@ -1,0 +1,204 @@
+// The member Talent Partner Network resume form.
+//
+// The majors are dropdowns now, which introduces the one thing worth pinning
+// down: a member whose stored major predates the dropdown must still see their
+// answer. Everything else here is the consent rule - a resume must never reach
+// a partner on an answer nobody gave.
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import MemberResumeCard from './MemberResumeCard';
+import apiClient from '../utils/api';
+import { MAJOR_OPTIONS } from '../utils/majors';
+
+vi.mock('./DocumentPreviewModal', () => ({ default: () => <div /> }));
+
+const load = (resume = null) =>
+  vi.spyOn(apiClient, 'get').mockResolvedValue({ resume, genders: ['Male', 'Female', 'Other'] });
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+const stored = (overrides = {}) => ({
+  id: 'mr-1',
+  originalName: 'resume.pdf',
+  fileSize: 1024,
+  major1: 'Life Sciences',
+  major2: null,
+  graduationYear: '2027',
+  gender: 'Female',
+  shareConsent: false,
+  consentAt: null,
+  consentRevokedAt: null,
+  assignedCount: 0,
+  ...overrides,
+});
+
+const pdf = () => new File(['%PDF-1.4'], 'resume.pdf', { type: 'application/pdf' });
+
+// Two radios in document order: consent Yes, then No.
+const CONSENT_YES = 0;
+const CONSENT_NO = 1;
+
+const chooseYear = async (user, year = '2028') => {
+  await user.click(screen.getByRole('combobox', { name: /Graduation year/ }));
+  await user.click(await screen.findByRole('option', { name: year }));
+};
+
+describe('the major dropdowns', () => {
+  it('offers the same categories the application form does, plus Other', async () => {
+    load();
+    render(<MemberResumeCard />);
+
+    const user = userEvent.setup();
+    await user.click(await screen.findByRole('combobox', { name: /^Major/ }));
+
+    for (const option of MAJOR_OPTIONS) {
+      expect(await screen.findByRole('option', { name: option })).toBeInTheDocument();
+    }
+    expect(await screen.findByRole('option', { name: 'Other' })).toBeInTheDocument();
+  });
+
+  it('shows a stored category as the selected option', async () => {
+    load(stored({ major1: 'Life Sciences' }));
+    render(<MemberResumeCard />);
+    expect(await screen.findByText('Life Sciences')).toBeInTheDocument();
+  });
+
+  it('keeps a free-text major from before the dropdown existed', async () => {
+    // Members filled this in as free text until now. Dropping what they typed
+    // on load would be a worse bug than the typos the dropdown prevents.
+    load(stored({ major1: 'Marine Biology' }));
+    render(<MemberResumeCard />);
+    expect(await screen.findByDisplayValue('Marine Biology')).toBeInTheDocument();
+  });
+
+  it('reveals a text field when Other is chosen', async () => {
+    load();
+    render(<MemberResumeCard />);
+
+    const user = userEvent.setup();
+    await user.click(await screen.findByRole('combobox', { name: /^Major/ }));
+    await user.click(await screen.findByRole('option', { name: 'Other' }));
+
+    expect(await screen.findByLabelText(/Your major/)).toBeInTheDocument();
+  });
+
+  it('submits what was typed, never the sentinel', async () => {
+    load();
+    const post = vi.spyOn(apiClient, 'post').mockResolvedValue({ resume: stored() });
+    render(<MemberResumeCard />);
+
+    const user = userEvent.setup();
+    await user.click(await screen.findByRole('combobox', { name: /^Major/ }));
+    await user.click(await screen.findByRole('option', { name: 'Other' }));
+    await user.type(await screen.findByLabelText(/Your major/), 'Marine Biology');
+    await chooseYear(user);
+    await user.click(screen.getAllByRole('radio')[CONSENT_YES]);
+    await user.upload(document.querySelector('input[type="file"]'), pdf());
+    await user.click(screen.getByRole('button', { name: /Upload resume/i }));
+
+    await waitFor(() => expect(post).toHaveBeenCalled());
+    expect(post.mock.calls[0][1].get('major1')).toBe('Marine Biology');
+    expect(post.mock.calls[0][1].get('shareConsent')).toBe('true');
+  });
+
+  it('refuses an empty Other without discarding the chosen file', async () => {
+    load();
+    const post = vi.spyOn(apiClient, 'post');
+    render(<MemberResumeCard />);
+
+    const user = userEvent.setup();
+    await user.click(await screen.findByRole('combobox', { name: /^Major/ }));
+    await user.click(await screen.findByRole('option', { name: 'Other' }));
+    await user.upload(document.querySelector('input[type="file"]'), pdf());
+    await user.click(screen.getByRole('button', { name: /Upload resume/i }));
+
+    expect(await screen.findByText('Type your major.')).toBeInTheDocument();
+    expect(post).not.toHaveBeenCalled();
+    // The file survives, so fixing the major is one step and not two.
+    expect(screen.getByText('resume.pdf')).toBeInTheDocument();
+  });
+});
+
+describe('consent', () => {
+  it('is asked as a yes/no with neither answer preselected', async () => {
+    load();
+    render(<MemberResumeCard />);
+    await screen.findByRole('combobox', { name: /^Major/ });
+
+    const radios = screen.getAllByRole('radio');
+    // A preselected "yes" would turn a skipped question into permission to
+    // send someone's resume to a company.
+    expect(radios[CONSENT_YES]).not.toBeChecked();
+    expect(radios[CONSENT_NO]).not.toBeChecked();
+  });
+
+  it('reflects the answer already on file rather than resetting it', async () => {
+    // Regression: this was never read back, so a member who had opted in saw a
+    // blank answer and could revoke sharing just by replacing their PDF.
+    load(stored({ shareConsent: true }));
+    render(<MemberResumeCard />);
+    await waitFor(() => expect(screen.getAllByRole('radio')[CONSENT_YES]).toBeChecked());
+  });
+
+  it('reflects a stored no as well', async () => {
+    load(stored({ shareConsent: false }));
+    render(<MemberResumeCard />);
+    await waitFor(() => expect(screen.getAllByRole('radio')[CONSENT_NO]).toBeChecked());
+  });
+
+  it('sends nothing until the question is answered', async () => {
+    load();
+    const post = vi.spyOn(apiClient, 'post');
+    render(<MemberResumeCard />);
+
+    const user = userEvent.setup();
+    await user.click(await screen.findByRole('combobox', { name: /^Major/ }));
+    await user.click(await screen.findByRole('option', { name: MAJOR_OPTIONS[0] }));
+    await chooseYear(user);
+    await user.upload(document.querySelector('input[type="file"]'), pdf());
+    await user.click(screen.getByRole('button', { name: /Upload resume/i }));
+
+    expect(await screen.findByText(/whether we may share your resume/i)).toBeInTheDocument();
+    expect(post).not.toHaveBeenCalled();
+  });
+});
+
+describe('the required fields', () => {
+  it('will not upload without a graduation year', async () => {
+    load();
+    const post = vi.spyOn(apiClient, 'post');
+    render(<MemberResumeCard />);
+
+    const user = userEvent.setup();
+    await user.click(await screen.findByRole('combobox', { name: /^Major/ }));
+    await user.click(await screen.findByRole('option', { name: MAJOR_OPTIONS[0] }));
+    await user.click(screen.getAllByRole('radio')[CONSENT_YES]);
+    await user.upload(document.querySelector('input[type="file"]'), pdf());
+    await user.click(screen.getByRole('button', { name: /Upload resume/i }));
+
+    expect(await screen.findByText('Choose your graduation year.')).toBeInTheDocument();
+    expect(post).not.toHaveBeenCalled();
+  });
+
+  it('offers the graduation years as a dropdown, not free text', async () => {
+    load();
+    render(<MemberResumeCard />);
+
+    const user = userEvent.setup();
+    await user.click(await screen.findByRole('combobox', { name: /Graduation year/ }));
+    for (const year of ['2027', '2028', '2029', '2030']) {
+      expect(await screen.findByRole('option', { name: year })).toBeInTheDocument();
+    }
+  });
+
+  it('cannot be submitted without a PDF', async () => {
+    load();
+    render(<MemberResumeCard />);
+    await screen.findByRole('combobox', { name: /^Major/ });
+
+    expect(screen.getByRole('button', { name: /Upload resume/i })).toBeDisabled();
+  });
+});

--- a/client/src/components/MemberTalentNetworkPrompt.jsx
+++ b/client/src/components/MemberTalentNetworkPrompt.jsx
@@ -1,0 +1,108 @@
+import React, { useEffect, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+} from '@mui/material';
+import apiClient from '../utils/api';
+import { useAuth } from '../context/AuthContext';
+
+// Asks a member to set up their Talent Partner Network resume.
+//
+// Shown once per login and every login until they have one, which is what makes
+// it a reminder rather than a gate: a member has work to do in this app and
+// blocking them from it over an optional resume would be the wrong trade. The
+// once-per-login part matters just as much - re-appearing on every navigation
+// would train people to dismiss it without reading.
+//
+// "Complete" means a resume exists, not that they said yes to sharing. Someone
+// who uploaded and declined has answered the question, and continuing to ask
+// would be nagging them to change a decision they already made.
+
+// sessionStorage, not localStorage: it is cleared when the browser session ends,
+// so the next login asks again. Keyed by user so two people sharing a browser
+// do not inherit each other's dismissal.
+const dismissKey = (userId) => `tpn_prompt_dismissed_${userId}`;
+
+const MemberTalentNetworkPrompt = () => {
+  const { user } = useAuth();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    if (user?.role !== 'MEMBER' || !user?.id) return;
+    // Never over the page it is asking them to visit.
+    if (location.pathname === '/member/talent-network') return;
+
+    let dismissed = false;
+    try {
+      dismissed = sessionStorage.getItem(dismissKey(user.id)) === '1';
+    } catch {
+      // Private mode, or storage disabled. Falling through means the prompt may
+      // appear more than once in a session, which is better than a thrown
+      // exception taking the page down with it.
+    }
+    if (dismissed) return;
+
+    let cancelled = false;
+    apiClient
+      .get('/member/resume')
+      .then((data) => {
+        if (!cancelled && !data.resume) setOpen(true);
+      })
+      // A failed check is not a reason to interrupt someone. Staying quiet costs
+      // one skipped reminder; guessing costs a modal over a broken page.
+      .catch(() => {});
+
+    return () => {
+      cancelled = true;
+    };
+  }, [user?.id, user?.role, location.pathname]);
+
+  const dismiss = () => {
+    try {
+      sessionStorage.setItem(dismissKey(user.id), '1');
+    } catch {
+      // See above - dismissal is a convenience, not a correctness requirement.
+    }
+    setOpen(false);
+  };
+
+  const go = () => {
+    dismiss();
+    navigate('/member/talent-network');
+  };
+
+  return (
+    <Dialog open={open} onClose={dismiss} maxWidth="sm" fullWidth>
+      <DialogTitle>Set up your Talent Partner Network resume</DialogTitle>
+      <DialogContent>
+        <DialogContentText component="div">
+          UConsulting shares member resumes with partner organizations hiring interns and
+          early-career candidates. It takes a minute: upload a PDF, add your major and graduation
+          year, and choose whether we may share it.
+          <br />
+          <br />
+          If you applied in an earlier cycle we already have the resume you applied with, but it is
+          out of date — please upload a current one.
+          <br />
+          <br />
+          Taking part is optional, and you can withdraw at any time.
+        </DialogContentText>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={dismiss}>Not now</Button>
+        <Button variant="contained" onClick={go}>
+          Set it up
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default MemberTalentNetworkPrompt;

--- a/client/src/components/MemberTalentNetworkPrompt.test.jsx
+++ b/client/src/components/MemberTalentNetworkPrompt.test.jsx
@@ -1,0 +1,141 @@
+// The member Talent Partner Network reminder.
+//
+// The rules worth pinning down are all about when it stays quiet: it is a
+// reminder, not a gate, so every way it could become an irritation - showing to
+// the wrong role, showing to someone who already answered, showing twice in a
+// session, showing over the page it points at - is a bug.
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import MemberTalentNetworkPrompt from './MemberTalentNetworkPrompt';
+import apiClient from '../utils/api';
+
+const navigate = vi.fn();
+let pathname = '/';
+let currentUser = { id: 'member-1', role: 'MEMBER' };
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => navigate,
+  useLocation: () => ({ pathname }),
+}));
+
+vi.mock('../context/AuthContext', () => ({
+  useAuth: () => ({ user: currentUser }),
+}));
+
+const mockResume = (resume) => vi.spyOn(apiClient, 'get').mockResolvedValue({ resume });
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  navigate.mockClear();
+  pathname = '/';
+  currentUser = { id: 'member-1', role: 'MEMBER' };
+  sessionStorage.clear();
+});
+
+const title = /Set up your Talent Partner Network resume/;
+
+describe('when it appears', () => {
+  it('asks a member who has no resume yet', async () => {
+    mockResume(null);
+    render(<MemberTalentNetworkPrompt />);
+    expect(await screen.findByText(title)).toBeInTheDocument();
+  });
+
+  it('mentions the stale application resume, which is why we are asking', async () => {
+    mockResume(null);
+    render(<MemberTalentNetworkPrompt />);
+    await screen.findByText(title);
+    expect(screen.getByText(/applied in an earlier cycle/i)).toBeInTheDocument();
+  });
+});
+
+describe('when it stays quiet', () => {
+  it('never asks a member who already uploaded a resume', async () => {
+    const get = mockResume({ id: 'mr-1', shareConsent: true });
+    render(<MemberTalentNetworkPrompt />);
+    await waitFor(() => expect(get).toHaveBeenCalled());
+    expect(screen.queryByText(title)).not.toBeInTheDocument();
+  });
+
+  it('never asks someone who uploaded and declined - they answered', async () => {
+    // Continuing to ask would be nagging them to reverse a decision they made.
+    const get = mockResume({ id: 'mr-1', shareConsent: false });
+    render(<MemberTalentNetworkPrompt />);
+    await waitFor(() => expect(get).toHaveBeenCalled());
+    expect(screen.queryByText(title)).not.toBeInTheDocument();
+  });
+
+  it.each([['ADMIN'], ['USER'], ['CLIENT']])('never asks a %s', async (role) => {
+    currentUser = { id: 'u-1', role };
+    const get = vi.spyOn(apiClient, 'get');
+    render(<MemberTalentNetworkPrompt />);
+    expect(screen.queryByText(title)).not.toBeInTheDocument();
+    expect(get).not.toHaveBeenCalled();
+  });
+
+  it('does not appear over the page it is asking them to visit', async () => {
+    pathname = '/member/talent-network';
+    const get = vi.spyOn(apiClient, 'get');
+    render(<MemberTalentNetworkPrompt />);
+    expect(screen.queryByText(title)).not.toBeInTheDocument();
+    expect(get).not.toHaveBeenCalled();
+  });
+
+  it('stays quiet when the check fails rather than interrupting a broken page', async () => {
+    const get = vi.spyOn(apiClient, 'get').mockRejectedValue(new Error('boom'));
+    render(<MemberTalentNetworkPrompt />);
+    await waitFor(() => expect(get).toHaveBeenCalled());
+    expect(screen.queryByText(title)).not.toBeInTheDocument();
+  });
+});
+
+describe('dismissal', () => {
+  it('does not come back for the rest of the session', async () => {
+    mockResume(null);
+    const { unmount } = render(<MemberTalentNetworkPrompt />);
+    await screen.findByText(title);
+
+    await userEvent.click(screen.getByRole('button', { name: /Not now/ }));
+    await waitFor(() => expect(screen.queryByText(title)).not.toBeInTheDocument());
+
+    // A later navigation remounts it; it must not reappear.
+    unmount();
+    render(<MemberTalentNetworkPrompt />);
+    await waitFor(() => expect(screen.queryByText(title)).not.toBeInTheDocument());
+  });
+
+  it('asks again in a new session, which is the next login', async () => {
+    mockResume(null);
+    const { unmount } = render(<MemberTalentNetworkPrompt />);
+    await screen.findByText(title);
+    await userEvent.click(screen.getByRole('button', { name: /Not now/ }));
+    unmount();
+
+    sessionStorage.clear(); // what ending the browser session does
+    render(<MemberTalentNetworkPrompt />);
+    expect(await screen.findByText(title)).toBeInTheDocument();
+  });
+
+  it('keys dismissal per user, so a shared browser does not silence the next person', async () => {
+    mockResume(null);
+    const { unmount } = render(<MemberTalentNetworkPrompt />);
+    await screen.findByText(title);
+    await userEvent.click(screen.getByRole('button', { name: /Not now/ }));
+    unmount();
+
+    currentUser = { id: 'member-2', role: 'MEMBER' };
+    render(<MemberTalentNetworkPrompt />);
+    expect(await screen.findByText(title)).toBeInTheDocument();
+  });
+
+  it('sends them to the page and does not ask again on arrival', async () => {
+    mockResume(null);
+    render(<MemberTalentNetworkPrompt />);
+    await screen.findByText(title);
+
+    await userEvent.click(screen.getByRole('button', { name: /Set it up/ }));
+    expect(navigate).toHaveBeenCalledWith('/member/talent-network');
+    await waitFor(() => expect(screen.queryByText(title)).not.toBeInTheDocument());
+  });
+});

--- a/client/src/pages/MemberDashboard.jsx
+++ b/client/src/pages/MemberDashboard.jsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react';
 import { useAuth } from '../context/AuthContext';
-import MemberResumeCard from '../components/MemberResumeCard';
 import {
   Box,
   Typography,
@@ -219,8 +218,6 @@ export default function MemberDashboard() {
           Welcome, {user?.fullName}.
         </Typography>
       </Box>
-
-      <MemberResumeCard />
 
       {/* Tasks and Resources Container */}
       <Grid container spacing={3}>

--- a/client/src/pages/MemberTalentNetwork.jsx
+++ b/client/src/pages/MemberTalentNetwork.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { Box, Typography } from '@mui/material';
+import MemberResumeCard from '../components/MemberResumeCard';
+
+// The member's Talent Partner Network resume, on a page of its own.
+//
+// It used to sit on the dashboard, where it competed with tasks and resources
+// and was easy to scroll past - which is how members ended up never answering
+// the sharing question at all. Its own route means the login prompt has
+// somewhere to send them, and the nav has somewhere to point.
+//
+// The form itself is still MemberResumeCard: it owns the upload, the consent
+// toggle and the withdrawal rules, and those are the same wherever it renders.
+
+const MemberTalentNetwork = () => (
+  <Box sx={{ maxWidth: 900, mx: 'auto', p: 0 }}>
+    <Box sx={{ mb: 3 }}>
+      <Typography variant="h4" component="h1" sx={{ fontWeight: 700, color: 'primary.dark' }}>
+        Talent Partner Network
+      </Typography>
+      <Typography variant="body1" color="text.secondary" sx={{ mt: 1 }}>
+        UConsulting shares member resumes with partner organizations hiring interns and
+        early-career candidates. Taking part is optional, and you can withdraw at any time —
+        withdrawing pulls your resume back from every company it was sent to.
+      </Typography>
+      <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+        If you applied to UConsulting in an earlier cycle we already have that resume, but it is
+        the one you applied with. Upload a current version here so partners see your most recent
+        experience.
+      </Typography>
+    </Box>
+
+    <MemberResumeCard />
+  </Box>
+);
+
+export default MemberTalentNetwork;

--- a/client/src/pages/TalentPoolPartnerNetwork.jsx
+++ b/client/src/pages/TalentPoolPartnerNetwork.jsx
@@ -171,6 +171,14 @@ const TalentPoolPartnerNetwork = () => {
       .some((f) => String(f).toLowerCase().includes(q));
   });
 
+  const memberRows = (data?.memberResumes || []).filter((r) => {
+    if (!search.trim()) return true;
+    const q = search.trim().toLowerCase();
+    return [r.name, r.email, r.major1, r.graduationYear]
+      .filter(Boolean)
+      .some((f) => String(f).toLowerCase().includes(q));
+  });
+
   const showCycle = data?.deduplicated;
 
   return (
@@ -261,6 +269,15 @@ const TalentPoolPartnerNetwork = () => {
             caption={
               data?.externalTalent
                 ? `${data.externalTalent.verified} verified of ${data.externalTalent.accounts} on file — all cycles`
+                : undefined
+            }
+          />
+          <StatCard
+            label="Members shareable"
+            value={data ? data.memberTalent?.shareable : undefined}
+            caption={
+              data?.memberTalent
+                ? `of ${data.memberTalent.accounts} member resumes on file — all cycles`
                 : undefined
             }
           />
@@ -457,6 +474,73 @@ const TalentPoolPartnerNetwork = () => {
                           <Tooltip title="Opted in, but the email address is not verified yet.">
                             <Chip size="small" color="warning" variant="outlined" label="Pending" />
                           </Tooltip>
+                        ) : (
+                          <Chip size="small" variant="outlined" label="Opted out" />
+                        )}
+                      </TableCell>
+                      <TableCell>
+                        {r.updatedAt ? new Date(r.updatedAt).toLocaleDateString() : '—'}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </TableContainer>
+          )}
+        </Paper>
+
+        {/* Members who have uploaded a resume. A second uploaded-resume pool,
+            separate from the one above because a member is vouched for by
+            having been recruited rather than by a verified address - and
+            because "which members are in?" is its own question. */}
+        <Paper sx={{ p: { xs: 2, sm: 3 }, mt: 3 }}>
+          <Stack
+            direction={{ xs: 'column', sm: 'row' }}
+            justifyContent="space-between"
+            alignItems={{ xs: 'stretch', sm: 'center' }}
+            spacing={2}
+            mb={2}
+          >
+            <Typography variant="h6" sx={{ fontWeight: 600 }}>
+              Members{data ? ` (${memberRows.length})` : ''}
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              All cycles
+            </Typography>
+          </Stack>
+
+          {memberRows.length === 0 ? (
+            <Typography variant="body2" color="text.secondary" sx={{ p: 2 }}>
+              {(data?.memberResumes || []).length
+                ? 'No members match that search.'
+                : 'No member has uploaded a resume yet.'}
+            </Typography>
+          ) : (
+            <TableContainer>
+              <Table size="small">
+                <TableHead>
+                  <TableRow>
+                    <TableCell>Name</TableCell>
+                    <TableCell>Email</TableCell>
+                    <TableCell>Major</TableCell>
+                    <TableCell>Grad year</TableCell>
+                    <TableCell>TPN</TableCell>
+                    <TableCell>Updated</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {memberRows.map((r) => (
+                    <TableRow key={r.id} hover>
+                      <TableCell>{r.name || '—'}</TableCell>
+                      <TableCell>{r.email}</TableCell>
+                      <TableCell>{r.major1 || '—'}</TableCell>
+                      <TableCell>{r.graduationYear || '—'}</TableCell>
+                      <TableCell>
+                        {/* Consent is the whole gate for a member - there is no
+                            email to verify - so there is no "pending" state
+                            here, unlike the pool above. */}
+                        {r.shared ? (
+                          <Chip size="small" color="success" label="Shareable" />
                         ) : (
                           <Chip size="small" variant="outlined" label="Opted out" />
                         )}

--- a/server/src/routes/admin.js
+++ b/server/src/routes/admin.js
@@ -5709,6 +5709,51 @@ router.get('/talent-pool/stats', async (req, res) => {
       })
     ]);
 
+    // Members are the second uploaded-resume pool, and until now the page said
+    // nothing about them at all - no count, no roster. Counted and listed the
+    // same way, off member_resumes, because "how many members have uploaded?"
+    // is the same question as "how many students have?" asked of the other
+    // table.
+    //
+    // The gate here is consent alone. A member is vouched for by having been
+    // recruited, so there is no email to verify - which is why this is not the
+    // same conjunction the external pool uses.
+    const memberPool = { isCurrent: true, member: { isActive: true } };
+    const [memberAccounts, memberShared, memberRows] = await Promise.all([
+      prisma.memberResume.count({ where: memberPool }),
+      prisma.memberResume.count({
+        where: { ...memberPool, shareConsent: true, consentRevokedAt: null }
+      }),
+      prisma.memberResume.findMany({
+        where: memberPool,
+        orderBy: { updatedAt: 'desc' },
+        select: {
+          id: true,
+          major1: true,
+          major2: true,
+          graduationYear: true,
+          gender: true,
+          shareConsent: true,
+          consentRevokedAt: true,
+          updatedAt: true,
+          member: { select: { id: true, fullName: true, email: true, graduationClass: true } }
+        }
+      })
+    ]);
+
+    const memberResumes = memberRows.map((r) => ({
+      id: r.id,
+      userId: r.member.id,
+      name: r.member.fullName,
+      email: r.member.email,
+      graduationYear: r.graduationYear,
+      major1: r.major1,
+      major2: r.major2,
+      gender: r.gender,
+      shared: Boolean(r.shareConsent) && !r.consentRevokedAt,
+      updatedAt: r.updatedAt
+    }));
+
     // The roster behind those counts. Without it the page can say how many
     // uploaded resumes exist but cannot show a single one of the people, which
     // is the only question an admin actually opens this page to answer.
@@ -5768,7 +5813,14 @@ router.get('/talent-pool/stats', async (req, res) => {
         verified: externalVerified,
         shareable: externalShared
       },
-      externals
+      externals,
+      // Cycle-independent for the same reason the external counts are: a member
+      // resume belongs to a person, not to a recruiting cycle.
+      memberTalent: {
+        accounts: memberAccounts,
+        shareable: memberShared
+      },
+      memberResumes
     });
   } catch (error) {
     console.error('Error fetching talent pool stats:', error);


### PR DESCRIPTION
Three related gaps in how members reach the Talent Partner Network.

## Its own page

The resume form sat on the member dashboard between the welcome heading and the
tasks grid, where it was easy to scroll past — part of why members never
answered the sharing question. It now has a route (`/member/talent-network`) and
a nav entry, so the reminder has somewhere to send people.

It also rendered wrong: the four fields used MUI v5 `Grid item xs={12} sm={6}`
props on a v7 `Grid`, which ignores them, so instead of a 2×2 layout all four
collapsed onto one row and the gender select was crushed to a three-character
stub.

## A login reminder

A dialog, not a gate — a member has real work in this app and blocking them over
an optional resume would be the wrong trade. Shown once per login, and every
login until a resume exists, keyed per user in `sessionStorage` so a shared
browser does not silence the next person. It never appears over the page it
points at, and stays quiet if the check fails rather than interrupting a broken
page.

"Complete" means a resume exists, not that they consented. Someone who uploaded
and declined has answered; asking again would be nagging them to reverse it.

Members recruited from earlier cycles already have a resume, but it is the one
they applied with and it lives on `Application.resumeUrl`, which the member pool
does not read. Both the page and the dialog say so and ask for a current one.

## The form matches candidate onboarding

Major and second major are dropdowns over the six categories the application
form produces, with Other revealing a text field; graduation year is a dropdown
over the shared constant; the PDF is stated as required and guarded on submit.

Consent is now a required yes/no rather than a checkbox. A checkbox cannot tell
"no" apart from "not answered", and reading the second as permission is how a
resume reaches a company on an answer nobody gave.

A major stored before this change that is not one of the six reads back as Other
with the text preserved — members filled this in freely until now, and dropping
what they typed would be worse than the typos the dropdown prevents.

**Bug fixed:** consent was never read back off the saved resume, so a member who
had opted in saw a blank answer, and replacing their PDF silently revoked
sharing.

## Admin visibility

The TPN admin page had no member resumes on it at all — no count, no roster —
though members are one of the three assignable pools. Added a "Members
shareable" card and a roster, counted off `member_resumes` and filtered by the
same search box as the tables above it. Member rows have no "pending" state
because consent alone is the whole gate: a member is vouched for by having been
recruited, so there is no email to verify.

## Verification

381 client tests and 631 server tests pass. The two `offerLetter.test.js`
failures are byte-identical to `main`'s copy and fail there too. The member
stats were checked against live data. This adds the first tests for
`MemberResumeCard`, which had none.

## Note

Overlaps `feature/member-resume-edit` (unmerged, adds `PATCH /api/member/resume`)
on `MemberResumeCard` — whichever lands second needs a small merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)