### PR TITLE
Deactivating a user removes them from the Talent Partner Network

### DIFF
--- a/server/src/routes/admin.js
+++ b/server/src/routes/admin.js
@@ -1,6 +1,7 @@
 import express from 'express';
 import multer from 'multer';
 import prisma from '../prismaClient.js';
+import { revokeTalentPoolAccess } from '../services/talentPoolAccess.js';
 import { requireAuth, requireAdmin, invalidateUserCache } from '../middleware/auth.js';
 import { syncEventAttendance, syncEventRSVP, syncMemberEventRSVP, syncAllEventForms } from '../services/syncEventResponses.js';
 import syncFormResponses from '../services/syncResponses.js';
@@ -5560,10 +5561,22 @@ router.post('/users/deactivate', async (req, res) => {
     // Cut existing sessions immediately rather than after the cache TTL
     invalidateUserCache(eligibleIds);
 
+    // Their resumes stop being assignable via the pool gates, but assignments
+    // already handed to a client are snapshots and would otherwise survive the
+    // deactivation. Failing here must not un-deactivate anyone, so it is
+    // reported rather than thrown.
+    let revoked = 0;
+    try {
+      ({ revoked } = await revokeTalentPoolAccess(eligibleIds, req.user.id));
+    } catch (error) {
+      console.error('[POST /api/admin/users/deactivate] talent pool revocation failed', error);
+    }
+
     res.json({
       ...preview,
       dryRun: false,
-      deactivatedCount: updateResult.count
+      deactivatedCount: updateResult.count,
+      talentPoolAssignmentsRevoked: revoked
     });
   } catch (error) {
     console.error('[POST /api/admin/users/deactivate]', error);

--- a/server/src/routes/users.js
+++ b/server/src/routes/users.js
@@ -7,6 +7,7 @@ import { fileURLToPath } from 'url';
 import { dirname } from 'path';
 import { requireAuth, invalidateUserCache } from '../middleware/auth.js';
 import prisma from '../prismaClient.js';
+import { revokeTalentPoolAccess } from '../services/talentPoolAccess.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -324,7 +325,22 @@ router.patch('/:id/deactivate', requireAuth, async (req, res) => {
     // Cut the existing session immediately rather than after the cache TTL
     invalidateUserCache(id);
 
-    res.json({ message: 'User deactivated successfully', user: updatedUser });
+    // Their resume stops being assignable via the pool gates, but assignments
+    // already handed to a client are snapshots and would otherwise outlive the
+    // deactivation. Reported rather than thrown: a revocation failure must not
+    // leave the account half-deactivated.
+    let talentPoolAssignmentsRevoked = 0;
+    try {
+      ({ revoked: talentPoolAssignmentsRevoked } = await revokeTalentPoolAccess([id], req.user.id));
+    } catch (error) {
+      console.error('[deactivate user] talent pool revocation failed', error);
+    }
+
+    res.json({
+      message: 'User deactivated successfully',
+      user: updatedUser,
+      talentPoolAssignmentsRevoked,
+    });
   } catch (error) {
     console.error('Error deactivating user:', error);
     res.status(500).json({ error: 'Failed to deactivate user' });

--- a/server/src/services/talentPoolAccess.js
+++ b/server/src/services/talentPoolAccess.js
@@ -1,0 +1,77 @@
+// Withdrawing someone from the Talent Partner Network when their account is
+// deactivated.
+//
+// Deactivation is how this app records that a person has left: a member who
+// graduated, an account that was removed. Until now it flipped isActive and
+// nothing else, so their resume kept going out to recruiters — and for members
+// it was still assignable to *new* clients, because the member pool gate never
+// checked isActive the way the external pool does.
+//
+// Two things have to happen, and the gate alone is not enough for either:
+//
+//   1. No new assignments. That is the pool gate, fixed in talentPoolFilters.
+//   2. No existing access. Assignments are snapshots and are never re-derived,
+//      so a client who already holds the resume keeps it until it is revoked.
+//      This is that revocation.
+//
+// Consent itself is deliberately left alone. shareConsent and talentPoolOptIn
+// record what the person chose, and overwriting them would mean a reactivated
+// account silently comes back opted out of something they had agreed to.
+import prisma from '../prismaClient.js';
+
+/**
+ * Revoke every live client assignment belonging to these users.
+ *
+ * Covers all three pools, because a person can be in more than one: a member
+ * who also applied is in the applicant pool through their application and in
+ * the member pool through their uploaded resume.
+ *
+ * @param {string[]} userIds
+ * @param {string} revokedById  the admin performing the deactivation
+ * @returns {Promise<{ revoked: number }>}
+ */
+export async function revokeTalentPoolAccess(userIds, revokedById) {
+  if (!Array.isArray(userIds) || userIds.length === 0) return { revoked: 0 };
+
+  const users = await prisma.user.findMany({
+    where: { id: { in: userIds } },
+    select: { id: true, email: true, studentId: true },
+  });
+  if (users.length === 0) return { revoked: 0 };
+
+  const [memberResumes, externalResumes] = await Promise.all([
+    prisma.memberResume.findMany({ where: { memberId: { in: userIds } }, select: { id: true } }),
+    prisma.externalResume.findMany({ where: { userId: { in: userIds } }, select: { id: true } }),
+  ]);
+
+  // Applications carry no foreign key to User - they arrive from the Google
+  // Form before an account exists - so they are matched on the same two
+  // identifiers ownership is matched on everywhere else.
+  const identityFilters = [];
+  for (const user of users) {
+    if (user.email) {
+      identityFilters.push({ email: user.email });
+      identityFilters.push({ candidate: { email: user.email } });
+    }
+    if (user.studentId) {
+      identityFilters.push({ studentId: String(user.studentId) });
+      identityFilters.push({ candidate: { studentId: String(user.studentId) } });
+    }
+  }
+  const applications = identityFilters.length
+    ? await prisma.application.findMany({ where: { OR: identityFilters }, select: { id: true } })
+    : [];
+
+  const targets = [];
+  if (memberResumes.length) targets.push({ memberResumeId: { in: memberResumes.map((r) => r.id) } });
+  if (externalResumes.length) targets.push({ externalResumeId: { in: externalResumes.map((r) => r.id) } });
+  if (applications.length) targets.push({ applicationId: { in: applications.map((a) => a.id) } });
+  if (targets.length === 0) return { revoked: 0 };
+
+  const { count } = await prisma.clientResumeAssignment.updateMany({
+    where: { revokedAt: null, OR: targets },
+    data: { revokedAt: new Date(), revokedById },
+  });
+
+  return { revoked: count };
+}

--- a/server/src/services/talentPoolAccess.test.js
+++ b/server/src/services/talentPoolAccess.test.js
@@ -1,0 +1,109 @@
+// Withdrawing someone from the Talent Partner Network on deactivation.
+//
+// Deactivation is how this app records that a person has left. Two things have
+// to follow, and the pool gate only covers the first: no new assignments, and
+// no surviving access through assignments already handed out. Assignments are
+// snapshots and are never re-derived, so the second needs an explicit
+// revocation, which is what this covers.
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import prisma from '../prismaClient.js';
+import { revokeTalentPoolAccess } from './talentPoolAccess.js';
+
+vi.mock('../prismaClient.js', () => ({
+  default: {
+    user: { findMany: vi.fn() },
+    memberResume: { findMany: vi.fn() },
+    externalResume: { findMany: vi.fn() },
+    application: { findMany: vi.fn() },
+    clientResumeAssignment: { updateMany: vi.fn() },
+  },
+}));
+
+const leaver = { id: 'user-1', email: 'gone@uc.org', studentId: '405123456' };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  prisma.user.findMany.mockResolvedValue([leaver]);
+  prisma.memberResume.findMany.mockResolvedValue([]);
+  prisma.externalResume.findMany.mockResolvedValue([]);
+  prisma.application.findMany.mockResolvedValue([]);
+  prisma.clientResumeAssignment.updateMany.mockResolvedValue({ count: 0 });
+});
+
+const whereOf = () => prisma.clientResumeAssignment.updateMany.mock.calls[0][0].where;
+
+describe('revoking access', () => {
+  it('revokes a member resume that is out with clients', async () => {
+    prisma.memberResume.findMany.mockResolvedValue([{ id: 'mr-1' }]);
+    prisma.clientResumeAssignment.updateMany.mockResolvedValue({ count: 2 });
+
+    const result = await revokeTalentPoolAccess(['user-1'], 'admin-1');
+
+    expect(result).toEqual({ revoked: 2 });
+    expect(whereOf().OR).toContainEqual({ memberResumeId: { in: ['mr-1'] } });
+  });
+
+  it('covers all three pools, because one person can be in more than one', async () => {
+    // A member who also applied is in the applicant pool through their
+    // application and the member pool through their uploaded resume.
+    prisma.memberResume.findMany.mockResolvedValue([{ id: 'mr-1' }]);
+    prisma.externalResume.findMany.mockResolvedValue([{ id: 'er-1' }]);
+    prisma.application.findMany.mockResolvedValue([{ id: 'app-1' }]);
+
+    await revokeTalentPoolAccess(['user-1'], 'admin-1');
+
+    expect(whereOf().OR).toEqual([
+      { memberResumeId: { in: ['mr-1'] } },
+      { externalResumeId: { in: ['er-1'] } },
+      { applicationId: { in: ['app-1'] } },
+    ]);
+  });
+
+  it('matches applications on email and student ID, since they have no user FK', async () => {
+    await revokeTalentPoolAccess(['user-1'], 'admin-1');
+
+    expect(prisma.application.findMany.mock.calls[0][0].where.OR).toEqual([
+      { email: leaver.email },
+      { candidate: { email: leaver.email } },
+      { studentId: leaver.studentId },
+      { candidate: { studentId: leaver.studentId } },
+    ]);
+  });
+
+  it('only touches assignments that are still live', async () => {
+    prisma.memberResume.findMany.mockResolvedValue([{ id: 'mr-1' }]);
+    await revokeTalentPoolAccess(['user-1'], 'admin-1');
+
+    expect(whereOf().revokedAt).toBeNull();
+    expect(prisma.clientResumeAssignment.updateMany.mock.calls[0][0].data).toMatchObject({
+      revokedById: 'admin-1',
+    });
+  });
+
+  it('leaves the consent record alone', async () => {
+    // shareConsent and talentPoolOptIn record what the person chose.
+    // Overwriting them would mean a reactivated account silently comes back
+    // opted out of something they had agreed to.
+    prisma.memberResume.findMany.mockResolvedValue([{ id: 'mr-1' }]);
+    await revokeTalentPoolAccess(['user-1'], 'admin-1');
+
+    expect(prisma.clientResumeAssignment.updateMany.mock.calls[0][0].data.shareConsent).toBeUndefined();
+  });
+});
+
+describe('when there is nothing to revoke', () => {
+  it('does no work for an empty list', async () => {
+    expect(await revokeTalentPoolAccess([], 'admin-1')).toEqual({ revoked: 0 });
+    expect(prisma.user.findMany).not.toHaveBeenCalled();
+  });
+
+  it('does no work for someone with no resume and no application', async () => {
+    expect(await revokeTalentPoolAccess(['user-1'], 'admin-1')).toEqual({ revoked: 0 });
+    expect(prisma.clientResumeAssignment.updateMany).not.toHaveBeenCalled();
+  });
+
+  it('handles a user id that no longer exists', async () => {
+    prisma.user.findMany.mockResolvedValue([]);
+    expect(await revokeTalentPoolAccess(['ghost'], 'admin-1')).toEqual({ revoked: 0 });
+  });
+});

