### PR TITLE
Fix: 403 opening your own replaced resume

### DIFF
--- a/server/src/routes/files.js
+++ b/server/src/routes/files.js
@@ -11,6 +11,29 @@ router.use(requireAuth);
 // view any file referenced by an application; USER role may only view files
 // attached to their own application (matched via candidate email/studentId or
 // the application's own email field).
+/**
+ * Was this Drive file ever a resume on this application?
+ *
+ * Replacing a resume repoints Application.resumeUrl at the new upload, so the
+ * file the applicant originally submitted stops being referenced by any URL
+ * column - and the reference check below then refuses it. That is how a
+ * candidate came to get a 403 opening their *own* previous resume.
+ *
+ * ResumeUpload.sourceUrl is where that history is kept, so it is the second
+ * place worth asking. Scoped to applications the caller already owns, so this
+ * widens what an owner can reach and nothing else.
+ */
+const referencedByVersionHistory = async (fileId, applicationFilter) => {
+  const upload = await prisma.resumeUpload.findFirst({
+    where: {
+      sourceUrl: { contains: fileId },
+      ...(applicationFilter ? { application: applicationFilter } : {}),
+    },
+    select: { id: true },
+  });
+  return Boolean(upload);
+};
+
 async function authorizeFileAccess(fileId, user) {
   if (user.role === 'ADMIN' || user.role === 'MEMBER') {
     const referenced = await prisma.application.findFirst({
@@ -25,7 +48,10 @@ async function authorizeFileAccess(fileId, user) {
       },
       select: { id: true },
     });
-    return Boolean(referenced);
+    if (referenced) return true;
+    // Staff read the same version history, unscoped - they can already open any
+    // current application document.
+    return referencedByVersionHistory(fileId, null);
   }
 
   const ownerFilters = [];
@@ -56,7 +82,11 @@ async function authorizeFileAccess(fileId, user) {
     },
     select: { id: true },
   });
