### PR TITLE
Candidate dashboard shows the wrong application deadline

### DIFF
--- a/client/src/pages/CandidateDashboard.jsx
+++ b/client/src/pages/CandidateDashboard.jsx
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 import AccessControl from '../components/AccessControl';
 import apiClient from '../utils/api';
-import { formatDeadline, getNextDeadline } from '../utils/getNextDeadline';
+import { formatDeadline, getCycleDeadline } from '../utils/getNextDeadline';
 import '../styles/CandidateDashboard.css';
 
 export default function CandidateDashboard() {
@@ -39,9 +39,12 @@ export default function CandidateDashboard() {
     const fetchDeadline = async () => {
       try {
         setDeadlineLoading(true);
-        const applications = await apiClient.get('/applications/my-applications');
+        // The cycle open to candidates, not this candidate's own applications.
+        // Deriving it from their applications showed the deadline of a cycle
+        // they had already applied to and ignored the one actually open.
+        const data = await apiClient.get('/active-cycle');
         if (!cancelled) {
-          setDeadline(getNextDeadline(applications));
+          setDeadline(getCycleDeadline(data?.cycle));
         }
       } catch (error) {
         console.error('Error fetching next deadline:', error);

--- a/client/src/pages/CandidateDashboard.test.jsx
+++ b/client/src/pages/CandidateDashboard.test.jsx
@@ -34,6 +34,10 @@ describe('CandidateDashboard application deadline card', () => {
         },
       },
     ]);
+    // The card reads the open cycle now, not this candidate's applications.
+    apiClient.get.mockResolvedValue({
+      cycle: { id: 'cycle-1', name: 'Fall 2026', endDate: '2026-10-05T00:00:00.000Z' },
+    });
 
     renderWithRouter(<CandidateDashboard />);
 
@@ -99,5 +103,47 @@ describe('CandidateDashboard application deadline card', () => {
     await waitFor(() => {
       expect(screen.getByText(/No upcoming deadline posted/i)).toBeInTheDocument();
     });
+  });
+});
+
+describe('which deadline the card shows', () => {
+  it('shows the cycle open to candidates, not one they already applied to', async () => {
+    // Regression: a candidate with a Winter 2026 application saw that cycle's
+    // deadline even after Fall 2026 was made the candidate-active cycle,
+    // because the card scanned their own applications.
+    apiClient.get.mockResolvedValue({
+      cycle: { id: 'fall', name: 'Fall 2026', endDate: '2026-10-10T00:00:00.000Z' },
+    });
+
+    renderWithRouter(<CandidateDashboard />);
+
+    await waitFor(() => expect(screen.getByText(/Fall 2026/i)).toBeInTheDocument());
+    expect(screen.queryByText(/Winter 2026/i)).not.toBeInTheDocument();
+  });
+
+  it('asks for the open cycle rather than the applications list', async () => {
+    apiClient.get.mockResolvedValue({ cycle: null });
+    renderWithRouter(<CandidateDashboard />);
+
+    await waitFor(() => expect(apiClient.get).toHaveBeenCalledWith('/active-cycle'));
+    expect(apiClient.get.mock.calls.some(([url]) => url.includes('my-applications'))).toBe(false);
+  });
+
+  it('shows nothing when no cycle is open', async () => {
+    apiClient.get.mockResolvedValue({ cycle: null });
+    renderWithRouter(<CandidateDashboard />);
+    await waitFor(() =>
+      expect(screen.getByText(/No upcoming deadline posted/i)).toBeInTheDocument()
+    );
+  });
+
+  it('shows nothing when the open cycle deadline has passed', async () => {
+    apiClient.get.mockResolvedValue({
+      cycle: { id: 'old', name: 'Fall 2025', endDate: '2025-10-11T00:00:00.000Z' },
+    });
+    renderWithRouter(<CandidateDashboard />);
+    await waitFor(() =>
+      expect(screen.getByText(/No upcoming deadline posted/i)).toBeInTheDocument()
+    );
   });
 });