--- a/server/src/utils/talentPoolFilters.js
+++ b/server/src/utils/talentPoolFilters.js
@@ -335,7 +335,15 @@ export const buildMemberResumeWhere = (dsl, { visibility = 'BLIND' } = {}) => {
   }
 
   const filterClauses = [{ isCurrent: true }];
-  const gateClauses = [{ shareConsent: true }, { consentRevokedAt: null }];
+  const gateClauses = [
+    { shareConsent: true },
+    { consentRevokedAt: null },
+    // A deactivated account is how this app records that someone has left, and
+    // their resume should stop going to recruiters. The external pool below has
+    // always required this; the member pool did not, so a graduated member
+    // stayed assignable indefinitely.
+    { member: { isActive: true } },
+  ];
 
   const AND = filterClauses;
   const unsupported = [];

--- a/server/src/utils/talentPoolFilters.test.js
+++ b/server/src/utils/talentPoolFilters.test.js
@@ -411,3 +411,26 @@ describe('sanitizeFilterDsl and pools', () => {
       .toEqual(['APPLICANTS', 'MEMBERS', 'EXTERNALS']);
   });
 });
+
+describe('deactivated accounts', () => {
+  const rows = [{ field: 'graduationYear', values: ['2028'] }];
+  const seen = { visibility: 'IDENTIFIED' };
+
+  it('are excluded from the member pool', () => {
+    // A deactivated account is how this app records that someone has left.
+    // The member pool used to check only consent, so a graduated member stayed
+    // assignable to new clients indefinitely.
+    const { gateClauses } = buildMemberResumeWhere({ pools: ['MEMBERS'], rows }, seen);
+    expect(gateClauses).toContainEqual({ member: { isActive: true } });
+  });
+
+  it('are excluded from the external pool, as they always were', () => {
+    const { gateClauses } = buildExternalResumeWhere({ pools: ['EXTERNALS'], rows }, seen);
+    expect(gateClauses).toContainEqual({ user: { emailVerifiedAt: { not: null }, isActive: true } });
+  });
+
+  it('keeps the member gate non-negotiable, not something a filter can drop', () => {
+    const { where } = buildMemberResumeWhere({ pools: ['MEMBERS'], rows }, seen);
+    expect(where.AND).toContainEqual({ member: { isActive: true } });
+  });
+});


