### PR TITLE
feat: polling fallback for live interview questions (ATS-13)

### DIFF
--- a/server/prisma/migrations/20260827070000_add_interview_session_questions/migration.sql
+++ b/server/prisma/migrations/20260827070000_add_interview_session_questions/migration.sql
@@ -1,0 +1,16 @@
+-- Live interview session questions (ATS-13 / ATS-69)
+
+CREATE TABLE IF NOT EXISTS "interview_session_questions" (
+    "id" TEXT NOT NULL,
+    "interviewId" TEXT NOT NULL,
+    "prompt" TEXT NOT NULL,
+    "addedBy" TEXT NOT NULL,
+    "position" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "interview_session_questions_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX IF NOT EXISTS "interview_session_questions_interviewId_position_idx" ON "interview_session_questions"("interviewId", "position");
+
+ALTER TABLE "interview_session_questions" DROP CONSTRAINT IF EXISTS "interview_session_questions_interviewId_fkey";
+ALTER TABLE "interview_session_questions" ADD CONSTRAINT "interview_session_questions_interviewId_fkey" FOREIGN KEY ("interviewId") REFERENCES "interviews"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/server/prisma/migrations/20260827100000_add_sync_fields_to_session_questions/migration.sql
+++ b/server/prisma/migrations/20260827100000_add_sync_fields_to_session_questions/migration.sql
@@ -1,0 +1,6 @@
+-- Add polling sync fields to live interview session questions (ATS-13)
+
+ALTER TABLE "interview_session_questions" ADD COLUMN IF NOT EXISTS "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;
+ALTER TABLE "interview_session_questions" ADD COLUMN IF NOT EXISTS "deletedAt" TIMESTAMP(3);
+
+CREATE INDEX IF NOT EXISTS "interview_session_questions_interviewId_updatedAt_idx" ON "interview_session_questions"("interviewId", "updatedAt");

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -905,8 +905,11 @@ model InterviewSessionQuestion {
   addedBy     String
   position    Int       @default(0)
   createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @updatedAt
+  deletedAt   DateTime?
 
   @@index([interviewId, position])
+  @@index([interviewId, updatedAt])
   @@map("interview_session_questions")
 }
 

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -898,6 +898,18 @@ model Message {
   @@map("messages")
 }
 
+model InterviewSessionQuestion {
+  id          String    @id @default(uuid())
+  interviewId String
+  prompt      String
+  addedBy     String
+  position    Int       @default(0)
+  createdAt   DateTime  @default(now())
+
+  @@index([interviewId, position])
+  @@map("interview_session_questions")
+}
+
 enum ConversationContextType {
   INTERVIEW
   APPLICATION

--- a/server/src/routes/member.js
+++ b/server/src/routes/member.js
@@ -2079,14 +2079,26 @@ router.post('/interviews/:interviewId/session-questions', requireAuth, requireAd
 router.get('/interviews/:interviewId/session-questions', requireAuth, requireAdminOrMember, async (req, res) => {
   try {
     const { interviewId } = req.params;
+    const { since } = req.query || {};
 
     if (!(await canAccessInterview(req, interviewId))) {
       return res.status(403).json({ error: 'Not assigned to this interview' });
     }
 
+    const where = { interviewId };
+    if (since) {
+      try {
+        where.updatedAt = { gte: new Date(since) };
+      } catch {
+        return res.status(400).json({ error: 'Invalid since timestamp' });
+      }
+    } else {
+      where.deletedAt = null;
+    }
+
     const questions = await prisma.interviewSessionQuestion.findMany({
-      where: { interviewId },
-      orderBy: [{ position: 'asc' }, { createdAt: 'asc' }]
+      where,
+      orderBy: [{ position: 'asc' }, { updatedAt: 'asc' }]
     });
 
     res.json(questions);
@@ -2116,9 +2128,12 @@ router.delete('/interviews/:interviewId/session-questions/:id', requireAuth, req
       return res.status(403).json({ error: 'You can only remove your own questions' });
     }
 
-    await prisma.interviewSessionQuestion.delete({ where: { id } });
+    const updated = await prisma.interviewSessionQuestion.update({
+      where: { id },
+      data: { deletedAt: new Date() }
+    });
 
-    res.status(204).send();
+    res.json(updated);
   } catch (error) {
     console.error('[DELETE /api/member/interviews/:interviewId/session-questions/:id]', error);
     res.status(500).json({ error: 'Failed to remove interview question' });

--- a/server/src/routes/member.js
+++ b/server/src/routes/member.js
@@ -2027,4 +2027,102 @@ router.delete('/resume', requireAuth, requireMemberRole, async (req, res) => {
   }
 });
 
+// Live interview session questions (ATS-13 / ATS-69)
+
+async function canAccessInterview(req, interviewId) {
+  if (req.user.role === 'ADMIN') return true;
+  const assignment = await prisma.interviewAssignment.findFirst({
+    where: { interviewId, userId: req.user.id }
+  });
+  return Boolean(assignment);
+}
+
+router.post('/interviews/:interviewId/session-questions', requireAuth, requireAdminOrMember, async (req, res) => {
+  try {
+    const { interviewId } = req.params;
+    const { prompt, position } = req.body || {};
+
+    if (!prompt || !prompt.trim()) {
+      return res.status(400).json({ error: 'prompt is required' });
+    }
+
+    if (!(await canAccessInterview(req, interviewId))) {
+      return res.status(403).json({ error: 'Not assigned to this interview' });
+    }
+
+    let targetPosition = Number(position);
+    if (Number.isNaN(targetPosition)) {
+      const last = await prisma.interviewSessionQuestion.findFirst({
+        where: { interviewId },
+        orderBy: { position: 'desc' },
+        select: { position: true }
+      });
+      targetPosition = (last?.position || 0) + 1;
+    }
+
+    const question = await prisma.interviewSessionQuestion.create({
+      data: {
+        interviewId,
+        prompt: prompt.trim(),
+        addedBy: req.user.id,
+        position: targetPosition
+      }
+    });
+
+    res.status(201).json(question);
+  } catch (error) {
+    console.error('[POST /api/member/interviews/:interviewId/session-questions]', error);
+    res.status(500).json({ error: 'Failed to add interview question' });
+  }
+});
+
+router.get('/interviews/:interviewId/session-questions', requireAuth, requireAdminOrMember, async (req, res) => {
+  try {
+    const { interviewId } = req.params;
+
+    if (!(await canAccessInterview(req, interviewId))) {
+      return res.status(403).json({ error: 'Not assigned to this interview' });
+    }
+
+    const questions = await prisma.interviewSessionQuestion.findMany({
+      where: { interviewId },
+      orderBy: [{ position: 'asc' }, { createdAt: 'asc' }]
+    });
+
+    res.json(questions);
+  } catch (error) {
+    console.error('[GET /api/member/interviews/:interviewId/session-questions]', error);
+    res.status(500).json({ error: 'Failed to fetch interview questions' });
+  }
+});
+
+router.delete('/interviews/:interviewId/session-questions/:id', requireAuth, requireAdminOrMember, async (req, res) => {
+  try {
+    const { interviewId, id } = req.params;
+
+    if (!(await canAccessInterview(req, interviewId))) {
+      return res.status(403).json({ error: 'Not assigned to this interview' });
+    }
+
+    const question = await prisma.interviewSessionQuestion.findFirst({
+      where: { id, interviewId }
+    });
+
+    if (!question) {
+      return res.status(404).json({ error: 'Question not found' });
+    }
+
+    if (req.user.role !== 'ADMIN' && question.addedBy !== req.user.id) {
+      return res.status(403).json({ error: 'You can only remove your own questions' });
+    }
+
+    await prisma.interviewSessionQuestion.delete({ where: { id } });
+
+    res.status(204).send();
+  } catch (error) {
+    console.error('[DELETE /api/member/interviews/:interviewId/session-questions/:id]', error);
+    res.status(500).json({ error: 'Failed to remove interview question' });
+  }
+});
+
 export default router;


### PR DESCRIPTION
Adds bounded polling support for real-time sync of live interview session questions (ATS-13).\n\n- Adds updatedAt and soft-delete (deletedAt) to InterviewSessionQuestion\n- GET /api/member/interviews/:interviewId/session-questions?since=... for incremental sync\n- DELETE now soft-deletes to support reconnect catch-up\n\nCloses ATS-13