### PR TITLE
Let applicants replace their resume outside an open cycle

### DIFF
--- a/server/src/routes/resumeUploads.js
+++ b/server/src/routes/resumeUploads.js
@@ -79,23 +79,27 @@ export function replacementWindow(application, user, now = new Date()) {
   if (!isOwnedBy(application, user)) {
     return { ...base, canReplace: false, reason: 'Only the applicant can replace this resume.' };
   }
-  if (!application.cycle) {
-    return { ...base, canReplace: false, reason: 'This application is not attached to a recruiting cycle.' };
-  }
-  if (!application.cycle.isActive) {
-    return {
-      ...base,
-      canReplace: false,
-      reason: `${application.cycle.name} has closed, so its documents can no longer be changed.`,
-    };
-  }
-  if (deadline && now.getTime() > deadline.getTime()) {
+
+  // What this window protects is an evaluation in progress: a resume must not
+  // change under a review team part-way through scoring it. That is a property
+  // of an OPEN cycle past its document deadline, and of nothing else.
+  //
+  // It used to also refuse a closed cycle, and a cycle-less application, which
+  // locked every past applicant out permanently. There is nothing left to
+  // protect once a cycle has closed, and plenty of reason to allow it: an
+  // applicant's resume goes stale, and the Talent Partner Network shows it to
+  // recruiters long after the cycle it arrived in. Replacement is also
+  // non-destructive - the file a reviewer scored is captured as a version
+  // before it is superseded - so the record of what was evaluated survives.
+  const cycleIsOpen = Boolean(application.cycle?.isActive);
+  if (cycleIsOpen && deadline && now.getTime() > deadline.getTime()) {
     return {
       ...base,
       canReplace: false,
       reason: `The resume deadline for ${application.cycle.name} has passed.`,
     };
   }
+
   return { ...base, canReplace: true, reason: null };
 }
 

--- a/server/src/routes/resumeUploads.routes.test.js
+++ b/server/src/routes/resumeUploads.routes.test.js
@@ -61,6 +61,7 @@ const memberUser = {
 
 // Far enough out that the window stays open without freezing the clock.
 const openDeadline = `${new Date().getFullYear() + 5}-10-04`;
+const passedDeadline = `${new Date().getFullYear() - 1}-10-04`;
 
 const application = (overrides = {}) => ({
   id: 'app-1',
@@ -157,13 +158,37 @@ describe('replacement window', () => {
     expect(window.reason).toMatch(/deadline/i);
   });
 
-  it('closes for a cycle that is no longer active', () => {
+  it('stays open for a cycle that has closed', () => {
+    // The window protects an evaluation in progress. Once a cycle is closed
+    // there is nothing left to protect, and an applicant's resume goes stale
+    // while the Talent Partner Network keeps showing it to recruiters.
     const window = replacementWindow(
       application({ cycle: { id: 'c', name: 'Fall 2025', isActive: false, resumeDeadline: openDeadline } }),
       candidateUser
     );
+    expect(window.canReplace).toBe(true);
+  });
+
+  it('stays open for a closed cycle even past its old resume deadline', () => {
+    const window = replacementWindow(
+      application({ cycle: { id: 'c', name: 'Fall 2025', isActive: false, resumeDeadline: passedDeadline } }),
+      candidateUser
+    );
+    expect(window.canReplace).toBe(true);
+  });
+
+  it('stays open for an application attached to no cycle', () => {
+    const window = replacementWindow(application({ cycle: null }), candidateUser);
+    expect(window.canReplace).toBe(true);
+  });
+
+  it('still refuses someone who does not own the application', () => {
+    const window = replacementWindow(
+      application({ cycle: { id: 'c', name: 'Fall 2025', isActive: false, resumeDeadline: openDeadline } }),
+      otherCandidate
+    );
     expect(window.canReplace).toBe(false);
-    expect(window.reason).toMatch(/closed/i);
+    expect(window.reason).toMatch(/Only the applicant/i);
   });
 
   it('matches an applicant by student ID when the emails differ', () => {


### PR DESCRIPTION
The resume replacement window refused a closed cycle:

```js
if (!application.cycle) return { canReplace: false, ... }
if (!application.cycle.isActive) return { canReplace: false, reason: '... has closed ...' }
```

which locked **every past applicant** out permanently. That is exactly the group
most likely to want a current resume: the Talent Partner Network shows an
applicant's resume to recruiters long after the cycle it arrived in, and the
launch email asks them to upload a fresher one.

## What the window is for

Protecting an evaluation in progress. A resume must not change under a review
team part-way through scoring it. That is a property of an **open** cycle past
its document deadline, and of nothing else. Once a cycle has closed there is
nothing left to protect.

The rule is now exactly that. Ownership is unchanged: only the applicant may
replace their own resume.

## Why this is safe

Replacement is already non-destructive. On first replacement the route captures
the file being replaced as a version — the existing comment says it plainly,
*"capture the resume being replaced, so the file a reviewer scored stays
reachable"* — so the record of what was actually evaluated survives and remains
viewable.

Worth knowing: an admin looking at a historical application will see the current
resume, with the originally-scored one in its version history rather than in
front of them.

## Tests

The test that encoded the old rule is replaced with four covering the new one:
closed cycle open, closed cycle past its old deadline still open, no cycle open,
and a non-owner still refused.

682 server tests and 396 client tests pass; the two `offerLetter.test.js`
failures are byte-identical to `main`'s copy and fail there too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)