### PR TITLE
Let a candidate who onboarded maintain their own information

### DIFF
--- a/client/src/components/OnboardingResumeSection.jsx
+++ b/client/src/components/OnboardingResumeSection.jsx
@@ -1,0 +1,141 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import apiClient from '../utils/api';
+
+// The resume and sharing controls for a candidate who onboarded instead of
+// applying.
+//
+// ResumeReuploadSection cannot serve them: it is keyed to an applicationId, and
+// these people have no application - which is why this page used to show
+// "Application not found" where their resume should be.
+//
+// The sharing question lives here rather than on the details form above because
+// it is not a detail. Answering it moves a resume in or out of the partner
+// network, and turning it off pulls the resume back from every company that
+// already has it, so it gets its own control and its own save.
+
+export default function OnboardingResumeSection({ record, onPreview, onReplaced }) {
+  const [file, setFile] = useState(null);
+  const [shared, setShared] = useState(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState('');
+  const [message, setMessage] = useState('');
+
+  const loadSharing = useCallback(async () => {
+    try {
+      const data = await apiClient.get('/candidate/onboarding/status');
+      setShared(Boolean(data.talentPool?.shared));
+    } catch {
+      // Leave it unanswered rather than guessing. Defaulting to "no" would look
+      // like a withdrawal they never made; defaulting to "yes" would be worse.
+    }
+  }, []);
+
+  useEffect(() => {
+    loadSharing();
+  }, [loadSharing]);
+
+  const replace = async () => {
+    if (!file) return;
+    setBusy(true);
+    setError('');
+    setMessage('');
+    try {
+      const body = new FormData();
+      body.append('resume', file);
+      const result = await apiClient.put('/candidate/onboarding/resume', body);
+      setFile(null);
+      setMessage(result.message || 'Your resume has been replaced.');
+      if (onReplaced) onReplaced(result.onboarding);
+    } catch (e) {
+      setError(e.message || 'Failed to replace your resume');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const setSharing = async (next) => {
+    setBusy(true);
+    setError('');
+    setMessage('');
+    try {
+      const result = await apiClient.patch('/candidate/onboarding/talent-pool', {
+        talentPoolOptIn: next,
+      });
+      setShared(Boolean(result.talentPool?.shared));
+      setMessage(
+        next
+          ? 'Your resume is now shared with partner organizations.'
+          : 'Sharing stopped, and your resume has been withdrawn from any company that had it.'
+      );
+    } catch (e) {
+      setError(e.message || 'Failed to update your sharing preference');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <>
+      <div className="applicant-grid">
+        <div className="applicant-field">
+          <span className="applicant-label">Current resume</span>
+          <span className="applicant-readonly">{record?.resumeOriginalName || 'None on file'}</span>
+        </div>
+      </div>
+
+      <div className="applicant-actions">
+        {record?.resumeOriginalName && (
+          <button
+            type="button"
+            className="applicant-save"
+            onClick={() => onPreview('/api/candidate/onboarding/resume', record.resumeOriginalName)}
+          >
+            Preview
+          </button>
+        )}
+        <label className="applicant-save" style={{ cursor: 'pointer' }}>
+          {file ? file.name : 'Choose a new PDF'}
+          <input
+            hidden
+            type="file"
+            accept="application/pdf"
+            onChange={(e) => setFile(e.target.files?.[0] || null)}
+          />
+        </label>
+        <button type="button" className="applicant-save" disabled={!file || busy} onClick={replace}>
+          {busy ? 'Saving…' : 'Replace resume'}
+        </button>
+      </div>
+
+      <h2 className="applicant-section-title" style={{ marginTop: '1.5rem' }}>
+        Talent Partner Network
+      </h2>
+      <p className="applicant-note">
+        UConsulting shares resumes with partner organizations hiring interns and early-career
+        candidates. You can change this at any time — saying no withdraws your resume from every
+        company that already has it.
+      </p>
+      <div className="applicant-actions">
+        <button
+          type="button"
+          className="applicant-save"
+          disabled={busy || shared === true}
+          onClick={() => setSharing(true)}
+        >
+          {shared === true ? 'Sharing — yes' : 'Yes, share it'}
+        </button>
+        <button
+          type="button"
+          className="applicant-save"
+          disabled={busy || shared === false}
+          onClick={() => setSharing(false)}
+        >
+          {shared === false ? 'Sharing — no' : 'No, do not share'}
+        </button>
+      </div>
+
+      {error && <p className="applicant-error">{error}</p>}
+      {message && <p className="applicant-success">{message}</p>}
+    </>
+  );
+}

--- a/client/src/pages/ApplicantInformation.jsx
+++ b/client/src/pages/ApplicantInformation.jsx
@@ -3,6 +3,7 @@ import apiClient from '../utils/api';
 import AccessControl from '../components/AccessControl';
 import DocumentPreviewModal from '../components/DocumentPreviewModal';
 import ResumeReuploadSection from '../components/ResumeReuploadSection';
+import OnboardingResumeSection from '../components/OnboardingResumeSection';
 import '../styles/ApplicantInformation.css';
 
 // The fields a candidate may correct themselves, in the order they are shown.
@@ -66,6 +67,43 @@ const SECTIONS = [
 
 const EDITABLE_NAMES = SECTIONS.flatMap((section) => section.fields.map((field) => field.name));
 
+// What a candidate who onboarded instead of applying can maintain here.
+//
+// Their details live on CandidateOnboarding, which stores everything above
+// except a name (that is on the Candidate row), a major GPA and prior college
+// years — the application form asks for those and the onboarding module does
+// not. Rendering a field with nothing behind it would invite an edit that
+// silently goes nowhere.
+const ONBOARDING_FIELD_NAMES = new Set([
+  'phoneNumber',
+  'gender',
+  'graduationYear',
+  'major1',
+  'major2',
+  'cumulativeGpa',
+  'isTransferStudent',
+  'isFirstGeneration',
+]);
+
+const onboardingSections = () =>
+  SECTIONS.map((section) => ({
+    ...section,
+    fields: section.fields.filter((field) => ONBOARDING_FIELD_NAMES.has(field.name)),
+  })).filter((section) => section.fields.length > 0);
+
+// The onboarding record uses the same field names as an application, so the
+// existing form state maps straight across.
+const onboardingToFormState = (record) => ({
+  phoneNumber: record.phoneNumber ?? '',
+  gender: record.gender ?? '',
+  graduationYear: record.graduationYear ?? '',
+  major1: record.major1 ?? '',
+  major2: record.major2 ?? '',
+  cumulativeGpa: record.cumulativeGpa ?? '',
+  isTransferStudent: Boolean(record.isTransferStudent),
+  isFirstGeneration: Boolean(record.isFirstGeneration),
+});
+
 // Inputs are controlled, so every value has to be a string (or a boolean for the
 // yes/no fields) — null would make React treat the input as uncontrolled.
 function toFormState(application) {
@@ -94,6 +132,34 @@ export default function ApplicantInformation() {
   const [saveError, setSaveError] = useState('');
   const [confirmation, setConfirmation] = useState('');
   const [preview, setPreview] = useState({ open: false, src: '', title: '' });
+  // 'application' when editing a submitted application, 'onboarding' when the
+  // candidate never applied and is maintaining what they gave us at signup.
+  const [mode, setMode] = useState('application');
+
+  /**
+   * Load what this candidate gave us at signup, for someone with no application.
+   *
+   * Their details should stay theirs to keep current whether or not they ever
+   * applied - before this the page simply told them they had nothing here, even
+   * though they had filled the whole module in.
+   */
+  const loadOnboarding = useCallback(async () => {
+    try {
+      const data = await apiClient.get('/candidate/onboarding/status');
+      if (data?.onboarding) {
+        setMode('onboarding');
+        setRecord(data.onboarding);
+        const initial = onboardingToFormState(data.onboarding);
+        setForm(initial);
+        setBaseline(initial);
+      }
+    } catch {
+      // Leave the empty state as it was. Someone with neither an application nor
+      // an onboarding record genuinely has nothing to edit here.
+    } finally {
+      setLoading(false);
+    }
+  }, []);
 
   // Which application to edit. A candidate can have one per cycle, so prefer the
   // one still open, then the most recent.
@@ -110,7 +176,7 @@ export default function ApplicantInformation() {
           (a, b) => new Date(b.submittedAt) - new Date(a.submittedAt)
         )[0];
         setSelectedId((active || newest)?.id ?? null);
-        if (list.length === 0) setLoading(false);
+        if (list.length === 0) await loadOnboarding();
       } catch (e) {
         if (cancelled) return;
         // A candidate with no application yet gets a 404 from this endpoint;
@@ -120,13 +186,13 @@ export default function ApplicantInformation() {
           e.message?.includes('Candidate not found for this user');
         if (!noApplication) setLoadError(e.message || 'Failed to load your applications');
         setApplications([]);
-        setLoading(false);
+        await loadOnboarding();
       }
     })();
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [loadOnboarding]);
 
   const loadRecord = useCallback(async (applicationId) => {
     setLoading(true);
@@ -171,6 +237,20 @@ export default function ApplicantInformation() {
     setSaveError('');
     setConfirmation('');
     try {
+      if (mode === 'onboarding') {
+        // Sent whole rather than as a diff: the onboarding endpoint validates
+        // every field together, the way the module itself does, so a partial
+        // body would fail on the fields that were not touched.
+        const result = await apiClient.patch('/candidate/onboarding', form);
+        const updated = result.onboarding;
+        setRecord(updated);
+        const next = onboardingToFormState(updated);
+        setForm(next);
+        setBaseline(next);
+        setConfirmation(result.message || 'Your information has been updated.');
+        return;
+      }
+
       const result = await apiClient.patch(
         `/applicant-info/applications/${selectedId}`,
         changedFields(form, baseline)
@@ -283,7 +363,14 @@ export default function ApplicantInformation() {
 
         {loading && <p className="applicant-note">Loading your information…</p>}
         {!loading && loadError && <p className="applicant-error">{loadError}</p>}
-        {!loading && !loadError && applications.length === 0 && (
+        {!loading && !loadError && applications.length === 0 && mode === 'onboarding' && (
+          <p className="applicant-note">
+            You have not applied yet. This is the information you gave us when you signed up —
+            keeping it current means partner organizations see the right details.
+          </p>
+        )}
+
+        {!loading && !loadError && applications.length === 0 && mode !== 'onboarding' && (
           <p className="applicant-note">
             You do not have an application yet. Once you apply, you can update your details here.
           </p>
@@ -292,6 +379,7 @@ export default function ApplicantInformation() {
         {!loading && !loadError && record && form && (
           <>
             <form className="applicant-card" onSubmit={handleSubmit}>
+              {mode !== 'onboarding' && (
               <section className="applicant-section">
                 <h2 className="applicant-section-title">Identity</h2>
                 <p className="applicant-note">
@@ -309,8 +397,9 @@ export default function ApplicantInformation() {
                   </div>
                 </div>
               </section>
+              )}
 
-              {SECTIONS.map((section) => (
+              {(mode === 'onboarding' ? onboardingSections() : SECTIONS).map((section) => (
                 <section className="applicant-section" key={section.title}>
                   <h2 className="applicant-section-title">{section.title}</h2>
                   <div className="applicant-grid">{section.fields.map(renderField)}</div>
@@ -338,10 +427,18 @@ export default function ApplicantInformation() {
             <div className="applicant-card">
               <section className="applicant-section">
                 <h2 className="applicant-section-title">Resume</h2>
-                <ResumeReuploadSection
-                  applicationId={selectedId}
-                  onPreview={(src, title) => setPreview({ open: true, src, title })}
-                />
+                {mode === 'onboarding' ? (
+                  <OnboardingResumeSection
+                    record={record}
+                    onPreview={(src, title) => setPreview({ open: true, src, title })}
+                    onReplaced={(updated) => setRecord(updated)}
+                  />
+                ) : (
+                  <ResumeReuploadSection
+                    applicationId={selectedId}
+                    onPreview={(src, title) => setPreview({ open: true, src, title })}
+                  />
+                )}
               </section>
             </div>
           </>

--- a/client/src/pages/ApplicantInformation.test.jsx
+++ b/client/src/pages/ApplicantInformation.test.jsx
@@ -147,8 +147,75 @@ describe('ApplicantInformation', () => {
   });
 
   it('shows an empty state when the candidate has no application', async () => {
-    apiClient.get = vi.fn(() => Promise.reject(new Error('User not found or no studentId associated')));
+    apiClient.get = vi.fn((url) =>
+      url.includes('onboarding')
+        ? Promise.resolve({ onboarding: null })
+        : Promise.reject(new Error('User not found or no studentId associated'))
+    );
     renderPage();
     await waitFor(() => expect(screen.getByText(/do not have an application yet/)).toBeInTheDocument());
+  });
+});
+
+describe('a candidate who onboarded instead of applying', () => {
+  const onboarding = {
+    id: 'onb-1',
+    phoneNumber: '3105550134',
+    graduationYear: '2029',
+    cumulativeGpa: '3.85',
+    major1: 'Life Sciences',
+    major2: null,
+    gender: 'Female',
+    isTransferStudent: false,
+    isFirstGeneration: true,
+  };
+
+  const mockOnboarded = () => {
+    apiClient.get = vi.fn((url) =>
+      url.includes('onboarding')
+        ? Promise.resolve({ required: false, completed: true, onboarding })
+        : Promise.reject(new Error('User not found or no studentId associated'))
+    );
+  };
+
+  beforeEach(mockOnboarded);
+
+  it('shows what they entered instead of telling them they have nothing', async () => {
+    renderPage();
+    await waitFor(() => expect(screen.getByLabelText(/Primary major/)).toHaveValue('Life Sciences'));
+    expect(screen.queryByText(/do not have an application yet/)).not.toBeInTheDocument();
+    expect(screen.getByLabelText(/Graduation year/)).toHaveValue('2029');
+  });
+
+  it('hides the fields onboarding does not collect, so no edit goes nowhere', async () => {
+    renderPage();
+    await screen.findByLabelText(/Primary major/);
+    // Major GPA, prior college years and the name fields live on an
+    // application, not on the onboarding record.
+    expect(screen.queryByLabelText(/Major GPA/)).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(/First name/)).not.toBeInTheDocument();
+  });
+
+  it('hides the identity block, which reads application-only fields', async () => {
+    renderPage();
+    await screen.findByLabelText(/Primary major/);
+    expect(screen.queryByText('Identity')).not.toBeInTheDocument();
+  });
+
+  it('saves an edit to the onboarding record, not to an application', async () => {
+    const patch = vi.fn(() =>
+      Promise.resolve({ onboarding: { ...onboarding, major1: 'Social Sciences' }, message: 'Saved.' })
+    );
+    apiClient.patch = patch;
+
+    renderPage();
+    const major = await screen.findByLabelText(/Primary major/);
+    fireEvent.change(major, { target: { value: 'Social Sciences' } });
+    fireEvent.click(screen.getByRole('button', { name: /Save changes/ }));
+
+    await waitFor(() => expect(patch).toHaveBeenCalled());
+    expect(patch.mock.calls[0][0]).toBe('/candidate/onboarding');
+    // Sent whole rather than as a diff - the endpoint validates every field.
+    expect(patch.mock.calls[0][1]).toMatchObject({ major1: 'Social Sciences', graduationYear: '2029' });
   });
 });

--- a/client/src/utils/api.js
+++ b/client/src/utils/api.js
@@ -80,7 +80,9 @@ class ApiClient {
     return this.request(endpoint, {
       ...options,
       method: 'PUT',
-      body: JSON.stringify(data),
+      // Same FormData check post() has. Without it an upload sent over PUT or
+      // PATCH is stringified to "[object FormData]" and the file never arrives.
+      body: data instanceof FormData ? data : JSON.stringify(data),
     });
   }
 
@@ -88,7 +90,9 @@ class ApiClient {
     return this.request(endpoint, {
       ...options,
       method: 'PATCH',
-      body: JSON.stringify(data),
+      // Same FormData check post() has. Without it an upload sent over PUT or
+      // PATCH is stringified to "[object FormData]" and the file never arrives.
+      body: data instanceof FormData ? data : JSON.stringify(data),
     });
   }
 

--- a/server/src/routes/candidateOnboarding.js
+++ b/server/src/routes/candidateOnboarding.js
@@ -118,6 +118,29 @@ const loadOwnCandidate = async (user) => {
 };
 
 /**
+ * Whether this person has ever applied.
+ *
+ * Asked of the applications table directly rather than through
+ * Candidate.applications, which is what this used to do and which was wrong.
+ * Signup creates its own Candidate row, so an applicant who signed up with a
+ * different address than they applied with ends up with two candidate rows: the
+ * new empty one, and the one their application is attached to. Reading the
+ * relation off whichever row matched found the empty one and concluded they had
+ * never applied - which sent four real past applicants into the onboarding
+ * module and told them to verify an email they never had a link for.
+ *
+ * Student ID first and email second, the same identifiers the Forms sync
+ * matches on.
+ */
+const hasAnyApplication = async (user) => {
+  const or = [];
+  if (user.studentId) or.push({ studentId: user.studentId });
+  if (user.email) or.push({ email: user.email });
+  if (or.length === 0) return false;
+  return (await prisma.application.count({ where: { OR: or } })) > 0;
+};
+
+/**
  * GET /api/candidate/onboarding/status
  *
  * Whether this account needs to be taken through the module, and what it has
@@ -136,7 +159,7 @@ router.get('/status', async (req, res) => {
       return res.status(404).json({ error: 'No candidate record for this account' });
     }
 
-    const hasApplication = candidate.applications.length > 0;
+    const hasApplication = await hasAnyApplication(req.user);
     const completed = Boolean(candidate.onboarding);
 
     const pooled = await prisma.externalResume.findFirst({
@@ -273,7 +296,7 @@ router.post('/', requireVerifiedEmail, uploadMiddleware, async (req, res) => {
       return res.status(404).json({ error: 'No candidate record for this account' });
     }
 
-    if (candidate.applications.length > 0) {
+    if (await hasAnyApplication(req.user)) {
       return res.status(409).json({
         error: 'You already have an application on file, so there is nothing to onboard.'
       });

--- a/server/src/routes/candidateOnboarding.js
+++ b/server/src/routes/candidateOnboarding.js
@@ -28,7 +28,11 @@ import multer from 'multer';
 import prisma from '../prismaClient.js';
 import { putResume, getResume } from '../services/resumeStorage.js';
 import { requireAuth } from '../middleware/auth.js';
-import { sanitizeOnboardingInput, serializeOnboarding } from '../utils/candidateOnboarding.js';
+import {
+  sanitizeOnboardingInput,
+  sanitizeOnboardingUpdate,
+  serializeOnboarding
+} from '../utils/candidateOnboarding.js';
 
 const router = express.Router();
 
@@ -354,6 +358,118 @@ router.post('/', requireVerifiedEmail, uploadMiddleware, async (req, res) => {
   } catch (error) {
     console.error('[POST /api/candidate/onboarding]', error);
     res.status(500).json({ error: 'Failed to save your information' });
+  }
+});
+
+/**
+ * PATCH /api/candidate/onboarding
+ *
+ * Correct the details without re-uploading the resume.
+ *
+ * A candidate with no application has nowhere else to maintain this: the
+ * Applicant Information page is built on Application rows, so before this the
+ * only way to fix a typo in a major was to submit the whole module again, PDF
+ * and all. Their information should stay theirs to keep current whether or not
+ * they ever applied.
+ */
+router.patch('/', requireVerifiedEmail, async (req, res) => {
+  try {
+    const { value, errors } = sanitizeOnboardingUpdate(req.body || {});
+    if (errors.length > 0) {
+      return res.status(400).json({ error: errors[0], errors });
+    }
+
+    const candidate = await loadOwnCandidate(req.user);
+    if (!candidate?.onboarding) {
+      return res.status(404).json({ error: 'Complete onboarding first' });
+    }
+
+    const record = await prisma.candidateOnboarding.update({
+      where: { candidateId: candidate.id },
+      data: value
+    });
+
+    // Carry the corrections onto the pooled copy. The partner network filters on
+    // major and graduation year, so leaving the ExternalResume behind would mean
+    // a client searching "class of 2029" still misses someone who just fixed
+    // their year - the correction would be visible to them and to nobody else.
+    const pooled = await prisma.externalResume.findFirst({
+      where: { userId: req.user.id, isCurrent: true },
+      select: { id: true }
+    });
+    if (pooled) {
+      await prisma.externalResume.update({
+        where: { id: pooled.id },
+        data: {
+          major1: value.major1,
+          major2: value.major2,
+          graduationYear: value.graduationYear,
+          gender: value.gender
+        }
+      });
+    }
+
+    res.json({ onboarding: serializeOnboarding(record), message: 'Your information has been updated.' });
+  } catch (error) {
+    console.error('[PATCH /api/candidate/onboarding]', error);
+    res.status(500).json({ error: 'Failed to update your information' });
+  }
+});
+
+/**
+ * PUT /api/candidate/onboarding/resume
+ *
+ * Replace the PDF without re-answering the form.
+ *
+ * The application version of this lives in routes/resumeUploads.js and is keyed
+ * to an applicationId, which a candidate who never applied does not have - so
+ * the Applicant Information page asked for one and got "Application not found".
+ */
+router.put('/resume', requireVerifiedEmail, uploadMiddleware, async (req, res) => {
+  try {
+    const resumeFile = req.files?.resume?.[0];
+    if (!resumeFile) {
+      return res.status(400).json({ error: 'Attach a PDF resume' });
+    }
+
+    const candidate = await loadOwnCandidate(req.user);
+    if (!candidate?.onboarding) {
+      return res.status(404).json({ error: 'Complete onboarding first' });
+    }
+
+    const relPath = `candidate-onboarding/${candidate.id}/resume.pdf`;
+    await putResume(relPath, resumeFile.buffer);
+
+    const record = await prisma.candidateOnboarding.update({
+      where: { candidateId: candidate.id },
+      data: {
+        resumeStoragePath: relPath,
+        resumeOriginalName: (resumeFile.originalname || 'resume.pdf').slice(0, 255),
+        resumeFileSize: resumeFile.size
+      }
+    });
+
+    // If they are sharing, the pooled copy has to be the new file too -
+    // otherwise a partner keeps reading the resume they replaced. Superseded
+    // rather than overwritten, for the same reason it is everywhere else: an
+    // assignment already handed to a client keeps pointing at the exact file
+    // that was assigned.
+    const pooled = await prisma.externalResume.findFirst({
+      where: { userId: req.user.id, isCurrent: true }
+    });
+    if (pooled?.shareConsent && !pooled.consentRevokedAt) {
+      await applyTalentPoolConsent({
+        user: req.user,
+        optIn: true,
+        resumeFile,
+        metadata: record
+      });
+    }
+
+    res.json({ onboarding: serializeOnboarding(record), message: 'Your resume has been replaced.' });
+  } catch (error) {
+    console.error('[PUT /api/candidate/onboarding/resume]', error);
+    res.status(500).json({ error: 'Failed to replace your resume' });
   }
 });
 

--- a/server/src/routes/candidateOnboarding.routes.test.js
+++ b/server/src/routes/candidateOnboarding.routes.test.js
@@ -24,6 +24,7 @@ vi.mock('../prismaClient.js', () => {
       __tx: tx,
       user: { findUnique: vi.fn() },
       candidate: { findFirst: vi.fn() },
+      application: { count: vi.fn() },
       candidateOnboarding: { upsert: vi.fn() },
       externalResume: { findFirst: vi.fn(), update: vi.fn(), delete: vi.fn() },
       clientResumeAssignment: { updateMany: vi.fn() },
@@ -174,6 +175,7 @@ beforeEach(() => {
     ALL_USERS.find((u) => u.id === id) || null
   );
   prisma.candidate.findFirst.mockResolvedValue(candidateRow());
+  prisma.application.count.mockResolvedValue(0);
   prisma.candidateOnboarding.upsert.mockImplementation(({ create, update }) =>
     Promise.resolve(onboardingRow({ ...create, ...update }))
   );
@@ -223,7 +225,7 @@ describe('whether onboarding is required', () => {
   });
 
   it('is not required once an application exists - it carries everything this asks', async () => {
-    prisma.candidate.findFirst.mockResolvedValue(candidateRow({ applications: [{ id: 'app-1' }] }));
+    prisma.application.count.mockResolvedValue(1);
     const body = await (await request('/api/candidate/onboarding/status', { user: verifiedCandidate })).json();
     expect(body).toMatchObject({ required: false, hasApplication: true });
   });
@@ -294,7 +296,7 @@ describe('submitting', () => {
   });
 
   it('refuses a candidate who already has an application', async () => {
-    prisma.candidate.findFirst.mockResolvedValue(candidateRow({ applications: [{ id: 'app-1' }] }));
+    prisma.application.count.mockResolvedValue(1);
     const res = await submit({ user: verifiedCandidate });
     expect(res.status).toBe(409);
   });
@@ -394,5 +396,35 @@ describe('talent partner network opt-in', () => {
     );
     const body = await (await request('/api/candidate/onboarding/status', { user: verifiedCandidate })).json();
     expect(body.talentPool.shared).toBe(false);
+  });
+});
+
+describe('finding a past application', () => {
+  it('looks in the applications table, not through the candidate relation', async () => {
+    // Regression. Signup creates its own Candidate row, so an applicant who
+    // signed up with a different address than they applied with has two: the
+    // new empty one, and the one their application hangs off. Reading the
+    // relation found the empty one and told four real past applicants to
+    // complete onboarding and verify an email they never had a link for.
+    prisma.candidate.findFirst.mockResolvedValue(candidateRow({ applications: [] }));
+    prisma.application.count.mockResolvedValue(2);
+
+    const body = await (await request('/api/candidate/onboarding/status', { user: verifiedCandidate })).json();
+    expect(body).toMatchObject({ required: false, hasApplication: true });
+  });
+
+  it('matches on student ID as well as email, like the Forms sync', async () => {
+    await request('/api/candidate/onboarding/status', { user: verifiedCandidate });
+    expect(prisma.application.count).toHaveBeenCalledWith({
+      where: { OR: [{ studentId: '123456789' }, { email: 'bruin@g.ucla.edu' }] }
+    });
+  });
+
+  it('still onboards someone with genuinely no application anywhere', async () => {
+    prisma.candidate.findFirst.mockResolvedValue(candidateRow({ applications: [] }));
+    prisma.application.count.mockResolvedValue(0);
+
+    const body = await (await request('/api/candidate/onboarding/status', { user: verifiedCandidate })).json();
+    expect(body).toMatchObject({ required: true, hasApplication: false });
   });
 });

--- a/server/src/routes/candidateOnboarding.routes.test.js
+++ b/server/src/routes/candidateOnboarding.routes.test.js
@@ -25,7 +25,7 @@ vi.mock('../prismaClient.js', () => {
       user: { findUnique: vi.fn() },
       candidate: { findFirst: vi.fn() },
       application: { count: vi.fn() },
-      candidateOnboarding: { upsert: vi.fn() },
+      candidateOnboarding: { upsert: vi.fn(), update: vi.fn() },
       externalResume: { findFirst: vi.fn(), update: vi.fn(), delete: vi.fn() },
       clientResumeAssignment: { updateMany: vi.fn() },
       $transaction: vi.fn((fn) => fn(tx))
@@ -184,6 +184,9 @@ beforeEach(() => {
   prisma.__tx.externalResume.updateMany.mockResolvedValue({ count: 0 });
   prisma.__tx.clientResumeAssignment.updateMany.mockResolvedValue({ count: 0 });
   prisma.externalResume.update.mockResolvedValue(externalResumeRow());
+  prisma.candidateOnboarding.update.mockImplementation(({ data }) =>
+    Promise.resolve(onboardingRow(data))
+  );
 });
 
 describe('access gating', () => {
@@ -426,5 +429,74 @@ describe('finding a past application', () => {
 
     const body = await (await request('/api/candidate/onboarding/status', { user: verifiedCandidate })).json();
     expect(body).toMatchObject({ required: true, hasApplication: false });
+  });
+});
+
+describe('editing details without re-uploading', () => {
+  const patch = (user, body) =>
+    fetch(`http://localhost:${port}/api/candidate/onboarding`, {
+      method: 'PATCH',
+      headers: { Authorization: `Bearer ${tokenFor(user)}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify(body)
+    });
+
+  const details = {
+    phoneNumber: '3105550134',
+    graduationYear: '2029',
+    cumulativeGpa: '3.90',
+    major1: 'Social Sciences',
+    isTransferStudent: 'false',
+    isFirstGeneration: 'true'
+  };
+
+  beforeEach(() => {
+    prisma.candidate.findFirst.mockResolvedValue(candidateRow({ onboarding: onboardingRow() }));
+  });
+
+  it('updates the record without asking for a file', async () => {
+    const res = await patch(verifiedCandidate, details);
+    expect(res.status).toBe(200);
+    expect((await res.json()).onboarding).toMatchObject({ major1: 'Social Sciences', graduationYear: '2029' });
+  });
+
+  it('does not require a sharing answer - that was settled at submission', async () => {
+    const res = await patch(verifiedCandidate, details);
+    expect(res.status).toBe(200);
+  });
+
+  it('carries corrections onto the pooled resume, which partners filter on', async () => {
+    prisma.externalResume.findFirst.mockResolvedValue(externalResumeRow());
+    await patch(verifiedCandidate, details);
+
+    expect(prisma.externalResume.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ major1: 'Social Sciences', graduationYear: '2029' })
+      })
+    );
+  });
+
+  it('is fine when there is no pooled resume to carry them to', async () => {
+    prisma.externalResume.findFirst.mockResolvedValue(null);
+    const res = await patch(verifiedCandidate, details);
+    expect(res.status).toBe(200);
+    expect(prisma.externalResume.update).not.toHaveBeenCalled();
+  });
+
+  it('validates the same way the submission does', async () => {
+    const res = await patch(verifiedCandidate, { ...details, cumulativeGpa: '3.456' });
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/two decimal places/);
+    expect(prisma.candidateOnboarding.update).not.toHaveBeenCalled();
+  });
+
+  it('refuses an unverified account', async () => {
+    const res = await patch(unverifiedCandidate, details);
+    expect(res.status).toBe(403);
+  });
+
+  it('404s for someone who has not onboarded', async () => {
+    prisma.candidate.findFirst.mockResolvedValue(candidateRow({ onboarding: null }));
+    const res = await patch(verifiedCandidate, details);
+    expect(res.status).toBe(404);
   });
 });

--- a/server/src/utils/candidateOnboarding.js
+++ b/server/src/utils/candidateOnboarding.js
@@ -195,3 +195,23 @@ export const serializeOnboarding = (record) => {
     updatedAt: record.updatedAt
   };
 };
+
+/**
+ * Validate an edit to onboarding details, with no file and no consent answer.
+ *
+ * Split from sanitizeOnboardingInput because that one is the *submission*: it
+ * requires a resume and an explicit sharing answer, both of which are already
+ * settled by the time someone is correcting a typo in their major. Requiring
+ * them again would mean re-uploading a PDF to fix a GPA.
+ */
+export const sanitizeOnboardingUpdate = (input = {}) => {
+  const { value, errors } = sanitizeOnboardingInput({
+    ...input,
+    // Satisfies the two checks that do not apply to an edit. Neither value is
+    // returned to the caller below.
+    talentPoolOptIn: 'false'
+  });
+
+  const { talentPoolOptIn: _ignored, ...details } = value;
+  return { value: details, errors };
+};


### PR DESCRIPTION
Stacked on #139 — includes that fix as its first commit.

The Applicant Information page is built on `Application` rows, so a candidate who
signed up and completed onboarding — entering their phone, major, graduation
year, GPA and background — was told *"You do not have an application yet"* and
shown nothing. The information was collected and then became unreachable to the
person who gave it.

## What changed

The page falls back to the onboarding record and edits it in place, reusing the
same form. Fields the module does not collect (a name, a major GPA, prior
college years) are not rendered — a field with nothing behind it invites an edit
that silently goes nowhere. The identity block is hidden for the same reason: it
reads application-only columns.

Three things had to exist behind it:

- **`PATCH /api/candidate/onboarding`** — correct details without re-uploading a
  PDF. Corrections are carried onto the pooled `ExternalResume`, since partners
  filter on major and graduation year and would otherwise keep matching the old
  values.
- **`PUT /api/candidate/onboarding/resume`** — the application version is keyed
  to an `applicationId`, which is why the page showed **"Application not found"**
  where the resume belonged.
- **The sharing question**, which had a working endpoint and no interface
  anywhere. An onboarded candidate could opt in during the module and then had
  no way to opt back out — the wrong shape for a consent decision.

## Incidental fix

`apiClient.put` and `.patch` stringified `FormData` instead of passing it
through the way `post()` does, so an upload sent over either arrived as
`"[object FormData]"` and the file was silently dropped. Nothing hit this before
because no existing caller uploaded over PUT or PATCH.

## Verification

385 client tests and 641 server tests pass. Verified end to end against the real
account: status reports the onboarding record, a details PATCH updates the major
and reverts cleanly, the resume preview returns a PDF, and opting out then back
in round-trips (`shared: false, revoked: true` → `shared: true`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)