### PR TITLE
Fix: fourth upload path still on local disk, and a silent storage fallback

### DIFF
--- a/server/src/routes/candidateOnboarding.routes.test.js
+++ b/server/src/routes/candidateOnboarding.routes.test.js
@@ -14,6 +14,16 @@ import fsPromises from 'node:fs/promises';
 import prisma from '../prismaClient.js';
 import onboardingRoutes from './candidateOnboarding.js';
 
+// Storage is mocked so the suite never writes to the real Supabase bucket. It
+// previously did, leaving objects named after fixtures ("er-1", "cand-1") in
+// production storage.
+const stored = new Map();
+vi.mock('../services/resumeStorage.js', () => ({
+  putResume: vi.fn(async (key, buffer) => { stored.set(key, buffer); }),
+  getResume: vi.fn(async (key) => stored.get(key) ?? null),
+  removeResume: vi.fn(async (key) => { stored.delete(key); }),
+}));
+
 vi.mock('../prismaClient.js', () => {
   const tx = {
     externalResume: { updateMany: vi.fn(), create: vi.fn(), update: vi.fn() },
@@ -171,6 +181,7 @@ afterAll(async () => {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  stored.clear();
   prisma.user.findUnique.mockImplementation(({ where: { id } }) =>
     ALL_USERS.find((u) => u.id === id) || null
   );

--- a/server/src/routes/resumeUploads.js
+++ b/server/src/routes/resumeUploads.js
@@ -7,6 +7,7 @@ import crypto from 'crypto';
 import { fileURLToPath } from 'url';
 import { dirname } from 'path';
 import prisma from '../prismaClient.js';
+import { putResume, getResume, removeResume } from '../services/resumeStorage.js';
 import { requireAuth } from '../middleware/auth.js';
 import { isOwnedBy, isStaff } from '../utils/applicationOwnership.js';
 
@@ -211,12 +212,10 @@ router.post(
 
       const uploadId = crypto.randomUUID();
       const relativePath = path.posix.join('resumes', application.id, `${uploadId}.pdf`);
-      const absolutePath = path.join(STORAGE_DIR, relativePath);
       const servedUrl = `/api/resume-uploads/${uploadId}/file`;
 
-      await fsPromises.mkdir(path.dirname(absolutePath), { recursive: true });
-      await fsPromises.writeFile(absolutePath, req.file.buffer);
-      writtenPath = absolutePath;
+      await putResume(relativePath, req.file.buffer);
+      writtenPath = relativePath;
 
       const existing = await versionRows(application.id);
       const now = new Date();
@@ -271,7 +270,7 @@ router.post(
       });
     } catch (error) {
       // Don't leave an orphaned file behind if the database write failed.
-      if (writtenPath) await fsPromises.unlink(writtenPath).catch(() => {});
+      if (writtenPath) await removeResume(writtenPath).catch(() => {});
       console.error('[POST /api/resume-uploads/applications/:applicationId]', error);
       res.status(500).json({ error: 'Failed to upload resume' });
     }
@@ -296,18 +295,21 @@ router.get('/:uploadId/file', requireAuth, async (req, res) => {
       return res.status(403).json({ error: 'Forbidden' });
     }
 
-    const absolutePath = path.join(STORAGE_DIR, upload.storagePath);
     // Defensive: the path comes from the database, but a traversal in it would
     // otherwise hand out arbitrary files.
-    if (!absolutePath.startsWith(RESUME_ROOT + path.sep)) {
+    if (!upload.storagePath.startsWith('resumes/')) {
       return res.status(400).json({ error: 'Invalid path' });
     }
-    if (!fs.existsSync(absolutePath)) return res.status(404).json({ error: 'Resume file not found' });
+
+    const buffer = await getResume(upload.storagePath);
+    if (!buffer) {
+      return res.status(404).json({ error: 'Resume file not found' });
+    }
 
     res.setHeader('Content-Type', 'application/pdf');
     res.setHeader('Content-Disposition', 'inline');
     res.setHeader('Cache-Control', 'private, max-age=3600');
-    fs.createReadStream(absolutePath).pipe(res);
+    res.send(buffer);
   } catch (error) {
     console.error('[GET /api/resume-uploads/:uploadId/file]', error);
     res.status(500).json({ error: 'Failed to serve resume' });

--- a/server/src/routes/resumeUploads.routes.test.js
+++ b/server/src/routes/resumeUploads.routes.test.js
@@ -14,6 +14,17 @@ import resumeUploadRoutes, { resumeDeadlineAt, replacementWindow } from './resum
 // leave real files behind, so this is torn down at the end of the run.
 const STORAGE_DIR = path.join(path.dirname(fileURLToPath(import.meta.url)), '../../storage');
 
+// Storage is mocked, not exercised. These tests are about the route's rules -
+// ownership, deadlines, version history - and letting them reach the real
+// Supabase bucket both slows them down and leaves fixture-named objects
+// ("app-1") sitting in production storage.
+const stored = new Map();
+vi.mock('../services/resumeStorage.js', () => ({
+  putResume: vi.fn(async (key, buffer) => { stored.set(key, buffer); }),
+  getResume: vi.fn(async (key) => stored.get(key) ?? null),
+  removeResume: vi.fn(async (key) => { stored.delete(key); }),
+}));
+
 vi.mock('../prismaClient.js', () => ({
   default: {
     user: { findUnique: vi.fn() },
@@ -94,7 +105,7 @@ beforeAll(async () => {
 
 afterAll(async () => {
   await new Promise((resolve) => server.close(resolve));
-  fs.rmSync(path.join(STORAGE_DIR, 'resumes', 'app-1'), { recursive: true, force: true });
+  stored.clear();
 });
 
 beforeEach(() => {
@@ -240,7 +251,8 @@ describe('POST /api/resume-uploads/applications/:applicationId', () => {
     expect(body.currentResumeUrl).toBe(created.sourceUrl);
 
     // The bytes really landed where the row says they did.
-    expect(fs.existsSync(path.join(STORAGE_DIR, created.storagePath))).toBe(true);
+    const { getResume } = await import('../services/resumeStorage.js');
+    expect(await getResume(created.storagePath)).not.toBeNull();
   });
 
   it('does not re-capture the original once a version history exists', async () => {

--- a/server/src/services/resumeStorage.js
+++ b/server/src/services/resumeStorage.js
@@ -14,6 +14,11 @@
 // previews and local development can run without Supabase credentials, and a
 // storage layer that throws on boot in those environments would be worse than
 // one that writes to a disk nobody is relying on to persist.
+//
+// In production that fallback is refused outright. Writing to the local disk
+// there is not a degraded mode, it is the original bug: the file is accepted,
+// the row is written, and the PDF is gone at the next deploy with nothing to
+// indicate it happened. Better to fail the upload and say why.
 import fs from 'node:fs';
 import fsPromises from 'node:fs/promises';
 import path from 'node:path';
@@ -61,7 +66,19 @@ const ensureBucket = async () => {
  * @param {Buffer} buffer
  * @param {string} contentType
  */
+const isProduction = () => process.env.NODE_ENV === 'production';
+
 export const putResume = async (key, buffer, contentType = 'application/pdf') => {
+  if (!isSupabaseAvailable() && isProduction()) {
+    // Loud on purpose. A silent local write here is indistinguishable from
+    // success right up until the file is needed.
+    console.error(
+      '[resumeStorage] SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY are not set. ' +
+        'Uploads cannot be stored durably and are being refused.'
+    );
+    throw new Error('File storage is not configured. Please contact the recruitment team.');
+  }
+
   if (isSupabaseAvailable()) {
     await ensureBucket();
     const { error } = await supabase.storage


### PR DESCRIPTION
Two things the Supabase migration in #138 missed. Both are live in production.

## `resumeUploads.js` was never migrated

The applicant resume-replacement flow added in #133 still writes to
`server/storage/resumes/` on the local disk — the same ephemeral-filesystem bug
as the other three upload paths. It is what produces:

```
404 {"error":"Resume file not found"}
```

while the already-migrated paths report their own message. I missed it because
it arrived with #133 rather than with the TPN work.

## The fallback degraded silently

If `SUPABASE_URL` / `SUPABASE_SERVICE_ROLE_KEY` are missing, the storage layer
quietly wrote to the instance's disk. In production that is not a degraded mode,
it is the original bug: the upload is accepted, the row is written, and the PDF
is gone at the next deploy with nothing to indicate it happened.

In production that path now refuses the upload, logs exactly which variables are
missing, and returns "File storage is not configured." Local development and
staging previews keep the fallback, which is the reason it exists.

**This matters for diagnosis:** if uploads on production start returning that
message, the Render service is missing the Supabase variables — which would also
explain why `"Your resume file could not be found"` persisted after #138 landed.
Worth confirming both are set on the production service.

## Tests no longer write to real storage

The route tests were exercising the live Supabase bucket, which is slow and left
objects named after fixtures — `er-1`, `cand-1`, `app-1` — sitting in production
storage. They now mock the storage layer. The three stray objects have been
removed from the bucket.

641 server tests pass; the two `offerLetter.test.js` failures are byte-identical
to `main`'s copy and fail there too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)