### PR TITLE
Fix: Applicant Information containers unreadable in dark mode

### DIFF
--- a/client/src/styles/ApplicantInformation.css
+++ b/client/src/styles/ApplicantInformation.css
@@ -23,7 +23,7 @@
 }
 
 .applicant-card {
-  background-color: var(--surface-color, #fff);
+  background-color: var(--bg-white);
   border: 1px solid var(--border-light);
   border-radius: var(--border-radius);
   padding: 1.5rem;
@@ -63,7 +63,7 @@
 }
 
 .applicant-required {
-  color: #b91c1c;
+  color: var(--status-error-text);
 }
 
 .applicant-hint {
@@ -75,7 +75,7 @@
   padding: 0.5rem 0.625rem;
   border: 1px solid var(--border-light);
   border-radius: var(--border-radius);
-  background-color: var(--surface-color, #fff);
+  background-color: var(--bg-white);
   color: var(--text-primary);
   font-size: 0.9375rem;
   font-family: inherit;
@@ -160,13 +160,13 @@
 .applicant-error {
   margin: 1rem 0 0 0;
   font-size: 0.875rem;
-  color: #991b1b;
+  color: var(--status-error-text);
 }
 
 .applicant-success {
   margin: 1rem 0 0 0;
   font-size: 0.875rem;
-  color: #065f46;
+  color: var(--status-success-text);
 }
 
 /* Resume replacement. These moved here with the ResumeReuploadSection when it
@@ -181,13 +181,13 @@
 .resume-reupload-error {
   margin: 0.5rem 0 0 0;
   font-size: 0.875rem;
-  color: #991b1b;
+  color: var(--status-error-text);
 }
 
 .resume-reupload-success {
   margin: 0.5rem 0 0 0;
   font-size: 0.875rem;
-  color: #065f46;
+  color: var(--status-success-text);
 }
 
 .resume-reupload-controls {
@@ -234,8 +234,8 @@
   margin-left: 0.5rem;
   padding: 0.125rem 0.5rem;
   border-radius: 999px;
-  background-color: #d1fae5;
-  color: #065f46;
+  background-color: var(--status-success-bg);
+  color: var(--status-success-text);
   font-size: 0.6875rem;
   font-weight: 600;
   text-transform: uppercase;


### PR DESCRIPTION
The cards on Applicant Information are white in dark mode, with light text on
them.

## Cause

```css
background-color: var(--surface-color, #fff);
```

`--surface-color` is defined in **neither** theme, so the `#fff` fallback always
won. The containers were white in both modes; it only looked correct in light
mode by coincidence.

The status messages had the same shape of problem for a different reason: their
colours were fixed hex values chosen for a light background — `#991b1b`,
`#065f46`, `#b91c1c`, `#d1fae5`.

## Fix

Cards use `--bg-white`, which is `#ffffff` in light and `#0f172a` in dark.

Status colours use `--status-error-text`, `--status-success-text` and
`--status-success-bg`. The theme already ships a dark variant of each, so
nothing new was invented — the stylesheet simply was not using what existed.

## Audit

Every variable this stylesheet references is now defined in both themes. The one
remaining literal is `#fff` for button text on the brand blue, correct in both.

Checked the sibling candidate stylesheets — `CandidateDashboard.css`,
`CandidateApplications.css`, `CandidateEvents.css` — and they contain no
hardcoded colours at all, so this was a one-off in the newest file rather than a
pattern worth sweeping.

The Talent Partner Network and onboarding resume sections on this page reuse the
same classes, so they are fixed by the same change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)