### PR TITLE
Fix: Master Communications page crashes on load

### DIFF
--- a/client/src/pages/MasterCommunications.jsx
+++ b/client/src/pages/MasterCommunications.jsx
@@ -130,6 +130,16 @@ const MasterCommunications = () => {
     fetchEvents();
   }, []);
 
+  const fetchDrafts = useCallback(async (cycleId) => {
+    try {
+      const query = cycleId ? `?cycleId=${cycleId}` : '';
+      const data = await apiClient.get(`/master-communications/drafts${query}`);
+      setDrafts(data.drafts || []);
+    } catch (e) {
+      setError(e.message || 'Failed to load drafts');
+    }
+  }, []);
+
   useEffect(() => {
     if (primaryCycle) {
       fetchTemplates(primaryCycle);
@@ -199,16 +209,6 @@ const MasterCommunications = () => {
     setError('');
     setSuccess('');
   };
-
-  const fetchDrafts = useCallback(async (cycleId) => {
-    try {
-      const query = cycleId ? `?cycleId=${cycleId}` : '';
-      const data = await apiClient.get(`/master-communications/drafts${query}`);
-      setDrafts(data.drafts || []);
-    } catch (e) {
-      setError(e.message || 'Failed to load drafts');
-    }
-  }, []);
 
   const saveDraft = async () => {
     clearMessages();

--- a/client/src/pages/MasterCommunications.test.jsx
+++ b/client/src/pages/MasterCommunications.test.jsx
@@ -1,0 +1,56 @@
+// Master Communications.
+//
+// This exists because the page shipped broken: a useCallback named in an
+// effect's dependency array was declared further down the component body, so
+// the dependency array read it during render and threw "Cannot access ... before
+// initialization". The build succeeded, every other test passed, and the entire
+// page was a blank screen in production.
+//
+// So the assertion that matters most here is simply that it renders at all.
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import MasterCommunications from './MasterCommunications';
+import apiClient from '../utils/api';
+
+vi.mock('../components/AccessControl', () => ({ default: ({ children }) => children }));
+vi.mock('../context/AuthContext', () => ({
+  useAuth: () => ({ user: { id: 'admin-1', role: 'ADMIN', email: 'admin@uc.org' } }),
+}));
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  // Deliberately permissive. This file is a smoke test for "does the page come
+  // up at all"; asserting on payload shapes here would make it fail for reasons
+  // that have nothing to do with that.
+  vi.spyOn(apiClient, 'get').mockResolvedValue({});
+});
+
+describe('the page', () => {
+  it('renders without throwing', async () => {
+    // A temporal-dead-zone reference in a hook dependency array throws here and
+    // nowhere else - not at build time, and not in any other test.
+    expect(() => render(<MasterCommunications />)).not.toThrow();
+    await waitFor(() => expect(apiClient.get).toHaveBeenCalled());
+  });
+
+  it('offers a Drafts tab', () => {
+    render(<MasterCommunications />);
+    expect(screen.getByRole('tab', { name: /Drafts/i })).toBeInTheDocument();
+  });
+
+  it('loads drafts on mount, not only when the tab is opened', async () => {
+    render(<MasterCommunications />);
+    await waitFor(() =>
+      expect(apiClient.get.mock.calls.some(([url]) => url.includes('drafts'))).toBe(true)
+    );
+  });
+
+  it('keeps every channel tab reachable, in order', () => {
+    render(<MasterCommunications />);
+    // Order matters: two effects used to key off a hard-coded tab index, so
+    // inserting a tab silently repointed them at the wrong one.
+    expect(screen.getAllByRole('tab').map((t) => t.textContent)).toEqual([
+      'Email', 'Slack', 'iMessage', 'Drafts', 'Templates', 'Logs', 'Scheduled',
+    ]);
+  });
+});


### PR DESCRIPTION
The Master Communications page is a blank screen on production:

```
Uncaught ReferenceError: Cannot access 'mt' before initialization
```

## Cause

My drafts change (#145) placed a `useCallback` **below** an effect that names it
in its dependency array:

```js
useEffect(() => { ... fetchDrafts(primaryCycle); }, [primaryCycle, fetchDrafts]);  // line 140
...
const fetchDrafts = useCallback(...)                                              // line 203
```

Dependency arrays are evaluated during render, so the array reads the binding
before the declaration runs — a temporal dead zone error. It takes the **whole
page** down, not just the drafts tab.

The declaration now sits above the effect.

## Why nothing caught it

The build succeeded — bundlers do not detect TDZ. Every existing test passed.
Nothing in the suite rendered this page, so a change that made it unloadable
looked completely clean. That is the real defect here, and it is on me: I shipped
a page-level change without ever rendering the page.

## Tests

Adds a smoke test for the page. Verified it fails against the broken version with
exactly the production error:

```
ReferenceError: Cannot access 'fetchDrafts' before initialization
```

It also pins the tab order, since two effects previously keyed off a hard-coded
tab index and inserting a tab silently repointed them at the wrong one.

389 client tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)