### PR TITLE
Fix: uploaded resumes vanish on deploy — store them in Supabase

### DIFF
--- a/server/src/routes/candidateOnboarding.js
+++ b/server/src/routes/candidateOnboarding.js
@@ -22,26 +22,17 @@
 // The gate is emailVerifiedAt, matching routes/talent.js. Reading the status is
 // open so the app can render the "check your email" state; submitting is not.
 import express from 'express';
-import fsPromises from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import multer from 'multer';
 import prisma from '../prismaClient.js';
+import { putResume, getResume } from '../services/resumeStorage.js';
 import { requireAuth } from '../middleware/auth.js';
 import { sanitizeOnboardingInput, serializeOnboarding } from '../utils/candidateOnboarding.js';
 
 const router = express.Router();
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-// Same private root talent.js, member.js and cases.js use, and deliberately NOT
-// uploads/, which index.js serves statically and unauthenticated.
-const STORAGE_DIR = path.join(__dirname, '../../storage');
-const ONBOARDING_ROOT = path.join(STORAGE_DIR, 'candidate-onboarding');
-// The TPN copy lives where every other pooled resume lives. routes/client.js
-// only serves files under member-resumes/ and external-resumes/, so a resume
-// left in candidate-onboarding/ would be invisible to the client portal that is
-// the whole point of opting in.
-const EXTERNAL_RESUME_ROOT = path.join(STORAGE_DIR, 'external-resumes');
 
 const MAX_RESUME_BYTES = 10 * 1024 * 1024;
 const MAX_HEADSHOT_BYTES = 5 * 1024 * 1024;
