### PR TITLE
Fix: 500 on resume replace hides a storage misconfiguration

### DIFF
--- a/server/src/routes/candidateOnboarding.js
+++ b/server/src/routes/candidateOnboarding.js
@@ -26,7 +26,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import multer from 'multer';
 import prisma from '../prismaClient.js';
-import { putResume, getResume } from '../services/resumeStorage.js';
+import { putResume, getResume, storageErrorResponse } from '../services/resumeStorage.js';
 import { requireAuth } from '../middleware/auth.js';
 import {
   sanitizeOnboardingInput,
@@ -357,6 +357,8 @@ router.post('/', requireVerifiedEmail, uploadMiddleware, async (req, res) => {
     res.status(201).json({ onboarding: serializeOnboarding(record), talentPool });
   } catch (error) {
     console.error('[POST /api/candidate/onboarding]', error);
+    const configured = storageErrorResponse(error);
+    if (configured) return res.status(configured.status).json(configured.body);
     res.status(500).json({ error: 'Failed to save your information' });
   }
 });
@@ -469,6 +471,8 @@ router.put('/resume', requireVerifiedEmail, uploadMiddleware, async (req, res) =
     res.json({ onboarding: serializeOnboarding(record), message: 'Your resume has been replaced.' });
   } catch (error) {
     console.error('[PUT /api/candidate/onboarding/resume]', error);
+    const configured = storageErrorResponse(error);
+    if (configured) return res.status(configured.status).json(configured.body);
     res.status(500).json({ error: 'Failed to replace your resume' });
   }
 });

--- a/server/src/routes/member.js
+++ b/server/src/routes/member.js
@@ -4,7 +4,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { requireAuth, requireAdminOrMember } from '../middleware/auth.js';
 import prisma from '../prismaClient.js';
-import { putResume, getResume, removeResume } from '../services/resumeStorage.js';
+import { putResume, getResume, removeResume, storageErrorResponse } from '../services/resumeStorage.js';
 import { sendSlackMessage } from '../services/slackService.js';
 import { sendMeetingCancellationEmail } from '../services/emailNotifications.js';
 import { sendAndLogMeetingCommunication, MEETING_COMM_SUBJECTS } from '../services/meetingComms.js';
@@ -1925,6 +1925,8 @@ router.post('/resume', requireAuth, requireMemberRole, resumeUploadMiddleware, a
     res.status(201).json({ resume: serializeMemberResume(resume, 0) });
   } catch (error) {
     console.error('[POST /api/member/resume]', error);
+    const configured = storageErrorResponse(error);
+    if (configured) return res.status(configured.status).json(configured.body);
     res.status(500).json({ error: 'Failed to upload your resume' });
   }
 });

--- a/server/src/routes/talent.js
+++ b/server/src/routes/talent.js
@@ -16,7 +16,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import multer from 'multer';
 import prisma from '../prismaClient.js';
-import { putResume, getResume } from '../services/resumeStorage.js';
+import { putResume, getResume, storageErrorResponse } from '../services/resumeStorage.js';
 import { requireAuth, invalidateUserCache } from '../middleware/auth.js';
 import {
   EXTERNAL_GENDERS,
@@ -213,6 +213,8 @@ router.post('/resume', requireVerifiedEmail, resumeUploadMiddleware, async (req,
     res.status(201).json({ resume: serializeExternalResume(resume, 0) });
   } catch (error) {
     console.error('[POST /api/talent/resume]', error);
+    const configured = storageErrorResponse(error);
+    if (configured) return res.status(configured.status).json(configured.body);
     res.status(500).json({ error: 'Failed to upload your resume' });
   }
 });

--- a/server/src/services/resumeStorage.js
+++ b/server/src/services/resumeStorage.js
@@ -76,7 +76,13 @@ export const putResume = async (key, buffer, contentType = 'application/pdf') =>
       '[resumeStorage] SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY are not set. ' +
         'Uploads cannot be stored durably and are being refused.'
     );