-  return Boolean(ownAndReferenced);
+  if (ownAndReferenced) return true;
+
+  // Not a current document, but it may be a superseded one. Restricted to
+  // applications this person owns.
+  return referencedByVersionHistory(fileId, { OR: ownerFilters });
 }
 
 router.get('/:fileId/image', async (req, res) => {

--- a/server/src/routes/files.routes.test.js
+++ b/server/src/routes/files.routes.test.js
@@ -1,0 +1,121 @@
+// Drive file access.
+//
+// The rule is that a candidate may open their own application documents and
+// nobody else's. The case worth pinning down is the one that broke: replacing a
+// resume repoints Application.resumeUrl at the new upload, so the file the
+// applicant originally submitted stops being referenced by any URL column — and
+// they were refused their own previous resume.
+import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest';
+import express from 'express';
+import jwt from 'jsonwebtoken';
+import prisma from '../prismaClient.js';
+import filesRoutes from './files.js';
+
+vi.mock('../prismaClient.js', () => ({
+  default: {
+    user: { findUnique: vi.fn() },
+    application: { findFirst: vi.fn() },
+    resumeUpload: { findFirst: vi.fn() },
+  },
+}));
+
+vi.mock('../services/google/drive.js', () => ({
+  getFileStream: vi.fn(async () => {
+    const { Readable } = await import('node:stream');
+    return Readable.from([Buffer.from('%PDF-1.4 drive')]);
+  }),
+  getFileMetadata: vi.fn(async () => ({ name: 'resume.pdf', mimeType: 'application/pdf' })),
+}));
+
+const candidate = {
+  id: 'user-1',
+  role: 'USER',
+  isActive: true,
+  email: 'rk@kw.com',
+  studentId: '912345786',
+};
+
+const admin = { id: 'admin-1', role: 'ADMIN', isActive: true, email: 'a@uc.org' };
+
+const ALL = [candidate, admin];
+const FILE_ID = '1jmfVKDm1MyzIHNbqe2oARQkrsU0TW32';
+
+let server;
+let port;
+
+const tokenFor = (user) => jwt.sign({ userId: user.id }, process.env.JWT_SECRET);
+
+const get = (path, user) =>
+  fetch(`http://localhost:${port}${path}`, {
+    headers: user ? { Authorization: `Bearer ${tokenFor(user)}` } : {},
+  });
+
+beforeAll(async () => {
+  const app = express();
+  app.use('/api/files', filesRoutes);
+  server = app.listen(0);
+  await new Promise((resolve) => server.on('listening', resolve));
+  port = server.address().port;
+});
+
+afterAll(async () => {
+  await new Promise((resolve) => server.close(resolve));
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  prisma.user.findUnique.mockImplementation(({ where: { id } }) => ALL.find((u) => u.id === id) || null);
+  prisma.application.findFirst.mockResolvedValue(null);
+  prisma.resumeUpload.findFirst.mockResolvedValue(null);
+});
+
+describe('a candidate opening a Drive document', () => {
+  it('is allowed when it is a current document on their own application', async () => {
+    prisma.application.findFirst.mockResolvedValue({ id: 'app-1' });
+    expect((await get(`/api/files/${FILE_ID}/pdf`, candidate)).status).toBe(200);
+  });
+
+  it('is allowed when it is a resume they replaced', async () => {
+    // Regression: resumeUrl now points at the replacement, so the reference
+    // check finds nothing and used to return 403 for their own old resume.
+    prisma.application.findFirst.mockResolvedValue(null);
+    prisma.resumeUpload.findFirst.mockResolvedValue({ id: 'upload-1' });
+
+    expect((await get(`/api/files/${FILE_ID}/pdf`, candidate)).status).toBe(200);
+  });
+
+  it('scopes the version-history lookup to applications they own', async () => {
+    prisma.resumeUpload.findFirst.mockResolvedValue({ id: 'upload-1' });
+    await get(`/api/files/${FILE_ID}/pdf`, candidate);
+
+    const where = prisma.resumeUpload.findFirst.mock.calls[0][0].where;
+    expect(where.sourceUrl).toEqual({ contains: FILE_ID });
+    // Without this an owner check would let anyone read any superseded resume.
+    expect(where.application).toBeTruthy();
+  });
+
+  it('is refused for a document that is neither current nor theirs', async () => {
+    expect((await get(`/api/files/${FILE_ID}/pdf`, candidate)).status).toBe(403);
+  });
+
+  it('is refused without a session', async () => {
+    expect((await get(`/api/files/${FILE_ID}/pdf`)).status).toBe(401);
+  });
+});
+
+describe('staff', () => {
+  it('may open a superseded resume too', async () => {
+    prisma.resumeUpload.findFirst.mockResolvedValue({ id: 'upload-1' });
+    expect((await get(`/api/files/${FILE_ID}/pdf`, admin)).status).toBe(200);
+  });
+
+  it('reads version history unscoped, unlike a candidate', async () => {
+    prisma.resumeUpload.findFirst.mockResolvedValue({ id: 'upload-1' });
+    await get(`/api/files/${FILE_ID}/pdf`, admin);
+    expect(prisma.resumeUpload.findFirst.mock.calls[0][0].where.application).toBeUndefined();
+  });
+
+  it('is still refused a file referenced by nothing at all', async () => {
+    expect((await get(`/api/files/${FILE_ID}/pdf`, admin)).status).toBe(403);
+  });
+});


### PR DESCRIPTION
Reported on production by `rkleczynski@kw.com`: opening a previous resume
returned `403 Forbidden`.

## Cause

Replacing a resume repoints `Application.resumeUrl` at the new upload. The Drive
file the applicant originally submitted is then referenced by **no URL column at
all**, and `authorizeFileAccess` only asks about those columns — so the owner is
refused their own previous resume.

Confirmed against that account:

```
original drive fileId: 1jmfVKDm1-MyzIHNbqe2oARQkrsU0TW32
still referenced by an application URL column?  false   -> candidate gets 403
application.resumeUrl now: /api/resume-uploads/34ac2c69-.../file
ResumeUpload.sourceUrl:    /api/files/1jmfVKDm1-.../pdf
```

Ownership was never in question — `isOwnedBy` returns `true` for that
application on both email and student ID. The file simply stopped being
reachable once it was superseded.

## Fix

The check falls back to `ResumeUpload.sourceUrl`, which is where resume history
is kept. For a candidate the lookup is **scoped to applications they already
own**, so this widens what an owner can reach and nothing else. Staff read it
unscoped, matching their existing access to any current application document.

## Tests

First tests for `files.js`, covering both directions: an owner reaching a
superseded resume, and a file referenced by nothing still being refused — plus
the scoping itself, since dropping that clause would let any candidate read any
superseded resume.

649 server tests pass; the two `offerLetter.test.js` failures are byte-identical
to `main`'s copy and fail there too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)