### PR TITLE
Fix: master communications reached deactivated members

### DIFF
--- a/server/src/services/masterCommunications.js
+++ b/server/src/services/masterCommunications.js
@@ -237,7 +237,11 @@ export async function resolveRecipients({ audience, filters = {} }) {
   if (audience === 'members' || audience === 'users') {
     const roles = filters.roles?.length ? filters.roles : ['MEMBER'];
     const users = await prisma.user.findMany({
-      where: { role: { in: roles } },
+      // Deactivated accounts are excluded. They are people who have left -
+      // graduated members, removed admins - and without this a send to
+      // "members" reached all 55 accounts rather than the 45 active ones,
+      // putting org mail in the inboxes of ten people who are no longer here.
+      where: { role: { in: roles }, isActive: true },
       select: { id: true, email: true, fullName: true, role: true },
     });
     return users.map((u) => ({
@@ -251,7 +255,8 @@ export async function resolveRecipients({ audience, filters = {} }) {
 
   if (audience === 'admins') {
     const users = await prisma.user.findMany({
-      where: { role: 'ADMIN' },
+      // Same rule as the members branch above.
+      where: { role: 'ADMIN', isActive: true },
       select: { id: true, email: true, fullName: true, role: true },
     });
     return users.map((u) => ({

--- a/server/src/services/masterCommunications.recipients.test.js
+++ b/server/src/services/masterCommunications.recipients.test.js
@@ -1,0 +1,64 @@
+// Who a master communication actually reaches.
+//
+// The rule worth pinning down is that a send never reaches someone who has left.
+// Deactivation is how this app records that, and the recipient query used to
+// ignore it entirely: a send to "members" resolved all 55 member accounts
+// rather than the 45 active ones, putting org mail in front of ten people who
+// were no longer part of the organization.
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import prisma from '../prismaClient.js';
+import { resolveRecipients } from './masterCommunications.js';
+
+vi.mock('../prismaClient.js', () => ({
+  default: {
+    user: { findMany: vi.fn() },
+    application: { findMany: vi.fn() },
+  },
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  prisma.user.findMany.mockResolvedValue([]);
+});
+
+const whereOf = () => prisma.user.findMany.mock.calls[0][0].where;
+
+describe('members', () => {
+  it('asks only for active accounts', async () => {
+    await resolveRecipients({ audience: 'members' });
+    expect(whereOf()).toEqual({ role: { in: ['MEMBER'] }, isActive: true });
+  });
+
+  it('keeps the active filter when roles are chosen explicitly', async () => {
+    await resolveRecipients({ audience: 'members', filters: { roles: ['MEMBER', 'ADMIN'] } });
+    expect(whereOf()).toMatchObject({ role: { in: ['MEMBER', 'ADMIN'] }, isActive: true });
+  });
+
+  it('treats the users audience the same way', async () => {
+    await resolveRecipients({ audience: 'users', filters: { roles: ['USER'] } });
+    expect(whereOf()).toMatchObject({ isActive: true });
+  });
+
+  it('returns the recipients the query produced', async () => {
+    prisma.user.findMany.mockResolvedValue([
+      { id: 'u1', email: 'a@uc.org', fullName: 'Active Member', role: 'MEMBER' },
+    ]);
+    const recipients = await resolveRecipients({ audience: 'members' });
+    expect(recipients).toEqual([
+      { id: 'u1', email: 'a@uc.org', fullName: 'Active Member', audience: 'user', role: 'MEMBER' },
+    ]);
+  });
+});
+
+describe('admins', () => {
+  it('asks only for active accounts', async () => {
+    await resolveRecipients({ audience: 'admins' });
+    expect(whereOf()).toEqual({ role: 'ADMIN', isActive: true });
+  });
+});
+
+describe('an unknown audience', () => {
+  it('is refused rather than silently reaching nobody', async () => {
+    await expect(resolveRecipients({ audience: 'everyone' })).rejects.toThrow(/Unsupported audience/);
+  });
+});


### PR DESCRIPTION
Filtering by members in Master Communications shows **55 recipients** when there
are **45 active members**.

## Cause

Recipient resolution queried on role alone:

```js
where: { role: { in: roles } }        // no isActive filter
```

So a send reached every account that had ever been a member. Against current
data:

| role | total | active | deactivated |
|---|---|---|---|
| MEMBER | 55 | 45 | **10** |
| ADMIN | 16 | 16 | 0 |

Ten people who have left the organization would have received org mail —
including the Talent Partner Network launch email, which is what surfaced it.

The `admins` audience had the same query and the same gap; it happens to be
harmless today only because no admin is currently deactivated.

## Fix

Deactivation is how this app records that someone is gone, so both branches now
require `isActive: true`.

If alumni outreach is ever wanted, that should be an explicit audience rather
than a side effect of a missing filter.

## Tests

First tests for recipient resolution. A silent over-send is not something a
reviewer can see in a diff, so the assertions are on the query itself as well as
the returned recipients.

659 server tests pass; the two `offerLetter.test.js` failures are byte-identical
to `main`'s copy and fail there too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)