### PR TITLE
Master communications: save drafts

### DIFF
--- a/client/src/pages/MasterCommunications.jsx
+++ b/client/src/pages/MasterCommunications.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   Box,
   Paper,
@@ -47,6 +47,7 @@ const CHANNELS = [
   { key: 'email', label: 'Email' },
   { key: 'slack', label: 'Slack' },
   { key: 'imessage', label: 'iMessage' },
+  { key: 'drafts', label: 'Drafts' },
   { key: 'templates', label: 'Templates' },
   { key: 'logs', label: 'Logs' },
   { key: 'scheduled', label: 'Scheduled' },
@@ -106,6 +107,11 @@ const MasterCommunications = () => {
   const [templateName, setTemplateName] = useState('');
   const [templateChannel, setTemplateChannel] = useState('email');
   const [scheduledAt, setScheduledAt] = useState('');
+  const [drafts, setDrafts] = useState([]);
+  const [draftName, setDraftName] = useState('');
+  // The draft currently open in the composer. Saving with this set updates that
+  // draft rather than creating a second copy of the same message.
+  const [openDraftId, setOpenDraftId] = useState(null);
 
   const [preview, setPreview] = useState(null);
   const [confirmOpen, setConfirmOpen] = useState(false);
@@ -129,13 +135,16 @@ const MasterCommunications = () => {
       fetchTemplates(primaryCycle);
       fetchLogs(primaryCycle);
     }
-  }, [primaryCycle]);
+    // Not gated on a cycle: a draft can be saved before one is chosen, and
+    // those would otherwise be invisible until you picked a cycle.
+    fetchDrafts(primaryCycle);
+  }, [primaryCycle, fetchDrafts]);
 
   useEffect(() => {
-    if (tab === 5 && primaryCycle) {
+    if (channel === 'scheduled' && primaryCycle) {
       fetchScheduled(primaryCycle);
     }
-  }, [tab, primaryCycle]);
+  }, [channel, primaryCycle]);
 
   const fetchCycles = async () => {
     try {
@@ -189,6 +198,88 @@ const MasterCommunications = () => {
   const clearMessages = () => {
     setError('');
     setSuccess('');
+  };
+
+  const fetchDrafts = useCallback(async (cycleId) => {
+    try {
+      const query = cycleId ? `?cycleId=${cycleId}` : '';
+      const data = await apiClient.get(`/master-communications/drafts${query}`);
+      setDrafts(data.drafts || []);
+    } catch (e) {
+      setError(e.message || 'Failed to load drafts');
+    }
+  }, []);
+
+  const saveDraft = async () => {
+    clearMessages();
+    if (!draftName.trim()) {
+      setError('Give the draft a name so you can find it again');
+      return;
+    }
+    // Body is deliberately not required. Saving is for work in progress, and
+    // refusing an empty one would throw away the audience and filters that were
+    // just assembled.
+    const payload = {
+      name: draftName.trim(),
+      channel,
+      audience,
+      filters: buildFilters(),
+      subject: channel === 'email' ? subject : '',
+      body,
+      cycleId: primaryCycle || null,
+    };
+
+    try {
+      if (openDraftId) {
+        await apiClient.patch(`/master-communications/drafts/${openDraftId}`, payload);
+        setSuccess('Draft updated');
+      } else {
+        const data = await apiClient.post('/master-communications/drafts', payload);
+        setOpenDraftId(data.draft?.id ?? null);
+        setSuccess('Draft saved');
+      }
+      fetchDrafts(primaryCycle);
+    } catch (e) {
+      setError(e.message || 'Failed to save draft');
+    }
+  };
+
+  /** Put the composer back exactly as the draft was left. */
+  const openDraft = (draft) => {
+    clearMessages();
+    setOpenDraftId(draft.id);
+    setDraftName(draft.name);
+    setAudience(draft.audience);
+    setSubject(draft.subject || '');
+    setBody(draft.body || '');
+
+    const filters = draft.filters || {};
+    setRoles(filters.roles || ['MEMBER']);
+    setApplicationStatus(filters.applicationStatus || '');
+    setInterviewRound(filters.interviewRound || '');
+    setDecision(filters.decision || '');
+    setEventRsvpId(filters.eventRsvpId || '');
+    setEventAttendedId(filters.eventAttendedId || '');
+    if (filters.cycleIds?.length) setSelectedCycles(filters.cycleIds);
+
+    const channelTab = CHANNELS.findIndex((c) => c.key === draft.channel);
+    if (channelTab >= 0) setTab(channelTab);
+    setSuccess(`Opened draft "${draft.name}"`);
+  };
+
+  const removeDraft = async (id) => {
+    clearMessages();
+    try {
+      await apiClient.delete(`/master-communications/drafts/${id}`);
+      if (openDraftId === id) {
+        setOpenDraftId(null);
+        setDraftName('');
+      }
+      setSuccess('Draft deleted');
+      fetchDrafts(primaryCycle);
+    } catch (e) {
+      setError(e.message || 'Failed to delete draft');
+    }
   };
 
   const buildFilters = () => {
@@ -319,7 +410,7 @@ const MasterCommunications = () => {
       await apiClient.post('/master-communications/schedule', payload);
       setSuccess(`Message scheduled for ${new Date(scheduledAt).toLocaleString()}`);
       setScheduledAt('');
-      if (tab === 5) fetchScheduled(primaryCycle);
+      if (channel === 'scheduled') fetchScheduled(primaryCycle);
     } catch (e) {
       setError(e.message || 'Failed to schedule');
     } finally {
@@ -684,6 +775,37 @@ const MasterCommunications = () => {
           {loading ? <CircularProgress size={20} /> : 'Preview Recipients'}
         </Button>
 
+        {/* Available on every channel, including iMessage: assembling an
+            audience is the slow part, and it is worth keeping regardless of how
+            the message eventually goes out. */}
+        <Stack direction="row" spacing={1} alignItems="center" sx={{ width: '100%', mb: 1 }}>
+          <TextField
+            size="small"
+            label="Draft name"
+            placeholder="TPN launch"
+            value={draftName}
+            onChange={(e) => setDraftName(e.target.value)}
+            sx={{ maxWidth: 260 }}
+          />
+          <Button variant="outlined" onClick={saveDraft} disabled={!draftName.trim()}>
+            {openDraftId ? 'Update draft' : 'Save draft'}
+          </Button>
+          {openDraftId && (
+            <Button
+              size="small"
+              onClick={() => {
+                // Leaves the composer as it is and stops further saves from
+                // overwriting the draft that was opened.
+                setOpenDraftId(null);
+                setDraftName('');
+                setSuccess('Detached from draft — saving now creates a new one');
+              }}
+            >
+              Detach
+            </Button>
+          )}
+        </Stack>
+
         {channel !== 'imessage' && (
           <>
             <Button
@@ -775,6 +897,60 @@ const MasterCommunications = () => {
           )}
         </Paper>
       )}
+    </Box>
+  );
+
+  const renderDraftsTab = () => (
+    <Box>
+      <Paper sx={{ p: 2, mb: 2 }}>
+        <Typography variant="h6" gutterBottom>Saved Drafts</Typography>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+          A draft keeps the whole message — channel, audience, filters, subject and body — so
+          opening one puts the composer back as it was left. Drafts are shared, so anyone on the
+          team can finish one.
+        </Typography>
+
+        {drafts.length === 0 ? (
+          <Typography variant="body2" color="text.secondary">
+            No drafts yet. Compose a message and use “Save draft” to keep it.
+          </Typography>
+        ) : (
+          <List dense>
+            {drafts.map((draft) => (
+              <ListItem
+                key={draft.id}
+                divider
+                secondaryAction={
+                  <Stack direction="row" spacing={1}>
+                    <Button size="small" onClick={() => openDraft(draft)}>Open</Button>
+                    <Button size="small" color="error" onClick={() => removeDraft(draft.id)}>
+                      Delete
+                    </Button>
+                  </Stack>
+                }
+              >
+                <ListItemText
+                  primary={
+                    <Stack direction="row" spacing={1} alignItems="center">
+                      <span>{draft.name}</span>
+                      <Chip size="small" variant="outlined" label={draft.channel} />
+                      <Chip size="small" variant="outlined" label={draft.audience} />
+                      {openDraftId === draft.id && <Chip size="small" color="primary" label="Open" />}
+                    </Stack>
+                  }
+                  secondary={
+                    /* Who last touched it, because these are shared and you
+                       want to know that before sending someone else's work. */
+                    `${draft.editor?.fullName || draft.creator?.fullName || 'Unknown'} · ${
+                      draft.updatedAt ? new Date(draft.updatedAt).toLocaleString() : ''
+                    }${draft.body ? '' : ' · empty body'}`
+                  }
+                />
+              </ListItem>
+            ))}
+          </List>
+        )}
+      </Paper>
     </Box>
   );
 
@@ -962,9 +1138,10 @@ const MasterCommunications = () => {
           <TabPanel value={tab} index={0}>{renderSendTab()}</TabPanel>
           <TabPanel value={tab} index={1}>{renderSendTab()}</TabPanel>
           <TabPanel value={tab} index={2}>{renderSendTab()}</TabPanel>
-          <TabPanel value={tab} index={3}>{renderTemplatesTab()}</TabPanel>
-          <TabPanel value={tab} index={4}>{renderLogsTab()}</TabPanel>
-          <TabPanel value={tab} index={5}>{renderScheduledTab()}</TabPanel>
+          <TabPanel value={tab} index={3}>{renderDraftsTab()}</TabPanel>
+          <TabPanel value={tab} index={4}>{renderTemplatesTab()}</TabPanel>
+          <TabPanel value={tab} index={5}>{renderLogsTab()}</TabPanel>
+          <TabPanel value={tab} index={6}>{renderScheduledTab()}</TabPanel>
         </Paper>
 
         <Dialog open={confirmOpen} onClose={() => setConfirmOpen(false)} maxWidth="sm" fullWidth>

--- a/server/prisma/migrations/20260827000000_add_message_drafts/migration.sql
+++ b/server/prisma/migrations/20260827000000_add_message_drafts/migration.sql
@@ -1,0 +1,46 @@
+-- Unsent master communications, saved so one can be finished later or by
+-- someone else. Re-runnable: applied with `prisma db execute`, which has no
+-- transaction of its own (see CLAUDE.md).
+
+CREATE TABLE IF NOT EXISTS "message_drafts" (
+  "id"          TEXT NOT NULL,
+  "name"        TEXT NOT NULL,
+  "channel"     TEXT NOT NULL,
+  "audience"    TEXT NOT NULL,
+  "filters"     JSONB,
+  "subject"     TEXT NOT NULL DEFAULT '',
+  "body"        TEXT NOT NULL,
+  "cycleId"     TEXT,
+  "createdById" TEXT NOT NULL,
+  "updatedById" TEXT,
+  "createdAt"   TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt"   TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+  CONSTRAINT "message_drafts_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX IF NOT EXISTS "message_drafts_cycleId_idx" ON "message_drafts"("cycleId");
+-- The list is ordered by most recently touched, so this covers it.
+CREATE INDEX IF NOT EXISTS "message_drafts_updatedAt_idx" ON "message_drafts"("updatedAt");
+
+-- ADD CONSTRAINT has no IF NOT EXISTS form, hence the guards.
+DO $$
+BEGIN
+  ALTER TABLE "message_drafts" ADD CONSTRAINT "message_drafts_cycleId_fkey"
+    FOREIGN KEY ("cycleId") REFERENCES "recruiting_cycles"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+DO $$
+BEGIN
+  ALTER TABLE "message_drafts" ADD CONSTRAINT "message_drafts_createdById_fkey"
+    FOREIGN KEY ("createdById") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+DO $$
+BEGIN
+  ALTER TABLE "message_drafts" ADD CONSTRAINT "message_drafts_updatedById_fkey"
+    FOREIGN KEY ("updatedById") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -64,6 +64,8 @@ model User {
   createdCycles              RecruitingCycle[]               @relation("RecruitingCycleCreator")
   resumeUploads              ResumeUpload[]                  @relation("ResumeUploader")
   createdMessageTemplates    MessageTemplate[]               @relation("MessageTemplateCreator")
+  createdMessageDrafts       MessageDraft[]                  @relation("MessageDraftCreator")
+  editedMessageDrafts        MessageDraft[]                  @relation("MessageDraftEditor")
   sentMessageLogs            MessageLog[]                    @relation("MessageLogSender")
   scheduledMessages          MessageSchedule[]               @relation("ScheduleSender")
   talentPartnerClient        TalentPartnerClient?            @relation("TalentPartnerClientUser")
@@ -271,6 +273,7 @@ model RecruitingCycle {
   cases                     Case[]
   gtkucProfileConfirmations MemberGtkucProfileConfirmation[]
   messageTemplates          MessageTemplate[]                @relation("CycleTemplates")
+  messageDrafts             MessageDraft[]                   @relation("CycleDrafts")
   messageLogs               MessageLog[]                     @relation("CycleLogs")
   scheduledMessages         MessageSchedule[]                @relation("ScheduleCycle")
 
@@ -1003,6 +1006,44 @@ enum MeetingCommunicationType {
   HOST_NOTIFICATION
   CANCELLATION
   REMINDER
+}
+
+/// A message someone started writing and has not sent.
+///
+/// Deliberately separate from MessageTemplate. A template is reusable
+/// boilerplate - a name, a subject and a body meant to be applied to many
+/// sends. A draft is one specific unsent message, so it also carries the
+/// audience and the filters that decide who it goes to; reopening it puts the
+/// composer back exactly as it was left. Folding the two together would make
+/// the template list a mix of "ready to reuse" and "half-written", with nothing
+/// to tell them apart.
+///
+/// Shared across admins rather than private, so comms can be written by one
+/// person and finished by another. updatedById records who touched it last,
+/// which is the thing you want to know before sending someone else's draft.
+model MessageDraft {
+  id          String           @id @default(uuid())
+  name        String
+  channel     String
+  audience    String
+  /// The composer's filter object, stored whole. Its shape is owned by
+  /// resolveRecipients and changes as audiences gain filters, so pinning it to
+  /// columns here would mean a migration every time one is added.
+  filters     Json?
+  subject     String           @default("")
+  body        String
+  cycleId     String?
+  createdById String
+  updatedById String?
+  createdAt   DateTime         @default(now())
+  updatedAt   DateTime         @updatedAt
+  cycle       RecruitingCycle? @relation("CycleDrafts", fields: [cycleId], references: [id], onDelete: SetNull)
+  creator     User             @relation("MessageDraftCreator", fields: [createdById], references: [id])
+  editor      User?            @relation("MessageDraftEditor", fields: [updatedById], references: [id])
+
+  @@index([cycleId])
+  @@index([updatedAt])
+  @@map("message_drafts")
 }
 
 model MessageTemplate {

--- a/server/src/routes/masterCommunications.drafts.test.js
+++ b/server/src/routes/masterCommunications.drafts.test.js
@@ -1,0 +1,201 @@
+// Saved drafts of master communications.
+//
+// The assertions worth having are about what a draft is for: it holds an
+// unfinished message, it holds the whole composition rather than just the text,
+// and it is shared - one admin writes it, another finishes it.
+import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest';
+import express from 'express';
+import jwt from 'jsonwebtoken';
+import prisma from '../prismaClient.js';
+import routes from './masterCommunications.js';
+
+vi.mock('../prismaClient.js', () => ({
+  default: {
+    user: { findUnique: vi.fn() },
+    messageDraft: {
+      findMany: vi.fn(),
+      findUnique: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+    },
+  },
+}));
+
+const admin = { id: 'admin-1', role: 'ADMIN', isActive: true, email: 'a@uc.org', fullName: 'Admin One' };
+const otherAdmin = { id: 'admin-2', role: 'ADMIN', isActive: true, email: 'b@uc.org', fullName: 'Admin Two' };
+const member = { id: 'member-1', role: 'MEMBER', isActive: true, email: 'm@uc.org' };
+const ALL = [admin, otherAdmin, member];
+
+let server;
+let port;
+
+const tokenFor = (user) => jwt.sign({ userId: user.id }, process.env.JWT_SECRET);
+
+const call = (path, { user, method = 'GET', body } = {}) =>
+  fetch(`http://localhost:${port}${path}`, {
+    method,
+    headers: {
+      ...(user ? { Authorization: `Bearer ${tokenFor(user)}` } : {}),
+      ...(body ? { 'Content-Type': 'application/json' } : {}),
+    },
+    ...(body ? { body: JSON.stringify(body) } : {}),
+  });
+
+const draftRow = (overrides = {}) => ({
+  id: 'draft-1',
+  name: 'TPN launch',
+  channel: 'email',
+  audience: 'members',
+  filters: { roles: ['MEMBER'] },
+  subject: 'Get on the Talent Partner Network',
+  body: 'Hi {{firstName}}!',
+  cycleId: null,
+  createdAt: new Date('2026-08-27'),
+  updatedAt: new Date('2026-08-27'),
+  creator: { id: admin.id, fullName: admin.fullName, email: admin.email },
+  editor: null,
+  ...overrides,
+});
+
+beforeAll(async () => {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/master-communications', routes);
+  server = app.listen(0);
+  await new Promise((resolve) => server.on('listening', resolve));
+  port = server.address().port;
+});
+
+afterAll(async () => {
+  await new Promise((resolve) => server.close(resolve));
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  prisma.user.findUnique.mockImplementation(({ where: { id } }) => ALL.find((u) => u.id === id) || null);
+  prisma.messageDraft.findMany.mockResolvedValue([draftRow()]);
+  prisma.messageDraft.findUnique.mockResolvedValue({ id: 'draft-1' });
+  prisma.messageDraft.create.mockImplementation(({ data }) => Promise.resolve(draftRow(data)));
+  prisma.messageDraft.update.mockImplementation(({ data }) => Promise.resolve(draftRow(data)));
+  prisma.messageDraft.delete.mockResolvedValue({ id: 'draft-1' });
+});
+
+describe('access', () => {
+  it('is admin-only', async () => {
+    expect((await call('/api/master-communications/drafts', { user: member })).status).toBe(403);
+  });
+
+  it('refuses an unauthenticated request', async () => {
+    expect((await call('/api/master-communications/drafts')).status).toBe(401);
+  });
+});
+
+describe('saving a draft', () => {
+  it('keeps the whole composition, not just the text', async () => {
+    const res = await call('/api/master-communications/drafts', {
+      user: admin,
+      method: 'POST',
+      body: {
+        name: 'TPN launch',
+        channel: 'email',
+        audience: 'members',
+        filters: { roles: ['MEMBER'] },
+        subject: 'Subject',
+        body: 'Body',
+      },
+    });
+
+    expect(res.status).toBe(201);
+    // Audience and filters are the difference between a draft and a template -
+    // without them reopening one would not restore who it was going to.
+    expect(prisma.messageDraft.create.mock.calls[0][0].data).toMatchObject({
+      audience: 'members',
+      filters: { roles: ['MEMBER'] },
+      channel: 'email',
+      createdById: admin.id,
+    });
+  });
+
+  it('accepts an empty body, because unfinished is the point', async () => {
+    const res = await call('/api/master-communications/drafts', {
+      user: admin,
+      method: 'POST',
+      body: { name: 'Half-written', channel: 'email', audience: 'members' },
+    });
+    expect(res.status).toBe(201);
+  });
+
+  it('still requires enough to identify it later', async () => {
+    const res = await call('/api/master-communications/drafts', {
+      user: admin,
+      method: 'POST',
+      body: { channel: 'email', audience: 'members' },
+    });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('editing a draft', () => {
+  it('lets a different admin finish someone else\'s draft', async () => {
+    const res = await call('/api/master-communications/drafts/draft-1', {
+      user: otherAdmin,
+      method: 'PATCH',
+      body: { body: 'Finished by someone else' },
+    });
+
+    expect(res.status).toBe(200);
+    expect(prisma.messageDraft.update.mock.calls[0][0].data).toMatchObject({
+      body: 'Finished by someone else',
+      // Recorded so you can see who touched it last before sending it.
+      updatedById: otherAdmin.id,
+    });
+  });
+
+  it('leaves untouched fields alone rather than blanking them', async () => {
+    await call('/api/master-communications/drafts/draft-1', {
+      user: admin,
+      method: 'PATCH',
+      body: { subject: 'New subject' },
+    });
+
+    const data = prisma.messageDraft.update.mock.calls[0][0].data;
+    expect(data.subject).toBe('New subject');
+    expect('body' in data).toBe(false);
+    expect('audience' in data).toBe(false);
+  });
+
+  it('404s for a draft that does not exist', async () => {
+    prisma.messageDraft.findUnique.mockResolvedValue(null);
+    const res = await call('/api/master-communications/drafts/nope', {
+      user: admin,
+      method: 'PATCH',
+      body: { subject: 'x' },
+    });
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('listing and deleting', () => {
+  it('shows who wrote each draft, since they are shared', async () => {
+    const body = await (await call('/api/master-communications/drafts', { user: admin })).json();
+    expect(body.drafts[0].creator).toMatchObject({ fullName: 'Admin One' });
+  });
+
+  it('orders by most recently touched - a draft list is a to-finish list', async () => {
+    await call('/api/master-communications/drafts', { user: admin });
+    expect(prisma.messageDraft.findMany.mock.calls[0][0].orderBy).toEqual({ updatedAt: 'desc' });
+  });
+
+  it('deletes one', async () => {
+    const res = await call('/api/master-communications/drafts/draft-1', { user: admin, method: 'DELETE' });
+    expect(res.status).toBe(200);
+    expect(prisma.messageDraft.delete).toHaveBeenCalledWith({ where: { id: 'draft-1' } });
+  });
+
+  it('404s deleting one that is already gone', async () => {
+    prisma.messageDraft.findUnique.mockResolvedValue(null);
+    const res = await call('/api/master-communications/drafts/nope', { user: admin, method: 'DELETE' });
+    expect(res.status).toBe(404);
+  });
+});

--- a/server/src/routes/masterCommunications.js
+++ b/server/src/routes/masterCommunications.js
@@ -1,6 +1,10 @@
 import express from 'express';
 import { requireAuth, requireAdmin } from '../middleware/auth.js';
 import {
+  listDrafts,
+  createDraft,
+  updateDraft,
+  deleteDraft,
   listTemplates,
   createTemplate,
   listLogs,
@@ -40,6 +44,65 @@ router.post('/templates', requireAuth, requireAdmin, async (req, res) => {
   } catch (err) {
     console.error('[POST /api/master-communications/templates]', err);
     res.status(err.status || 500).json({ error: err.message || 'Failed to create template' });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Drafts
+// ---------------------------------------------------------------------------
+// Shared across admins on purpose: comms here are written by one person and
+// often finished by another, so there is no per-author scoping on these.
+
+router.get('/drafts', requireAuth, requireAdmin, async (req, res) => {
+  try {
+    const drafts = await listDrafts({ cycleId: req.query.cycleId });
+    res.json({ drafts });
+  } catch (error) {
+    console.error('[GET /api/master-communications/drafts]', error);
+    res.status(error.status || 500).json({ error: error.message || 'Failed to load drafts' });
+  }
+});
+
+router.post('/drafts', requireAuth, requireAdmin, async (req, res) => {
+  try {
+    const { name, channel, audience, filters, subject, body, cycleId } = req.body || {};
+    const draft = await createDraft({
+      name,
+      channel,
+      audience,
+      filters,
+      subject,
+      body,
+      cycleId,
+      createdById: req.user.id,
+    });
+    res.status(201).json({ draft });
+  } catch (error) {
+    console.error('[POST /api/master-communications/drafts]', error);
+    res.status(error.status || 500).json({ error: error.message || 'Failed to save draft' });
+  }
+});
+
+router.patch('/drafts/:id', requireAuth, requireAdmin, async (req, res) => {
+  try {
+    const draft = await updateDraft({
+      id: req.params.id,
+      updatedById: req.user.id,
+      ...(req.body || {}),
+    });
+    res.json({ draft });
+  } catch (error) {
+    console.error('[PATCH /api/master-communications/drafts/:id]', error);
+    res.status(error.status || 500).json({ error: error.message || 'Failed to update draft' });
+  }
+});
+
+router.delete('/drafts/:id', requireAuth, requireAdmin, async (req, res) => {
+  try {
+    res.json(await deleteDraft({ id: req.params.id }));
+  } catch (error) {
+    console.error('[DELETE /api/master-communications/drafts/:id]', error);
+    res.status(error.status || 500).json({ error: error.message || 'Failed to delete draft' });
   }
 });
 

--- a/server/src/services/masterCommunications.js
+++ b/server/src/services/masterCommunications.js
@@ -540,3 +540,96 @@ export async function sendTestCommunication({ audience, filters, subject, body, 
     usedFallback: !sample,
   };
 }
+
+// ---------------------------------------------------------------------------
+// Drafts
+// ---------------------------------------------------------------------------
+// An unsent message, kept whole: channel, audience, filters, subject and body,
+// so reopening one puts the composer back exactly as it was left. Shared across
+// admins, so every read carries who wrote it and who touched it last - the
+// thing you want to know before sending someone else's work.
+
+const DRAFT_SELECT = {
+  id: true,
+  name: true,
+  channel: true,
+  audience: true,
+  filters: true,
+  subject: true,
+  body: true,
+  cycleId: true,
+  createdAt: true,
+  updatedAt: true,
+  creator: { select: { id: true, fullName: true, email: true } },
+  editor: { select: { id: true, fullName: true, email: true } },
+};
+
+export async function listDrafts({ cycleId, limit = 100 }) {
+  // Most recently touched first: a draft list is a to-finish list.
+  return prisma.messageDraft.findMany({
+    where: cycleId ? { cycleId } : {},
+    orderBy: { updatedAt: 'desc' },
+    take: limit,
+    select: DRAFT_SELECT,
+  });
+}
+
+export async function createDraft({ name, channel, audience, filters, subject, body, cycleId, createdById }) {
+  if (!name || !channel || !audience || !createdById) {
+    const err = new Error('name, channel, and audience are required');
+    err.status = 400;
+    throw err;
+  }
+
+  return prisma.messageDraft.create({
+    // A body is deliberately not required. The point of a draft is to save
+    // something unfinished, and refusing an empty one would mean losing the
+    // audience and filters somebody just spent time assembling.
+    data: {
+      name,
+      channel,
+      audience,
+      filters: filters ?? undefined,
+      subject: subject || '',
+      body: body || '',
+      cycleId: cycleId || null,
+      createdById,
+    },
+    select: DRAFT_SELECT,
+  });
+}
+
+export async function updateDraft({ id, updatedById, ...fields }) {
+  if (!id || !updatedById) {
+    const err = new Error('id and updatedById are required');
+    err.status = 400;
+    throw err;
+  }
+
+  const existing = await prisma.messageDraft.findUnique({ where: { id }, select: { id: true } });
+  if (!existing) {
+    const err = new Error('Draft not found');
+    err.status = 404;
+    throw err;
+  }
+
+  const data = { updatedById };
+  for (const key of ['name', 'channel', 'audience', 'subject', 'body']) {
+    if (fields[key] !== undefined) data[key] = fields[key];
+  }
+  if (fields.filters !== undefined) data.filters = fields.filters ?? undefined;
+  if (fields.cycleId !== undefined) data.cycleId = fields.cycleId || null;
+
+  return prisma.messageDraft.update({ where: { id }, data, select: DRAFT_SELECT });
+}
+
+export async function deleteDraft({ id }) {
+  const existing = await prisma.messageDraft.findUnique({ where: { id }, select: { id: true } });
+  if (!existing) {
+    const err = new Error('Draft not found');
+    err.status = 404;
+    throw err;
+  }
+  await prisma.messageDraft.delete({ where: { id } });
+  return { id };
+}


### PR DESCRIPTION
A message could be sent, scheduled, or saved as a template, but not simply put
down half-written.

## Why not templates

Templates are the wrong home for an unfinished message. A template is reusable
boilerplate — name, subject, body — and carries **no audience and no filters**,
so saving work-in-progress as one loses the part that took longest to assemble,
and turns the template list into a mix of "ready to reuse" and "not finished"
with nothing to tell them apart.

## What a draft is

The whole composition: channel, audience, filters, subject and body. Opening one
puts the composer back exactly as it was left, including which cycles and which
roles were selected.

A body is deliberately **not** required. Saving is for work in progress, and
refusing an empty one would discard the audience someone just built.

Drafts are **shared across admins**, so comms written by one person can be
finished by another. Every row shows who touched it last — the thing worth
knowing before sending someone else's draft — and an "Open" chip marks the one
currently loaded, with a Detach control so further saves don't overwrite it.

## Incidental fix

Two effects keyed off `tab === 5` to mean "scheduled". Inserting the Drafts tab
silently repointed them at the logs tab: the scheduled list would have stopped
refreshing, with nothing failing to show it. They now key off the channel name,
so the tab order is no longer load-bearing.

## Schema

New `message_drafts` table. `filters` is `Json` rather than columns because its
shape is owned by `resolveRecipients` and grows whenever an audience gains a
filter — pinning it to columns would mean a migration each time.

**The migration is already applied** to the shared database and recorded in
`_prisma_migrations`, so `migrate deploy` will be a no-op.

## Tests

12 new server tests covering the shared-editing rules, partial updates not
blanking untouched fields, and an empty body being accepted. 671 server tests
and 385 client tests pass; the two `offerLetter.test.js` failures are
byte-identical to `main`'s copy and fail there too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)