@@ -236,8 +227,7 @@ const applyTalentPoolConsent = async ({ user, optIn, resumeFile, metadata }) => 
 
   const relPath = `external-resumes/${created.id}/resume.pdf`;
   try {
-    await fsPromises.mkdir(path.join(EXTERNAL_RESUME_ROOT, created.id), { recursive: true });
-    await fsPromises.writeFile(path.join(STORAGE_DIR, relPath), resumeFile.buffer);
+    await putResume(relPath, resumeFile.buffer);
   } catch (writeError) {
     // Leaving a row pointing at a file that does not exist would put a resume in
     // the pool that 404s for the first client who opens it.
@@ -297,10 +287,9 @@ router.post('/', requireVerifiedEmail, uploadMiddleware, async (req, res) => {
     // Files first, row second. The opposite order can leave a completed-looking
     // profile pointing at a resume that does not exist, and a failed write here
     // just leaves an orphan file that the next successful submit overwrites.
-    await fsPromises.mkdir(path.join(ONBOARDING_ROOT, candidate.id), { recursive: true });
-    await fsPromises.writeFile(path.join(STORAGE_DIR, resumeRel), resumeFile.buffer);
+    await putResume(resumeRel, resumeFile.buffer);
     if (headshotFile) {
-      await fsPromises.writeFile(path.join(STORAGE_DIR, headshotRel), headshotFile.buffer);
+      await putResume(headshotRel, headshotFile.buffer, headshotFile.mimetype);
     }
 
     const data = {
@@ -365,7 +354,7 @@ router.patch('/talent-pool', requireVerifiedEmail, async (req, res) => {
     // Re-opting-in re-reads the stored resume rather than asking for it again,
     // so the pooled copy is the file this person actually submitted.
     const buffer = optIn
-      ? await fsPromises.readFile(path.join(STORAGE_DIR, record.resumeStoragePath))
+      ? await getResume(record.resumeStoragePath)
       : null;
 
     const talentPool = await applyTalentPoolConsent({
@@ -399,8 +388,10 @@ router.get('/resume', async (req, res) => {
       return res.status(404).json({ error: 'No resume on file' });
     }
 
-    const absolute = path.join(STORAGE_DIR, record.resumeStoragePath);
-    const buffer = await fsPromises.readFile(absolute);
+    const buffer = await getResume(record.resumeStoragePath);
+    if (!buffer) {
+      return res.status(404).json({ error: 'Your resume file could not be found. Please upload it again.' });
+    }
 
     res.setHeader('Content-Type', 'application/pdf');
     res.setHeader('Content-Disposition', `inline; filename="${encodeURIComponent(record.resumeOriginalName)}"`);

--- a/server/src/routes/client.js
+++ b/server/src/routes/client.js
@@ -13,10 +13,8 @@
 // select. That is what keeps the filter, facet, table and CSV paths from
 // drifting apart: four features, one projection, one place a field can leak.
 import express from 'express';
-import fs from 'node:fs';
-import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 import prisma from '../prismaClient.js';
+import { getResume } from '../services/resumeStorage.js';
 import { requireAuth, requireClient } from '../middleware/auth.js';
 import { getFileStream } from '../services/google/drive.js';
 import {
@@ -37,18 +35,11 @@ import {
   toCsv
 } from '../utils/clientResumeQuery.js';
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-// Same root cases.js uses, and deliberately not the statically-served uploads/
-// directory - see the comment in routes/cases.js.
-const STORAGE_DIR = path.join(__dirname, '../../storage');
 // The two directories an uploaded resume can legitimately live in. A resolved
 // path must sit under one of them: `storagePath` comes out of the database, and
 // this is the check that keeps a malformed or tampered value from reading its
 // way out of the storage tree.
-const UPLOADED_RESUME_ROOTS = [
-  path.join(STORAGE_DIR, 'member-resumes'),
-  path.join(STORAGE_DIR, 'external-resumes')
-];
+const UPLOADED_RESUME_PREFIXES = ['member-resumes/', 'external-resumes/'];
 
 const router = express.Router();
 
@@ -352,14 +343,18 @@ router.get('/resumes/:assignmentId/pdf', async (req, res) => {
       return stream.pipe(res);
     }
 
-    const absPath = path.join(STORAGE_DIR, source.storagePath);
-    if (!UPLOADED_RESUME_ROOTS.some((root) => absPath.startsWith(root))) {
+    // The two prefixes an uploaded resume can legitimately carry. `storagePath`
+    // comes out of the database, and this is the check that keeps a malformed or
+    // tampered value from reaching for something it should not.
+    if (!UPLOADED_RESUME_PREFIXES.some((prefix) => source.storagePath.startsWith(prefix))) {
       return res.status(400).json({ error: 'Invalid path' });
     }
-    if (!fs.existsSync(absPath)) {
+
+    const buffer = await getResume(source.storagePath);
+    if (!buffer) {
       return res.status(404).json({ error: 'This resume is not available.' });
     }
-    return fs.createReadStream(absPath).pipe(res);
+    return res.send(buffer);
   } catch (error) {
     console.error('[GET /api/client/resumes/:assignmentId/pdf]', error);
     if (!res.headersSent) {

--- a/server/src/routes/member.js
+++ b/server/src/routes/member.js
@@ -1,11 +1,10 @@
 import express from 'express';
 import multer from 'multer';
-import fs from 'node:fs';
-import fsPromises from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { requireAuth, requireAdminOrMember } from '../middleware/auth.js';
 import prisma from '../prismaClient.js';
+import { putResume, getResume, removeResume } from '../services/resumeStorage.js';
 import { sendSlackMessage } from '../services/slackService.js';
 import { sendMeetingCancellationEmail } from '../services/emailNotifications.js';
 import { sendAndLogMeetingCommunication, MEETING_COMM_SUBJECTS } from '../services/meetingComms.js';
@@ -1817,8 +1816,6 @@ router.post('/flag-document', requireAuth, async (req, res) => {
 const __memberDirname = path.dirname(fileURLToPath(import.meta.url));
 // Same root cases.js uses. Deliberately NOT uploads/, which index.js serves
 // statically and unauthenticated - a resume there would be world-readable.
-const RESUME_STORAGE_DIR = path.join(__memberDirname, '../../storage');
-const MEMBER_RESUME_ROOT = path.join(RESUME_STORAGE_DIR, 'member-resumes');
 
 // In memory so the file can be named by the DB-generated row id, matching the
 // reasoning in cases.js.
@@ -1912,8 +1909,7 @@ router.post('/resume', requireAuth, requireMemberRole, resumeUploadMiddleware, a
 
     const relPath = `member-resumes/${created.id}/resume.pdf`;
     try {
-      await fsPromises.mkdir(path.join(MEMBER_RESUME_ROOT, created.id), { recursive: true });
-      await fsPromises.writeFile(path.join(RESUME_STORAGE_DIR, relPath), req.file.buffer);
+      await putResume(relPath, req.file.buffer);
     } catch (writeError) {
       // Leaving a row pointing at a file that does not exist would make the
       // resume look uploaded and then 404 for whoever opens it.
@@ -1980,18 +1976,22 @@ router.get('/resume/pdf', requireAuth, requireMemberRole, async (req, res) => {
     const resume = await loadOwnResume(req.user.id);
     if (!resume) return res.status(404).json({ error: 'No resume on file' });
 
-    const absPath = path.join(RESUME_STORAGE_DIR, resume.storagePath);
-    if (!absPath.startsWith(MEMBER_RESUME_ROOT)) {
+    if (!resume.storagePath.startsWith('member-resumes/')) {
       return res.status(400).json({ error: 'Invalid path' });
     }
-    if (!fs.existsSync(absPath)) {
-      return res.status(404).json({ error: 'No resume on file' });
+
+    const buffer = await getResume(resume.storagePath);
+    if (!buffer) {
+      // Distinct from the "no resume" above on purpose. A row with no file
+      // behind it is a storage fault, and reporting it as "you never uploaded
+      // one" is what made this take a production debugging session to find.
+      return res.status(404).json({ error: 'Your resume file could not be found. Please upload it again.' });
     }
 
     res.setHeader('Content-Type', 'application/pdf');
     res.setHeader('Content-Disposition', 'inline');
     res.setHeader('Cache-Control', 'private, max-age=300');
-    fs.createReadStream(absPath).pipe(res);
+    res.send(buffer);
   } catch (error) {
     console.error('[GET /api/member/resume/pdf]', error);
     res.status(500).json({ error: 'Failed to load your resume' });

--- a/server/src/routes/talent.js
+++ b/server/src/routes/talent.js
@@ -12,12 +12,11 @@
 // So nothing that could reach a partner - the upload, and the consent that makes
 // it assignable - is reachable before that address is proved.
 import express from 'express';
-import fs from 'node:fs';
-import fsPromises from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import multer from 'multer';
 import prisma from '../prismaClient.js';
+import { putResume, getResume } from '../services/resumeStorage.js';
 import { requireAuth, invalidateUserCache } from '../middleware/auth.js';
 import {
   EXTERNAL_GENDERS,
@@ -29,11 +28,6 @@ import {
 const router = express.Router();
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-// Same root member.js and cases.js use, and deliberately NOT uploads/, which
-// index.js serves statically and unauthenticated - a resume there would be
-// world-readable.
-const STORAGE_DIR = path.join(__dirname, '../../storage');
-const EXTERNAL_RESUME_ROOT = path.join(STORAGE_DIR, 'external-resumes');
 
 // In memory so the file can be named by the DB-generated row id, matching the
 // reasoning in member.js and cases.js.
@@ -203,8 +197,7 @@ router.post('/resume', requireVerifiedEmail, resumeUploadMiddleware, async (req,
 
     const relPath = `external-resumes/${created.id}/resume.pdf`;
     try {
-      await fsPromises.mkdir(path.join(EXTERNAL_RESUME_ROOT, created.id), { recursive: true });
-      await fsPromises.writeFile(path.join(STORAGE_DIR, relPath), req.file.buffer);
+      await putResume(relPath, req.file.buffer);
     } catch (writeError) {
       // Leaving a row pointing at a file that does not exist would make the
       // resume look uploaded and then 404 for whoever opens it.
@@ -271,18 +264,19 @@ router.get('/resume/pdf', async (req, res) => {
     const resume = await loadOwnResume(req.user.id);
     if (!resume) return res.status(404).json({ error: 'No resume on file' });
 
-    const absPath = path.join(STORAGE_DIR, resume.storagePath);
-    if (!absPath.startsWith(EXTERNAL_RESUME_ROOT)) {
+    if (!resume.storagePath.startsWith('external-resumes/')) {
       return res.status(400).json({ error: 'Invalid path' });
     }
-    if (!fs.existsSync(absPath)) {
-      return res.status(404).json({ error: 'No resume on file' });
+
+    const buffer = await getResume(resume.storagePath);
+    if (!buffer) {
+      return res.status(404).json({ error: 'Your resume file could not be found. Please upload it again.' });
     }
 
     res.setHeader('Content-Type', 'application/pdf');
     res.setHeader('Content-Disposition', 'inline');
     res.setHeader('Cache-Control', 'private, max-age=300');
-    fs.createReadStream(absPath).pipe(res);
+    res.send(buffer);
   } catch (error) {
     console.error('[GET /api/talent/resume/pdf]', error);
     res.status(500).json({ error: 'Failed to load your resume' });

--- a/server/src/services/resumeStorage.js
+++ b/server/src/services/resumeStorage.js
@@ -1,0 +1,124 @@
+// Where uploaded resumes actually live.
+//
+// They used to be written to server/storage/ on the instance's own disk, which
+// works locally and silently does not work on Render: the filesystem there is
+// ephemeral, so every deploy replaced it. The database row survived in Postgres
+// and the PDF did not, which is why a resume uploaded in production came back
+// as 404 "No resume on file" - the row was found and the file was gone.
+//
+// Supabase Storage instead. Same account the app already uses for realtime and
+// for offer letters, same credentials, and the object outlives the instance
+// that wrote it.
+//
+// The local-disk path is kept as a fallback rather than deleted. Staging
+// previews and local development can run without Supabase credentials, and a
+// storage layer that throws on boot in those environments would be worse than
+// one that writes to a disk nobody is relying on to persist.
+import fs from 'node:fs';
+import fsPromises from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import supabase, { isSupabaseAvailable } from '../supabaseClient.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// The same root the local paths always used, so a `storagePath` written before
+// this change still resolves when running against a disk.
+export const LOCAL_STORAGE_ROOT = path.join(__dirname, '../../storage');
+
+// One private bucket for every uploaded resume. Private is the whole point:
+// nothing here may be fetched by URL, only streamed through a route that has
+// already decided the caller is allowed to see it.
+const BUCKET = 'resumes';
+
+let bucketReady = false;
+
+/**
+ * Create the bucket on first use.
+ *
+ * Cached rather than checked per upload - it is a network round trip, and the
+ * answer only changes once in the lifetime of the project.
+ */
+const ensureBucket = async () => {
+  if (bucketReady || !isSupabaseAvailable()) return;
+  try {
+    const { data } = await supabase.storage.getBucket(BUCKET);
+    if (!data) {
+      await supabase.storage.createBucket(BUCKET, { public: false });
+    }
+    bucketReady = true;
+  } catch (error) {
+    // Left unset so the next call retries. A bucket that could not be created
+    // is reported by the upload itself, where the caller can act on it.
+    console.warn('[resumeStorage] ensureBucket:', error.message);
+  }
+};
+
+/**
+ * Store a resume.
+ *
+ * @param {string} key   relative path, e.g. "member-resumes/<id>/resume.pdf"
+ * @param {Buffer} buffer
+ * @param {string} contentType
+ */
+export const putResume = async (key, buffer, contentType = 'application/pdf') => {
+  if (isSupabaseAvailable()) {
+    await ensureBucket();
+    const { error } = await supabase.storage
+      .from(BUCKET)
+      // upsert so a re-upload to the same key replaces rather than 409s. Keys
+      // are per-row ids, so this only ever overwrites a file's own revision.
+      .upload(key, buffer, { contentType, upsert: true });
+    if (error) throw new Error(`Failed to store resume: ${error.message}`);
+    return;
+  }
+
+  const absolute = path.join(LOCAL_STORAGE_ROOT, key);
+  await fsPromises.mkdir(path.dirname(absolute), { recursive: true });
+  await fsPromises.writeFile(absolute, buffer);
+};
+
+/**
+ * Read a resume back.
+ *
+ * Falls through to the local disk when the object is not in Supabase, which is
+ * what lets a file uploaded before this change still open on a host that kept
+ * its disk. Returns null when neither has it, so callers can 404 honestly.
+ *
+ * @returns {Promise<Buffer|null>}
+ */
+export const getResume = async (key) => {
+  if (isSupabaseAvailable()) {
+    const { data, error } = await supabase.storage.from(BUCKET).download(key);
+    if (!error && data) {
+      return Buffer.from(await data.arrayBuffer());
+    }
+  }
+
+  const absolute = path.join(LOCAL_STORAGE_ROOT, key);
+  // Resolved before reading: `key` comes out of the database, and this is what
+  // stops a malformed or tampered value reading its way out of the tree.
+  if (!path.resolve(absolute).startsWith(path.resolve(LOCAL_STORAGE_ROOT))) return null;
+  if (!fs.existsSync(absolute)) return null;
+  return fsPromises.readFile(absolute);
+};
+
+/** True when the resume can actually be served. */
+export const resumeExists = async (key) => (await getResume(key)) !== null;
+
+/**
+ * Delete a resume. Best-effort: a file that is already gone is not an error,
+ * because the caller's next step is removing the row that pointed at it.
+ */
+export const removeResume = async (key) => {
+  if (isSupabaseAvailable()) {
+    try {
+      await supabase.storage.from(BUCKET).remove([key]);
+    } catch (error) {
+      console.warn('[resumeStorage] remove:', error.message);
+    }
+  }
+
+  const absolute = path.join(LOCAL_STORAGE_ROOT, key);
+  await fsPromises.rm(absolute, { force: true }).catch(() => {});
+};


### PR DESCRIPTION
Uploaded resumes were written to `server/storage/` on the local filesystem. That
works on a laptop and silently does not work on Render, whose filesystem is
ephemeral — every deploy replaces it. The row survived in Postgres and the PDF
did not, so a member who uploaded a resume got a 404 the next time they opened
it, and a client would have got one for any resume assigned to them.

Reported as a 404 on `/api/member/resume/pdf` in production while it worked
locally, which is exactly the shape of an ephemeral-disk bug.

## Scope

Google Forms applications were never affected — those resumes live in Google
Drive and are streamed from there, which is why resume grading and the applicant
TPN pool have always worked. Only the three paths that accept an upload were
broken:

- member resumes (`/api/member/resume`)
- talent portal resumes (`/api/talent/resume`)
- candidate onboarding resumes and headshots (`/api/candidate/onboarding`)
- and the client portal read path that serves the first two to recruiters

## The fix

All of them now go through `services/resumeStorage.js`, backed by a private
Supabase Storage bucket. Supabase is already used here for realtime and for
offer letters, and its credentials are already set wherever they are needed.

The local-disk path is kept as a fallback rather than deleted: staging previews
and local development can run without Supabase credentials, and a storage layer
that refused to boot there would be worse than one writing to a disk nobody
relies on to persist.

This leaves two storage routes, deliberately: Drive for anything a Google Form
produced, Supabase for anything uploaded through the app. Migrating years of
applicant resumes out of Drive would be a large, risky backfill for no benefit.

## Error message

`"No resume on file"` meant both "you never uploaded one" and "the row exists
but its file is gone". That conflation is why this needed a production debugging
session to identify. The second case now says the file could not be found and
asks for a re-upload.

## Verification

631 server tests pass; the two `offerLetter.test.js` failures are byte-identical
to `main`'s copy and fail there too. Verified end to end against a real Supabase
bucket: upload returns 201, preview returns the exact bytes back, and delete
removes the object.

The three resumes that already existed have been back-filled into Supabase from
local copies, so nothing currently on file is lost. Any resume uploaded to
production before this lands and not held locally is unrecoverable and will need
re-uploading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)