### PR DESCRIPTION
It did not. Deactivation flipped `isActive`, cleared the session cache, and left
the person's resume going to recruiters.

## Three gaps

| | before | after |
|---|---|---|
| Member pool gate | consent only, **no `isActive`** | requires an active account |
| External pool gate | already required `isActive` | unchanged |
| Existing assignments | never revoked, in any pool | revoked on deactivation |
| Deactivation paths | neither touched TPN | both revoke |

The member pool gate was the silent one: it checked `shareConsent` and
`consentRevokedAt` and nothing else, so a graduated member stayed assignable to
**new** clients indefinitely, while the external pool beside it had always
required an active account.

Separately, no pool revoked assignments already handed out. Assignments are
snapshots and are never re-derived, so a client keeps the resume regardless of
what happens to the account behind it. The gate alone cannot fix that.

## Scope

One service, used by both the bulk (by graduation class) and single-user
deactivation paths. It covers all three pools, because a person can be in more
than one: a member who also applied is in the applicant pool through their
application and the member pool through their uploaded resume. Applications
carry no foreign key to `User`, so they are matched on the same email and
student ID that ownership uses everywhere else.

**Consent is deliberately untouched.** `shareConsent` and `talentPoolOptIn`
record what the person chose. Overwriting them would mean a reactivated account
silently comes back opted out of something they had agreed to.

Revocation failure is logged rather than thrown, so it cannot leave an account
half-deactivated.

## Current exposure

Checked live: **0** deactivated members are currently sitting in the member pool,
so nothing is exposed right now. This closes the hole before the next
graduation-class deactivation, which is exactly when it would have bitten.

## Tests

11 new tests: the service across all three pools, the identity matching, that
only live assignments are touched, that consent is left alone, and that both
pool gates require an active account.

693 server tests pass; the two `offerLetter.test.js` failures are byte-identical
to `main`'s copy and fail there too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)