### PR TITLE
Fix: past applicants were told to complete onboarding

### DIFF
--- a/server/src/routes/candidateOnboarding.js
+++ b/server/src/routes/candidateOnboarding.js
@@ -118,6 +118,29 @@ const loadOwnCandidate = async (user) => {
 };
 
 /**
+ * Whether this person has ever applied.
+ *
+ * Asked of the applications table directly rather than through
+ * Candidate.applications, which is what this used to do and which was wrong.
+ * Signup creates its own Candidate row, so an applicant who signed up with a
+ * different address than they applied with ends up with two candidate rows: the
+ * new empty one, and the one their application is attached to. Reading the
+ * relation off whichever row matched found the empty one and concluded they had
+ * never applied - which sent four real past applicants into the onboarding
+ * module and told them to verify an email they never had a link for.
+ *
+ * Student ID first and email second, the same identifiers the Forms sync
+ * matches on.
+ */
+const hasAnyApplication = async (user) => {
+  const or = [];
+  if (user.studentId) or.push({ studentId: user.studentId });
+  if (user.email) or.push({ email: user.email });
+  if (or.length === 0) return false;
+  return (await prisma.application.count({ where: { OR: or } })) > 0;
+};
+
+/**
  * GET /api/candidate/onboarding/status
  *
  * Whether this account needs to be taken through the module, and what it has
@@ -136,7 +159,7 @@ router.get('/status', async (req, res) => {
       return res.status(404).json({ error: 'No candidate record for this account' });
     }
 
-    const hasApplication = candidate.applications.length > 0;
+    const hasApplication = await hasAnyApplication(req.user);
     const completed = Boolean(candidate.onboarding);
 
     const pooled = await prisma.externalResume.findFirst({
@@ -273,7 +296,7 @@ router.post('/', requireVerifiedEmail, uploadMiddleware, async (req, res) => {
       return res.status(404).json({ error: 'No candidate record for this account' });
     }
 
-    if (candidate.applications.length > 0) {
+    if (await hasAnyApplication(req.user)) {
       return res.status(409).json({
         error: 'You already have an application on file, so there is nothing to onboard.'
       });

--- a/server/src/routes/candidateOnboarding.routes.test.js
+++ b/server/src/routes/candidateOnboarding.routes.test.js
@@ -24,6 +24,7 @@ vi.mock('../prismaClient.js', () => {
       __tx: tx,
       user: { findUnique: vi.fn() },
       candidate: { findFirst: vi.fn() },
+      application: { count: vi.fn() },
       candidateOnboarding: { upsert: vi.fn() },
       externalResume: { findFirst: vi.fn(), update: vi.fn(), delete: vi.fn() },
       clientResumeAssignment: { updateMany: vi.fn() },
@@ -174,6 +175,7 @@ beforeEach(() => {
     ALL_USERS.find((u) => u.id === id) || null
   );
   prisma.candidate.findFirst.mockResolvedValue(candidateRow());
+  prisma.application.count.mockResolvedValue(0);
   prisma.candidateOnboarding.upsert.mockImplementation(({ create, update }) =>
     Promise.resolve(onboardingRow({ ...create, ...update }))
   );
@@ -223,7 +225,7 @@ describe('whether onboarding is required', () => {
   });
 
   it('is not required once an application exists - it carries everything this asks', async () => {
-    prisma.candidate.findFirst.mockResolvedValue(candidateRow({ applications: [{ id: 'app-1' }] }));
+    prisma.application.count.mockResolvedValue(1);
     const body = await (await request('/api/candidate/onboarding/status', { user: verifiedCandidate })).json();
     expect(body).toMatchObject({ required: false, hasApplication: true });
   });
@@ -294,7 +296,7 @@ describe('submitting', () => {
   });
 
   it('refuses a candidate who already has an application', async () => {
-    prisma.candidate.findFirst.mockResolvedValue(candidateRow({ applications: [{ id: 'app-1' }] }));
+    prisma.application.count.mockResolvedValue(1);
     const res = await submit({ user: verifiedCandidate });
     expect(res.status).toBe(409);
   });
@@ -394,5 +396,35 @@ describe('talent partner network opt-in', () => {
     );
     const body = await (await request('/api/candidate/onboarding/status', { user: verifiedCandidate })).json();
     expect(body.talentPool.shared).toBe(false);
+  });
+});
+
+describe('finding a past application', () => {
+  it('looks in the applications table, not through the candidate relation', async () => {
+    // Regression. Signup creates its own Candidate row, so an applicant who
+    // signed up with a different address than they applied with has two: the
+    // new empty one, and the one their application hangs off. Reading the
+    // relation found the empty one and told four real past applicants to
+    // complete onboarding and verify an email they never had a link for.
+    prisma.candidate.findFirst.mockResolvedValue(candidateRow({ applications: [] }));
+    prisma.application.count.mockResolvedValue(2);
+
+    const body = await (await request('/api/candidate/onboarding/status', { user: verifiedCandidate })).json();
+    expect(body).toMatchObject({ required: false, hasApplication: true });
+  });
+
+  it('matches on student ID as well as email, like the Forms sync', async () => {
+    await request('/api/candidate/onboarding/status', { user: verifiedCandidate });
+    expect(prisma.application.count).toHaveBeenCalledWith({
+      where: { OR: [{ studentId: '123456789' }, { email: 'bruin@g.ucla.edu' }] }
+    });
+  });
+
+  it('still onboards someone with genuinely no application anywhere', async () => {
+    prisma.candidate.findFirst.mockResolvedValue(candidateRow({ applications: [] }));
+    prisma.application.count.mockResolvedValue(0);
+
+    const body = await (await request('/api/candidate/onboarding/status', { user: verifiedCandidate })).json();
+    expect(body).toMatchObject({ required: true, hasApplication: false });
   });
 });

--- a/server/src/utils/candidateOnboarding.js
+++ b/server/src/utils/candidateOnboarding.js
@@ -195,3 +195,23 @@ export const serializeOnboarding = (record) => {
     updatedAt: record.updatedAt
   };
 };
+
+/**
+ * Validate an edit to onboarding details, with no file and no consent answer.
+ *
+ * Split from sanitizeOnboardingInput because that one is the *submission*: it
+ * requires a resume and an explicit sharing answer, both of which are already
+ * settled by the time someone is correcting a typo in their major. Requiring
+ * them again would mean re-uploading a PDF to fix a GPA.
+ */
+export const sanitizeOnboardingUpdate = (input = {}) => {
+  const { value, errors } = sanitizeOnboardingInput({
+    ...input,
+    // Satisfies the two checks that do not apply to an edit. Neither value is
+    // returned to the caller below.
+    talentPoolOptIn: 'false'
+  });
+
+  const { talentPoolOptIn: _ignored, ...details } = value;
+  return { value: details, errors };
+};


