### PR TITLE
feat: interview question bank backend (ATS-68)

### DIFF
--- a/server/prisma/migrations/20260827060000_add_interview_questions/migration.sql
+++ b/server/prisma/migrations/20260827060000_add_interview_questions/migration.sql
@@ -1,0 +1,20 @@
+-- Interview question bank (ATS-23 / ATS-68)
+
+CREATE TABLE IF NOT EXISTS "interview_questions" (
+    "id" TEXT NOT NULL,
+    "cycleId" TEXT NOT NULL,
+    "prompt" TEXT NOT NULL,
+    "guidance" TEXT,
+    "round" TEXT NOT NULL,
+    "category" TEXT,
+    "status" TEXT NOT NULL DEFAULT 'DRAFT',
+    "createdBy" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    CONSTRAINT "interview_questions_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX IF NOT EXISTS "interview_questions_cycleId_idx" ON "interview_questions"("cycleId");
+CREATE INDEX IF NOT EXISTS "interview_questions_round_idx" ON "interview_questions"("round");
+CREATE INDEX IF NOT EXISTS "interview_questions_category_idx" ON "interview_questions"("category");
+CREATE INDEX IF NOT EXISTS "interview_questions_status_idx" ON "interview_questions"("status");

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -898,6 +898,31 @@ model Message {
   @@map("messages")
 }
 
+model InterviewQuestion {
+  id          String                  @id @default(uuid())
+  cycleId     String
+  prompt      String
+  guidance    String?
+  round       String
+  category    String?
+  status      InterviewQuestionStatus @default(DRAFT)
+  createdBy   String
+  createdAt   DateTime                @default(now())
+  updatedAt   DateTime                @updatedAt
+
+  @@index([cycleId])
+  @@index([round])
+  @@index([category])
+  @@index([status])
+  @@map("interview_questions")
+}
+
+enum InterviewQuestionStatus {
+  DRAFT
+  PUBLISHED
+  ARCHIVED
+}
+
 enum ConversationContextType {
   INTERVIEW
   APPLICATION

--- a/server/src/routes/admin.js
+++ b/server/src/routes/admin.js
@@ -6069,4 +6069,115 @@ router.get('/talent-pool/stats', async (req, res) => {
   }
 });
 
+// -------------------- Interview Question Bank (ATS-23 / ATS-68) --------------------
+
+// Create a new interview question
+router.post('/interview-questions', async (req, res) => {
+  try {
+    const { cycleId, prompt, guidance, round, category, status } = req.body || {};
+
+    if (!cycleId || !prompt || !round) {
+      return res.status(400).json({ error: 'cycleId, prompt, and round are required' });
+    }
+
+    const validStatus = ['DRAFT', 'PUBLISHED', 'ARCHIVED'];
+    const questionStatus = status && validStatus.includes(status) ? status : 'DRAFT';
+
+    const question = await prisma.interviewQuestion.create({
+      data: {
+        cycleId,
+        prompt,
+        guidance: guidance || null,
+        round,
+        category: category || null,
+        status: questionStatus,
+        createdBy: req.user.id
+      }
+    });
+
+    res.status(201).json(question);
+  } catch (error) {
+    console.error('[POST /api/admin/interview-questions]', error);
+    res.status(500).json({ error: 'Failed to create interview question' });
+  }
+});
+
+// List and filter interview questions (admin sees all)
+router.get('/interview-questions', async (req, res) => {
+  try {
+    const { cycleId, round, category, status } = req.query || {};
+    const where = {};
+    if (cycleId) where.cycleId = String(cycleId);
+    if (round) where.round = String(round);
+    if (category) where.category = String(category);
+    if (status) where.status = String(status);
+
+    const questions = await prisma.interviewQuestion.findMany({
+      where,
+      orderBy: { createdAt: 'desc' }
+    });
+
+    res.json(questions);
+  } catch (error) {
+    console.error('[GET /api/admin/interview-questions]', error);
+    res.status(500).json({ error: 'Failed to fetch interview questions' });
+  }
+});
+
+// Update an interview question
+router.put('/interview-questions/:id', async (req, res) => {
+  try {
+    const { id } = req.params;
+    const { prompt, guidance, round, category } = req.body || {};
+
+    if (!prompt || !round) {
+      return res.status(400).json({ error: 'prompt and round are required' });
+    }
+
+    const question = await prisma.interviewQuestion.update({
+      where: { id },
+      data: {
+        prompt,
+        guidance: guidance || null,
+        round,
+        category: category || null
+      }
+    });
+
+    res.json(question);
+  } catch (error) {
+    console.error('[PUT /api/admin/interview-questions/:id]', error);
+    if (error.code === 'P2025') {
+      return res.status(404).json({ error: 'Interview question not found' });
+    }
+    res.status(500).json({ error: 'Failed to update interview question' });
+  }
+});
+
+// Update question status (DRAFT / PUBLISHED / ARCHIVED)
+router.patch('/interview-questions/:id/status', async (req, res) => {
+  try {
+    const { id } = req.params;
+    const { status } = req.body || {};
+    const validStatus = ['DRAFT', 'PUBLISHED', 'ARCHIVED'];
+
+    if (!status || !validStatus.includes(status)) {
+      return res.status(400).json({ error: 'status must be DRAFT, PUBLISHED, or ARCHIVED' });
+    }
+
+    const question = await prisma.interviewQuestion.update({
+      where: { id },
+      data: { status }
+    });
+
+    res.json(question);
+  } catch (error) {
+    console.error('[PATCH /api/admin/interview-questions/:id/status]', error);
+    if (error.code === 'P2025') {
+      return res.status(404).json({ error: 'Interview question not found' });
+    }
+    res.status(500).json({ error: 'Failed to update interview question status' });
+  }
+});
+
 export default router;

--- a/server/src/routes/member.js
+++ b/server/src/routes/member.js
@@ -2027,4 +2027,34 @@ router.delete('/resume', requireAuth, requireMemberRole, async (req, res) => {
   }
 });
 
+// List published interview questions for the current cycle (ATS-23 / ATS-68)
+router.get('/interview-questions', requireAuth, requireAdminOrMember, async (req, res) => {
+  try {
+    const { cycleId, round, category } = req.query || {};
+    const activeCycle = await resolveCycleForRequest(prisma, req);
+    const targetCycleId = cycleId || activeCycle?.id;
+
+    if (!targetCycleId) {
+      return res.json([]);
+    }
+
+    const where = {
+      cycleId: targetCycleId,
+      status: 'PUBLISHED'
+    };
+    if (round) where.round = String(round);
+    if (category) where.category = String(category);
+
+    const questions = await prisma.interviewQuestion.findMany({
+      where,
+      orderBy: { createdAt: 'desc' }
+    });
+
+    res.json(questions);
+  } catch (error) {
+    console.error('[GET /api/member/interview-questions]', error);
+    res.status(500).json({ error: 'Failed to fetch interview questions' });
+  }
+});
+
 export default router;


### PR DESCRIPTION
Implements the backend for the admin-curated interview question bank (ATS-68 / ATS-23).\n\n- Adds InterviewQuestion Prisma model + migration\n- Admin CRUD endpoints with filtering by cycle, round, category, and status\n- Member endpoint returns only published questions for a cycle\n\nCloses ATS-68