-    throw new Error('File storage is not configured. Please contact the recruitment team.');
+    const error = new Error('File storage is not configured. Please contact the recruitment team.');
+    // Tagged so routes can report it as a configuration fault rather than
+    // letting it fall into a generic "something went wrong" 500, which is what
+    // hid it in production: the upload failed for a knowable reason and said
+    // nothing about it.
+    error.code = 'STORAGE_NOT_CONFIGURED';
+    throw error;
   }
 
   if (isSupabaseAvailable()) {
@@ -139,3 +145,14 @@ export const removeResume = async (key) => {
   const absolute = path.join(LOCAL_STORAGE_ROOT, key);
   await fsPromises.rm(absolute, { force: true }).catch(() => {});
 };
+
+/**
+ * Express-friendly shape for a storage misconfiguration.
+ *
+ * 503 rather than 500: the request was fine, the service is not, and retrying
+ * once someone sets the variables will work.
+ */
+export const storageErrorResponse = (error) =>
+  error?.code === 'STORAGE_NOT_CONFIGURED'
+    ? { status: 503, body: { error: error.message, code: error.code } }
+    : null;

--- a/server/src/services/resumeStorage.test.js
+++ b/server/src/services/resumeStorage.test.js
@@ -1,0 +1,65 @@
+// The storage layer's production guard.
+//
+// The rule worth pinning down is the one that cost a production debugging
+// session: without Supabase credentials the layer used to write to the
+// instance's local disk, which on Render is wiped by the next deploy. The
+// upload was accepted, the row was written, and the file was gone — with
+// nothing anywhere to say so.
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('../supabaseClient.js', () => ({
+  default: null,
+  isSupabaseAvailable: () => false,
+}));
+
+const original = process.env.NODE_ENV;
+
+beforeEach(() => {
+  vi.resetModules();
+});
+
+afterEach(() => {
+  process.env.NODE_ENV = original;
+});
+
+describe('when Supabase is not configured', () => {
+  it('refuses the upload in production rather than writing somewhere temporary', async () => {
+    process.env.NODE_ENV = 'production';
+    const { putResume } = await import('./resumeStorage.js');
+
+    await expect(putResume('member-resumes/x/resume.pdf', Buffer.from('%PDF-'))).rejects.toThrow(
+      /not configured/i
+    );
+  });
+
+  it('tags the failure so a route can report it as a misconfiguration', async () => {
+    process.env.NODE_ENV = 'production';
+    const { putResume, storageErrorResponse } = await import('./resumeStorage.js');
+
+    const error = await putResume('member-resumes/x/resume.pdf', Buffer.from('%PDF-')).catch((e) => e);
+    expect(error.code).toBe('STORAGE_NOT_CONFIGURED');
+
+    // 503, not 500: the request was fine, the service is not, and it will work
+    // once someone sets the variables.
+    expect(storageErrorResponse(error)).toMatchObject({ status: 503 });
+  });
+
+  it('still falls back to disk outside production, which is why the path exists', async () => {
+    process.env.NODE_ENV = 'development';
+    const { putResume, getResume, removeResume } = await import('./resumeStorage.js');
+
+    const key = 'member-resumes/__unit__/resume.pdf';
+    const body = Buffer.from('%PDF-1.4 local');
+    await putResume(key, body);
+    expect(await getResume(key)).toEqual(body);
+    await removeResume(key);
+  });
+});
+
+describe('storageErrorResponse', () => {
+  it('ignores ordinary failures, which must keep their own handling', async () => {
+    const { storageErrorResponse } = await import('./resumeStorage.js');
+    expect(storageErrorResponse(new Error('network blew up'))).toBeNull();
+    expect(storageErrorResponse(undefined)).toBeNull();
+  });
+});


### PR DESCRIPTION
`PUT /api/candidate/onboarding/resume` returns `500 {"error":"Failed to replace
your resume"}` in production while succeeding locally.

## Cause

The production guard added with the Supabase migration is doing its job —
refusing to write to an ephemeral disk when `SUPABASE_URL` /
`SUPABASE_SERVICE_ROLE_KEY` are missing — and the route's catch block flattens
that into a generic failure. The one thing worth knowing was the one thing not
reported.

## Fix

The guard tags its error, and every upload route now reports it as **503** with
the real message: *"File storage is not configured."* 503 rather than 500
because the request was fine, the service is not, and it will work once the
variables are set.

## This is diagnostic

If uploads on production start returning that message, the Render service is
missing the Supabase variables. That remains the most likely explanation for
uploads failing there after #138 and #141 landed — every object in the bucket
came from a local machine, and nothing production wrote is in it.

`render.yaml` only defines those variables for staging previews; production is
dashboard-configured.

## Tests

First tests for the storage layer: the production refusal, the error tag and its
503 mapping, and the non-production disk fallback that is the reason the fallback
exists at all.

653 server tests pass; the two `offerLetter.test.js` failures are byte-identical
to `main`'s copy and fail there too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)