### PR TITLE
Let applicants change their Talent Partner Network answer

### DIFF
--- a/client/src/components/ApplicantTalentPoolSection.jsx
+++ b/client/src/components/ApplicantTalentPoolSection.jsx
@@ -1,0 +1,80 @@
+import React, { useState } from 'react';
+import apiClient from '../utils/api';
+
+// The Talent Partner Network answer for someone who applied.
+//
+// Applicants gave this answer once, on the application form, and until now had
+// no way to change it — the one group of the four (applicants, members, talent
+// portal, onboarded candidates) with a consent decision they could not revisit.
+//
+// Its own control and its own save, rather than a field on the details form:
+// everything there is a fact being corrected, while this is a permission, and
+// turning it off reaches past the row to withdraw the resume from companies
+// that already have it.
+
+export default function ApplicantTalentPoolSection({ optedIn, onChanged }) {
+  const [shared, setShared] = useState(optedIn);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState('');
+  const [message, setMessage] = useState('');
+
+  const setSharing = async (next) => {
+    setBusy(true);
+    setError('');
+    setMessage('');
+    try {
+      const result = await apiClient.patch('/applicant-info/talent-pool', {
+        talentPoolOptIn: next,
+      });
+      setShared(next);
+      setMessage(result.message || 'Your preference has been updated.');
+      if (onChanged) onChanged(next);
+    } catch (e) {
+      setError(e.message || 'Failed to update your sharing preference');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <section className="applicant-section">
+      <h2 className="applicant-section-title">Talent Partner Network</h2>
+      <p className="applicant-note">
+        UConsulting shares resumes with partner organizations hiring interns and early-career
+        candidates. This is separate from your application and has no bearing on it. You can change
+        this at any time — saying no withdraws your resume from every company that already has it.
+      </p>
+
+      <div className="applicant-grid">
+        <div className="applicant-field">
+          <span className="applicant-label">Current answer</span>
+          <span className="applicant-readonly">
+            {shared === true ? 'Shared with partners' : shared === false ? 'Not shared' : 'Not answered'}
+          </span>
+        </div>
+      </div>
+
+      <div className="applicant-actions">
+        <button
+          type="button"
+          className="applicant-save"
+          disabled={busy || shared === true}
+          onClick={() => setSharing(true)}
+        >
+          Yes, share it
+        </button>
+        <button
+          type="button"
+          className="applicant-save"
+          disabled={busy || shared === false}
+          onClick={() => setSharing(false)}
+        >
+          No, do not share
+        </button>
+      </div>
+
+      {error && <p className="applicant-error">{error}</p>}
+      {message && <p className="applicant-success">{message}</p>}
+    </section>
+  );
+}

--- a/client/src/pages/ApplicantInformation.jsx
+++ b/client/src/pages/ApplicantInformation.jsx
@@ -4,6 +4,7 @@ import AccessControl from '../components/AccessControl';
 import DocumentPreviewModal from '../components/DocumentPreviewModal';
 import ResumeReuploadSection from '../components/ResumeReuploadSection';
 import OnboardingResumeSection from '../components/OnboardingResumeSection';
+import ApplicantTalentPoolSection from '../components/ApplicantTalentPoolSection';
 import '../styles/ApplicantInformation.css';
 
 // The fields a candidate may correct themselves, in the order they are shown.
@@ -397,6 +398,13 @@ export default function ApplicantInformation() {
                   </div>
                 </div>
               </section>
+              )}
+
+              {mode !== 'onboarding' && (
+                <ApplicantTalentPoolSection
+                  optedIn={record.talentPoolOptIn ?? null}
+                  onChanged={(next) => setRecord((r) => ({ ...r, talentPoolOptIn: next }))}
+                />
               )}
 
               {(mode === 'onboarding' ? onboardingSections() : SECTIONS).map((section) => (

--- a/client/src/pages/ApplicantInformation.test.jsx
+++ b/client/src/pages/ApplicantInformation.test.jsx
@@ -219,3 +219,50 @@ describe('a candidate who onboarded instead of applying', () => {
     expect(patch.mock.calls[0][1]).toMatchObject({ major1: 'Social Sciences', graduationYear: '2029' });
   });
 });
+
+describe('an applicant changing their Talent Partner Network answer', () => {
+  it('shows the answer already on file', async () => {
+    renderPage();
+    await screen.findByLabelText(/Primary major/);
+    expect(screen.getByText('Current answer')).toBeInTheDocument();
+  });
+
+  it('sends the change and says what turning it off does', async () => {
+    const patch = vi.fn(() =>
+      Promise.resolve({ talentPoolOptIn: false, message: 'Sharing stopped, and your resume has been withdrawn.' })
+    );
+    apiClient.patch = patch;
+
+    renderPage();
+    await screen.findByLabelText(/Primary major/);
+    fireEvent.click(screen.getByRole('button', { name: /No, do not share/ }));
+
+    await waitFor(() => expect(patch).toHaveBeenCalled());
+    expect(patch.mock.calls[0][0]).toBe('/applicant-info/talent-pool');
+    expect(patch.mock.calls[0][1]).toEqual({ talentPoolOptIn: false });
+    expect(await screen.findByText(/withdrawn/i)).toBeInTheDocument();
+  });
+
+  it('is not shown to a candidate who onboarded - they have their own control', async () => {
+    apiClient.get = vi.fn((url) =>
+      url.includes('onboarding')
+        ? Promise.resolve({
+            required: false,
+            completed: true,
+            onboarding: {
+              phoneNumber: '3105550134', graduationYear: '2029', cumulativeGpa: '3.85',
+              major1: 'Life Sciences', major2: null, gender: null,
+              isTransferStudent: false, isFirstGeneration: true,
+            },
+          })
+        : Promise.reject(new Error('User not found or no studentId associated'))
+    );
+
+    renderPage();
+    await screen.findByLabelText(/Primary major/);
+    // Both modes show a Talent Partner Network section, but an onboarded
+    // candidate gets the one in OnboardingResumeSection, which saves through a
+    // different endpoint. "Current answer" belongs only to the applicant one.
+    expect(screen.queryByText('Current answer')).not.toBeInTheDocument();
+  });
+});

--- a/server/src/routes/applicantInfo.js
+++ b/server/src/routes/applicantInfo.js
@@ -33,7 +33,17 @@ export const EDITABLE_FIELDS = [
 
 // Identity and process fields the page shows so a candidate can confirm what we
 // have, but cannot change.
-const READ_ONLY_FIELDS = ['id', 'email', 'studentId', 'status', 'currentRound', 'submittedAt'];
+const READ_ONLY_FIELDS = [
+  'id',
+  'email',
+  'studentId',
+  'status',
+  'currentRound',
+  'submittedAt',
+  // Shown so the page can render the current answer, but changed through its
+  // own endpoint rather than the general PATCH - see the note there.
+  'talentPoolOptIn',
+];
 
 const applicationSelect = {
   ...Object.fromEntries([...EDITABLE_FIELDS, ...READ_ONLY_FIELDS].map((field) => [field, true])),
@@ -134,6 +144,87 @@ async function loadOwned(req, res) {
   }
   return application;
 }
+
+/**
+ * PATCH /api/applicant-info/talent-pool
+ *
+ * Change the Talent Partner Network answer.
+ *
+ * Deliberately not a member of EDITABLE_FIELDS. Every other field on that list
+ * is a fact about the applicant that they are correcting; this is a permission,
+ * and turning it off has to reach further than the row - it withdraws the
+ * resume from companies that already have it. A field in a general PATCH cannot
+ * carry that.
+ *
+ * Applied to every application this person owns rather than the one on screen.
+ * Consent belongs to the person, not to a cycle: someone who has applied twice
+ * and says no means no, and leaving last year's application shared would be a
+ * consent record nobody would think to check.
+ */
+router.patch('/talent-pool', requireAuth, async (req, res) => {
+  try {
+    const optIn = req.body?.talentPoolOptIn;
+    if (optIn !== true && optIn !== false) {
+      return res.status(400).json({ error: 'Choose whether to share your resume with partner organizations.' });
+    }
+
+    // Same identifiers isOwnedBy matches on, asked of the table directly so it
+    // covers every application rather than one already in hand.
+    const ownerFilters = [];
+    if (req.user.email) {
+      ownerFilters.push({ email: req.user.email });
+      ownerFilters.push({ candidate: { email: req.user.email } });
+    }
+    if (req.user.studentId) {
+      ownerFilters.push({ studentId: String(req.user.studentId) });
+      ownerFilters.push({ candidate: { studentId: String(req.user.studentId) } });
+    }
+    if (ownerFilters.length === 0) {
+      return res.status(404).json({ error: 'No application found for this account' });
+    }
+
+    const owned = await prisma.application.findMany({
+      where: { OR: ownerFilters },
+      select: { id: true },
+    });
+    if (owned.length === 0) {
+      return res.status(404).json({ error: 'No application found for this account' });
+    }
+
+    const ids = owned.map((a) => a.id);
+    const now = new Date();
+
+    await prisma.$transaction(async (tx) => {
+      await tx.application.updateMany({
+        where: { id: { in: ids } },
+        data: { talentPoolOptIn: optIn },
+      });
+
+      if (!optIn) {
+        // Assignments are snapshots and are otherwise never re-derived, so
+        // without this an applicant could opt out and stay in front of every
+        // client who already had them. This is the one place that rule yields,
+        // and it yields to the person whose resume it is - the same exception
+        // the member and talent portals make.
+        await tx.clientResumeAssignment.updateMany({
+          where: { applicationId: { in: ids }, revokedAt: null },
+          data: { revokedAt: now, revokedById: req.user.id },
+        });
+      }
+    });
+
+    res.json({
+      talentPoolOptIn: optIn,
+      applicationsUpdated: ids.length,
+      message: optIn
+        ? 'Your resume is now shared with partner organizations.'
+        : 'Sharing stopped, and your resume has been withdrawn from any company that had it.',
+    });
+  } catch (error) {
+    console.error('[PATCH /api/applicant-info/talent-pool]', error);
+    res.status(500).json({ error: 'Failed to update your sharing preference' });
+  }
+});
 
 // GET /api/applicant-info/applications/:applicationId
 router.get('/applications/:applicationId', requireAuth, async (req, res) => {

--- a/server/src/routes/applicantInfo.routes.test.js
+++ b/server/src/routes/applicantInfo.routes.test.js
@@ -9,9 +9,17 @@ import applicantInfoRoutes, { EDITABLE_FIELDS } from './applicantInfo.js';
 vi.mock('../prismaClient.js', () => ({
   default: {
     user: { findUnique: vi.fn() },
-    application: { findUnique: vi.fn(), update: vi.fn() },
+    application: { findUnique: vi.fn(), update: vi.fn(), findMany: vi.fn(), updateMany: vi.fn() },
+    clientResumeAssignment: { updateMany: vi.fn() },
+    $transaction: vi.fn((fn) => fn(txMock)),
   },
 }));
+
+// The transaction body runs against these, so assertions read from them.
+const txMock = {
+  application: { updateMany: vi.fn() },
+  clientResumeAssignment: { updateMany: vi.fn() },
+};
 
 const candidateUser = {
   id: 'user-1',
@@ -103,6 +111,9 @@ beforeEach(() => {
   prisma.application.update.mockImplementation(({ data }) =>
     Promise.resolve(application(data))
   );
+  prisma.application.findMany.mockResolvedValue([{ id: 'app-1' }]);
+  txMock.application.updateMany.mockResolvedValue({ count: 1 });
+  txMock.clientResumeAssignment.updateMany.mockResolvedValue({ count: 0 });
 });
 
 describe('GET /api/applicant-info/applications/:applicationId', () => {
@@ -250,5 +261,80 @@ describe('PATCH /api/applicant-info/applications/:applicationId', () => {
     expect(EDITABLE_FIELDS).not.toContain('email');
     expect(EDITABLE_FIELDS).not.toContain('studentId');
     expect(EDITABLE_FIELDS).toContain('phoneNumber');
+  });
+});
+
+describe('PATCH /api/applicant-info/talent-pool', () => {
+  const setConsent = (talentPoolOptIn, user = candidateUser) =>
+    request('/api/applicant-info/talent-pool', { user, method: 'PATCH', body: { talentPoolOptIn } });
+
+  it('lets an applicant opt in', async () => {
+    const res = await setConsent(true);
+    expect(res.status).toBe(200);
+    expect(txMock.application.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({ data: { talentPoolOptIn: true } })
+    );
+  });
+
+  it('applies the answer to every application they own, not just one', async () => {
+    // Consent belongs to the person, not to a cycle. Leaving last year's
+    // application shared would be a consent record nobody thinks to check.
+    prisma.application.findMany.mockResolvedValue([{ id: 'app-1' }, { id: 'app-2' }]);
+    const body = await (await setConsent(false)).json();
+
+    expect(body.applicationsUpdated).toBe(2);
+    expect(txMock.application.updateMany.mock.calls[0][0].where).toEqual({
+      id: { in: ['app-1', 'app-2'] },
+    });
+  });
+
+  it('withdraws the resume from clients that already have it', async () => {
+    prisma.application.findMany.mockResolvedValue([{ id: 'app-1' }, { id: 'app-2' }]);
+    await setConsent(false);
+
+    // Assignments are snapshots and are never re-derived, so without this an
+    // applicant could opt out and stay in front of every client who had them.
+    expect(txMock.clientResumeAssignment.updateMany).toHaveBeenCalledWith({
+      where: { applicationId: { in: ['app-1', 'app-2'] }, revokedAt: null },
+      data: { revokedAt: expect.any(Date), revokedById: candidateUser.id },
+    });
+  });
+
+  it('does not revoke anything when opting in', async () => {
+    await setConsent(true);
+    expect(txMock.clientResumeAssignment.updateMany).not.toHaveBeenCalled();
+  });
+
+  it('matches applications on email and student ID, like ownership does', async () => {
+    await setConsent(true);
+    const or = prisma.application.findMany.mock.calls[0][0].where.OR;
+    expect(or).toEqual(
+      expect.arrayContaining([
+        { email: candidateUser.email },
+        { studentId: candidateUser.studentId },
+        { candidate: { email: candidateUser.email } },
+        { candidate: { studentId: candidateUser.studentId } },
+      ])
+    );
+  });
+
+  it('requires an explicit answer rather than treating a blank as no', async () => {
+    const res = await request('/api/applicant-info/talent-pool', {
+      user: candidateUser,
+      method: 'PATCH',
+      body: {},
+    });
+    expect(res.status).toBe(400);
+    expect(txMock.application.updateMany).not.toHaveBeenCalled();
+  });
+
+  it('404s for an account with no application', async () => {
+    prisma.application.findMany.mockResolvedValue([]);
+    expect((await setConsent(true)).status).toBe(404);
+  });
+
+  it('refuses an unauthenticated request', async () => {
+    const res = await request('/api/applicant-info/talent-pool', { method: 'PATCH', body: { talentPoolOptIn: true } });
+    expect(res.status).toBe(401);
   });
 });


### PR DESCRIPTION
Applicants answered this once, on the Google Form, and had no way to revisit it.

They were the only one of the four groups in the pool with a consent decision
they could not change:

| group | can change it? |
|---|---|
| Members | yes — `PATCH /api/member/resume/consent` |
| Talent portal | yes — `PATCH /api/talent/resume/consent` |
| Onboarded candidates | yes — added recently |
| **Applicants** | **no** |

An applicant who wanted out had to email someone.

## Why its own endpoint

Not a member of `EDITABLE_FIELDS`. Everything on that list is a fact the
applicant is correcting; this is a permission, and turning it off has to reach
past the row.

## Two consequences of consent belonging to the person

**It applies to every application they own**, not the one on screen. Someone who
has applied twice and says no means no — leaving last year's application shared
would be a consent record nobody would think to check.

**Withdrawing revokes live client assignments.** Assignments are snapshots and
are never re-derived, so without this an applicant could opt out and remain in
front of every client who already had them. Same exception the member and talent
portals already make, and it yields to the person whose resume it is.

## Tests

9 new server tests covering the multi-application behaviour, the revocation, and
that a blank is never read as "no". Plus client coverage that the applicant
control appears only in application mode — an onboarded candidate keeps their
own, which saves through a different endpoint.

679 server tests and 388 client tests pass; the two `offerLetter.test.js`
failures are byte-identical to `main`'s copy and fail there too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)