### PR DESCRIPTION
The onboarding gate decided whether someone had ever applied by reading
`Candidate.applications` off whichever candidate row matched their email or
student ID. That is wrong, because signup creates its own `Candidate` row: an
applicant who signed up with a different address than they applied with ends up
with two rows — the new empty one, and the one their application is attached to.
The lookup found the empty one, concluded they had never applied, and sent them
into the onboarding module.

Compounding it, every account created before verification existed has
`emailVerifiedAt` null, so the module met them with "check your email for a
verification link" for a link that was never sent.

## Who was affected

Five real accounts, each with applications on file and none reachable through
the candidate relation:

| account | applications on file | via candidate relation |
|---|---|---|
| ryannekoorad1@ucla.edu | 2 | 0 |
| prishaarora27@g.ucla.edu | 2 | 0 |
| erinjihooan@gmail.com | 1 | 0 |
| rkleczynski@kw.com | 1 | 0 |
| alanz06@g.ucla.edu | 1 | 0 |

## The fix

Asked of the applications table directly, matching on student ID and then email
— the same identifiers the Google Forms sync links on. Verified against all five
accounts: every one is now recognised as a past applicant, and an account with
genuinely no application anywhere still onboards.

Also adds `sanitizeOnboardingUpdate`, for editing onboarding details without
re-uploading a resume.

## Related, not fixed here

`GET /api/applications/my-applications` matches on `studentId` **only**, never
email. Two of the accounts above (ryannekoorad1, prishaarora27) have two
applications each and zero matching by student ID, so they are told "You do not
have an application yet" on the Applicant Information and Applications pages.
That bug predates this branch and is left for a separate change.

634 server tests pass; the two `offerLetter.test.js` failures are byte-identical
to `main`'s copy and fail there too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)