--- a/client/src/utils/getNextDeadline.js
+++ b/client/src/utils/getNextDeadline.js
@@ -121,3 +121,29 @@ export function getNextDeadline(applications, now = new Date()) {
   candidates.sort((a, b) => a.cutoff.getTime() - b.cutoff.getTime());
   return candidates[0];
 }
+
+/**
+ * The application deadline for one cycle.
+ *
+ * Separate from getNextDeadline, which answers a different question: that one
+ * scans the applications a candidate already submitted and returns the soonest
+ * of their deadlines. On a dashboard that is the wrong question. "Application
+ * deadline" means when applications close, which is a property of the cycle
+ * currently open, not of a cycle this person applied to last time.
+ *
+ * Returns null when there is no open cycle or its date is unusable, so a caller
+ * can render nothing rather than a wrong date.
+ */
+export function getCycleDeadline(cycle, now = new Date()) {
+  if (!cycle) return null;
+
+  const parsed = parseApplicationDeadline(cycle.endDate);
+  if (!parsed || parsed.cutoff.getTime() <= now.getTime()) return null;
+
+  return {
+    ...parsed,
+    label: 'Application deadline',
+    cycleName: cycle.name,
+    cycleId: cycle.id,
+  };
+}

--- a/server/src/routes/public.js
+++ b/server/src/routes/public.js
@@ -9,6 +9,36 @@ import { resolveCandidateCycle } from '../services/activeCycle.js';
 
 const router = express.Router();
 
+/**
+ * The cycle currently open to candidates.
+ *
+ * Exists so a candidate-facing screen can say "applications close on X" without
+ * inferring it from the applications that person happens to have. The dashboard
+ * used to derive its deadline from the candidate's own applications, which
+ * showed the deadline of a cycle they had already applied to and ignored the one
+ * actually open.
+ *
+ * Public because the answer already is: the application deadline is on the
+ * recruitment site. Only the fields a deadline needs are returned.
+ */
+router.get('/active-cycle', async (req, res) => {
+  try {
+    const cycle = await resolveCandidateCycle(prisma);
+    if (!cycle) return res.json({ cycle: null });
+    res.json({
+      cycle: {
+        id: cycle.id,
+        name: cycle.name,
+        startDate: cycle.startDate,
+        endDate: cycle.endDate,
+      },
+    });
+  } catch (error) {
+    console.error('[GET /api/active-cycle]', error);
+    res.status(500).json({ error: 'Failed to load the active cycle' });
+  }
+});
+
 // Public: list available meeting slots with remaining capacity and signups
 router.get('/meeting-slots', async (req, res) => {
   try {


### PR DESCRIPTION
Setting the candidate-active cycle to Fall 2026 left the dashboard showing
**"September 1, 2026 PDT (Winter 2026)"**.

## Cause

The card never read the active cycle. It called `/applications/my-applications`
and returned the soonest end date among the candidate's **own** applications:

| cycle | candidate-active | ends |
|---|---|---|
| Fall 2026 | **yes** | 2026-10-10 |
| Winter 2026 | no | **2026-09-01** |

The account has a Winter 2026 application, and Winter 2026 ends sooner, so it
won. Changing the active cycle could not affect the card at all.

That answers a different question than the label asks. "Application deadline"
means when applications close, which is a property of the cycle currently open,
not of a cycle this person applied to previously. It also meant a candidate with
no applications saw nothing, even with a cycle open.

## Change

Adds `GET /api/active-cycle`, returning the cycle open to candidates via the
existing `resolveCandidateCycle`. Public, because the answer already is (the
deadline is on the recruitment site), and it returns only the fields a deadline
needs.

`getCycleDeadline` is added rather than replacing `getNextDeadline`. The old
function answers "which of this candidate's submitted deadlines is next", which
is still a real question, just not this card's.

## Verified

Against live data, the endpoint returns Fall 2026 ending 2026-10-10 — what the
account in the report will now see.

393 client tests and 671 server tests pass; the two `offerLetter.test.js`
failures are byte-identical to `main`'s copy and fail there too.

## Unrelated, but noticed

The **admin** pointer is still on Winter 2026 (`isAdminActive`). If both were
meant to move to Fall 2026, that one is still outstanding — it is a separate
setting from the candidate one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)