### PR TITLE
feat: link question bank to interview sessions (ATS-23)

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -49,6 +49,7 @@ import AdminMeetingSlots from './pages/AdminMeetingSlots';
 import ReleaseNotes from './pages/ReleaseNotes';
 import MemberHelp from './pages/MemberHelp';
 import AdminHelpManagement from './pages/AdminHelpManagement';
+import AdminQuestionBank from './pages/AdminQuestionBank';
 import CandidateList from './pages/CandidateList';
 import CandidateDetail from './pages/CandidateDetail';
 import MasterCommunications from './pages/MasterCommunications';
@@ -570,6 +571,16 @@ const AppRoutes = () => {
         element={
           <ProtectedRoute>
             <MemberHelp />
+          </ProtectedRoute>
+        }
+      />
+
+      {/* Admin interview question bank */}
+      <Route
+        path="/admin/question-bank"
+        element={
+          <ProtectedRoute>
+            <AdminQuestionBank />
           </ProtectedRoute>
         }
       />

--- a/client/src/components/Layout.jsx
+++ b/client/src/components/Layout.jsx
@@ -58,6 +58,7 @@ const ADMIN_NAV_SECTIONS = [
     items: [
       { name: 'Assigned Interviews', href: '/admin/assigned-interviews', icon: UserGroupIcon2 },
       { name: 'Cases', href: '/cases', icon: PresentationChartBarIcon },
+      { name: 'Question Bank', href: '/admin/question-bank', icon: QuestionMarkCircleIcon },
       { name: 'Recruitment Resources', href: '/interview-prep', icon: ClipboardDocumentListIcon },
       { name: 'Get to Know UC', href: '/admin/meeting-slots', icon: ChatBubbleLeftRightIcon },
     ],

--- a/client/src/components/interview/InterviewQuestionPanel.css
+++ b/client/src/components/interview/InterviewQuestionPanel.css
@@ -1,0 +1,435 @@
+/* Right-edge launcher. The interview chat widget owns the bottom-right corner, so this
+   sits mid-edge as a vertical tab instead of stacking another floating circle on top. */
+.question-panel-tab {
+  position: fixed;
+  right: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: 1300;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 1rem 0.5rem;
+  border: 1px solid var(--border-light);
+  border-right: none;
+  border-radius: 10px 0 0 10px;
+  background: var(--bg-white);
+  color: var(--text-primary);
+  box-shadow: -4px 0 18px rgba(0, 0, 0, 0.1);
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.question-panel-tab:hover {
+  background: var(--primary-blue);
+  color: var(--text-white);
+}
+
+.question-panel-tab__icon {
+  width: 22px;
+  height: 22px;
+}
+
+.question-panel-tab__label {
+  writing-mode: vertical-rl;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+}
+
+.question-panel-tab__count {
+  min-width: 20px;
+  height: 20px;
+  padding: 0 6px;
+  border-radius: 10px;
+  background: var(--primary-blue);
+  color: var(--text-white);
+  font-size: 11px;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.question-panel-tab:hover .question-panel-tab__count {
+  background: var(--bg-white);
+  color: var(--primary-blue);
+}
+
+.question-panel {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  /* One above the chat panel (1301) so that if an interviewer has both open at once the
+     stacking is deterministic rather than dependent on render order. */
+  z-index: 1302;
+  width: 400px;
+  max-width: 100vw;
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-primary);
+  border-left: 1px solid var(--border-light);
+  box-shadow: -12px 0 40px rgba(0, 0, 0, 0.16);
+}
+
+.question-panel__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 1rem;
+  border-bottom: 1px solid var(--border-light);
+  flex-shrink: 0;
+}
+
+.question-panel__title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.question-panel__subtitle {
+  margin: 0.15rem 0 0;
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+}
+
+.question-panel__close {
+  flex-shrink: 0;
+  border: none;
+  background: none;
+  color: var(--text-secondary);
+  cursor: pointer;
+  padding: 0.25rem;
+  border-radius: 6px;
+}
+
+.question-panel__close:hover {
+  background: var(--bg-gray-lighter);
+  color: var(--text-primary);
+}
+
+.question-panel__close svg {
+  width: 20px;
+  height: 20px;
+}
+
+.question-panel__tabs {
+  display: flex;
+  border-bottom: 1px solid var(--border-light);
+  flex-shrink: 0;
+}
+
+.question-panel__tab {
+  flex: 1;
+  padding: 0.7rem 0.5rem;
+  border: none;
+  border-bottom: 2px solid transparent;
+  background: none;
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+  cursor: pointer;
+}
+
+.question-panel__tab.is-active {
+  color: var(--primary-blue);
+  border-bottom-color: var(--primary-blue);
+}
+
+.question-panel__error,
+.question-panel__notice {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  margin: 0.75rem 1rem 0;
+  padding: 0.55rem 0.7rem;
+  border-radius: 8px;
+  font-size: 0.8rem;
+}
+
+.question-panel__error {
+  background: var(--status-error-bg);
+  color: var(--status-error-text);
+}
+
+.question-panel__error button {
+  border: none;
+  background: none;
+  color: inherit;
+  cursor: pointer;
+  padding: 0;
+  display: flex;
+}
+
+.question-panel__error svg {
+  width: 16px;
+  height: 16px;
+}
+
+.question-panel__notice {
+  background: var(--status-info-bg);
+  color: var(--status-info-text);
+}
+
+.question-panel__filters {
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid var(--border-light);
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  flex-shrink: 0;
+}
+
+.question-panel__search {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.45rem 0.6rem;
+  border: 1px solid var(--border-medium);
+  border-radius: 8px;
+  background: var(--bg-white);
+}
+
+.question-panel__search svg {
+  width: 16px;
+  height: 16px;
+  color: var(--text-muted);
+  flex-shrink: 0;
+}
+
+.question-panel__search input {
+  flex: 1;
+  border: none;
+  outline: none;
+  background: none;
+  font-size: 0.85rem;
+  color: var(--text-primary);
+  min-width: 0;
+}
+
+.question-panel__selects {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.question-panel__selects select {
+  flex: 1;
+  min-width: 0;
+  padding: 0.4rem 0.5rem;
+  border: 1px solid var(--border-medium);
+  border-radius: 8px;
+  background: var(--bg-white);
+  color: var(--text-primary);
+  font-size: 0.8rem;
+}
+
+.question-panel__body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 0.75rem 1rem 1rem;
+}
+
+.question-panel__muted {
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+  text-align: center;
+  padding: 1.5rem 0;
+}
+
+.question-panel__empty {
+  text-align: center;
+  padding: 2rem 0.5rem;
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+}
+
+.question-panel__link {
+  margin-top: 0.5rem;
+  border: none;
+  background: none;
+  color: var(--primary-blue);
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  text-decoration: underline;
+}
+
+.question-panel__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  counter-reset: question;
+}
+
+.question-card {
+  display: flex;
+  gap: 0.6rem;
+  padding: 0.7rem;
+  border: 1px solid var(--border-light);
+  border-radius: 10px;
+  background: var(--bg-white);
+}
+
+.question-card__main {
+  flex: 1;
+  min-width: 0;
+}
+
+.question-card__prompt {
+  margin: 0;
+  font-size: 0.88rem;
+  line-height: 1.4;
+  color: var(--text-primary);
+}
+
+.question-card__guidance {
+  margin: 0.35rem 0 0;
+  font-size: 0.78rem;
+  line-height: 1.4;
+  color: var(--text-secondary);
+  padding-left: 0.55rem;
+  border-left: 2px solid var(--border-light);
+}
+
+.question-card__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  margin-top: 0.45rem;
+}
+
+.question-card__chip,
+.question-card__badge {
+  display: inline-block;
+  padding: 0.1rem 0.45rem;
+  border-radius: 999px;
+  font-size: 0.68rem;
+  font-weight: 600;
+  background: var(--bg-gray-lighter);
+  color: var(--text-tertiary);
+}
+
+.question-card__badge {
+  margin-top: 0.45rem;
+  background: var(--status-info-bg);
+  color: var(--status-info-text);
+}
+
+.question-card__actions {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.15rem;
+  flex-shrink: 0;
+}
+
+.question-card__actions button {
+  border: none;
+  background: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  padding: 0.15rem;
+  border-radius: 6px;
+  display: flex;
+}
+
+.question-card__actions button svg {
+  width: 16px;
+  height: 16px;
+}
+
+.question-card__actions button:hover:not(:disabled) {
+  background: var(--bg-gray-lighter);
+  color: var(--text-primary);
+}
+
+.question-card__actions button:disabled {
+  opacity: 0.35;
+  cursor: default;
+}
+
+.question-card__remove:hover:not(:disabled) {
+  color: var(--status-error-text) !important;
+}
+
+.question-card__add {
+  padding: 0.3rem 0.7rem !important;
+  border: 1px solid var(--primary-blue) !important;
+  border-radius: 999px !important;
+  color: var(--primary-blue) !important;
+  font-size: 0.75rem;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.question-card__add:hover:not(:disabled) {
+  background: var(--primary-blue) !important;
+  color: var(--text-white) !important;
+}
+
+.question-card__add:disabled {
+  border-color: var(--border-light) !important;
+  color: var(--text-muted) !important;
+}
+
+.question-panel__composer {
+  display: flex;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+  border-top: 1px solid var(--border-light);
+  flex-shrink: 0;
+}
+
+.question-panel__composer input {
+  flex: 1;
+  min-width: 0;
+  padding: 0.5rem 0.7rem;
+  border: 1px solid var(--border-medium);
+  border-radius: 999px;
+  background: var(--bg-white);
+  color: var(--text-primary);
+  font-size: 0.85rem;
+  outline: none;
+}
+
+.question-panel__composer input:focus {
+  border-color: var(--border-focus);
+}
+
+.question-panel__composer button {
+  flex-shrink: 0;
+  width: 36px;
+  height: 36px;
+  border: none;
+  border-radius: 50%;
+  background: var(--primary-blue);
+  color: var(--text-white);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.question-panel__composer button svg {
+  width: 18px;
+  height: 18px;
+}
+
+.question-panel__composer button:disabled {
+  background: var(--bg-gray-medium);
+  cursor: default;
+}
+
+@media (max-width: 640px) {
+  .question-panel {
+    width: 100vw;
+  }
+}

--- a/client/src/components/interview/InterviewQuestionPanel.jsx
+++ b/client/src/components/interview/InterviewQuestionPanel.jsx
@@ -1,0 +1,489 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  QuestionMarkCircleIcon,
+  XMarkIcon,
+  PlusIcon,
+  TrashIcon,
+  ChevronUpIcon,
+  ChevronDownIcon,
+  MagnifyingGlassIcon,
+} from '@heroicons/react/24/outline';
+import apiClient from '../../utils/api';
+import { useAuth } from '../../context/AuthContext';
+import './InterviewQuestionPanel.css';
+
+const POLL_INTERVAL_MS = 10000;
+
+const ROUND_LABELS = {
+  COFFEE_CHAT: 'Coffee Chat',
+  ROUND_ONE: 'Round 1',
+  ROUND_TWO: 'Round 2',
+  FINAL_ROUND: 'Final Round',
+  DELIBERATIONS: 'Deliberations',
+};
+
+const roundLabel = (round) => ROUND_LABELS[round] || round;
+
+// Session questions arrive as a stream of changes, not a snapshot: a ?since poll returns
+// soft-deleted rows too, because those tombstones are the only signal that a co-interviewer
+// removed something. Rows are folded into a Map so the boundary row a `gte` filter re-sends
+// on every poll is idempotent rather than a duplicate.
+function foldRows(map, rows) {
+  let watermark = null;
+  rows.forEach((row) => {
+    if (row.deletedAt) map.delete(row.id);
+    else map.set(row.id, row);
+    if (!watermark || new Date(row.updatedAt) > new Date(watermark)) watermark = row.updatedAt;
+  });
+  return watermark;
+}
+
+function sortQuestions(questions) {
+  return [...questions].sort(
+    (a, b) => a.position - b.position || new Date(a.updatedAt) - new Date(b.updatedAt)
+  );
+}
+
+export default function InterviewQuestionPanel({ interviewId, round, interviewTitle }) {
+  const { user } = useAuth();
+  const [open, setOpen] = useState(false);
+  const [tab, setTab] = useState('session');
+
+  const [sessionQuestions, setSessionQuestions] = useState([]);
+  const [bank, setBank] = useState([]);
+  const [facets, setFacets] = useState({ categories: [], rounds: [] });
+
+  const [loadingSession, setLoadingSession] = useState(false);
+  const [loadingBank, setLoadingBank] = useState(false);
+  const [error, setError] = useState(null);
+  const [notice, setNotice] = useState(null);
+
+  const [draft, setDraft] = useState('');
+  const [search, setSearch] = useState('');
+  const [roundFilter, setRoundFilter] = useState(round || '');
+  const [categoryFilter, setCategoryFilter] = useState('');
+  const [busyId, setBusyId] = useState(null);
+
+  const questionMap = useRef(new Map());
+  const watermark = useRef(null);
+
+  useEffect(() => {
+    if (round && !roundFilter) setRoundFilter(round);
+  }, [round]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const publish = useCallback(() => {
+    setSessionQuestions(sortQuestions([...questionMap.current.values()]));
+  }, []);
+
+  const loadSession = useCallback(
+    async ({ full = false } = {}) => {
+      if (!interviewId) return;
+      if (full) setLoadingSession(true);
+      try {
+        // No watermark yet (first load, or an empty list) means a full read. Deriving the
+        // watermark from the rows themselves rather than the local clock keeps this correct
+        // when the server and the browser disagree about the time.
+        const useSince = !full && watermark.current;
+        const url = `/member/interviews/${interviewId}/session-questions${
+          useSince ? `?since=${encodeURIComponent(watermark.current)}` : ''
+        }`;
+        const rows = await apiClient.get(url);
+        const list = Array.isArray(rows) ? rows : [];
+        if (full || !useSince) questionMap.current = new Map();
+        const next = foldRows(questionMap.current, list);
+        if (next) watermark.current = next;
+        publish();
+        setError(null);
+      } catch (e) {
+        setError(e.message || 'Could not load this interview’s questions.');
+      } finally {
+        if (full) setLoadingSession(false);
+      }
+    },
+    [interviewId, publish]
+  );
+
+  const loadBank = useCallback(async () => {
+    setLoadingBank(true);
+    try {
+      const params = new URLSearchParams();
+      if (roundFilter) params.set('round', roundFilter);
+      if (categoryFilter) params.set('category', categoryFilter);
+      const qs = params.toString();
+      const rows = await apiClient.get(`/member/interview-questions${qs ? `?${qs}` : ''}`);
+      setBank(Array.isArray(rows) ? rows : []);
+      setError(null);
+    } catch (e) {
+      setError(e.message || 'Could not load the question bank.');
+    } finally {
+      setLoadingBank(false);
+    }
+  }, [roundFilter, categoryFilter]);
+
+  useEffect(() => {
+    if (!open) return undefined;
+    loadSession({ full: true });
+    apiClient
+      .get('/member/interview-questions/facets')
+      .then((data) =>
+        setFacets({
+          categories: Array.isArray(data?.categories) ? data.categories : [],
+          rounds: Array.isArray(data?.rounds) ? data.rounds : [],
+        })
+      )
+      .catch(() => setFacets({ categories: [], rounds: [] }));
+    return undefined;
+  }, [open, loadSession]);
+
+  useEffect(() => {
+    if (!open || tab !== 'bank') return undefined;
+    loadBank();
+    return undefined;
+  }, [open, tab, loadBank]);
+
+  // Polling only runs while the panel is open - a closed panel has nothing to show, and
+  // this is the fallback sync path, not a live socket.
+  useEffect(() => {
+    if (!open) return undefined;
+    const timer = setInterval(() => loadSession(), POLL_INTERVAL_MS);
+    return () => clearInterval(timer);
+  }, [open, loadSession]);
+
+  useEffect(() => {
+    if (!notice) return undefined;
+    const timer = setTimeout(() => setNotice(null), 4000);
+    return () => clearTimeout(timer);
+  }, [notice]);
+
+  const addedBankIds = useMemo(
+    () => new Set(sessionQuestions.map((q) => q.questionBankId).filter(Boolean)),
+    [sessionQuestions]
+  );
+
+  const visibleBank = useMemo(() => {
+    const needle = search.trim().toLowerCase();
+    if (!needle) return bank;
+    return bank.filter(
+      (q) =>
+        (q.prompt || '').toLowerCase().includes(needle) ||
+        (q.guidance || '').toLowerCase().includes(needle) ||
+        (q.category || '').toLowerCase().includes(needle)
+    );
+  }, [bank, search]);
+
+  const addAdHoc = async (e) => {
+    e.preventDefault();
+    const prompt = draft.trim();
+    if (!prompt) return;
+    setDraft('');
+    try {
+      const created = await apiClient.post(`/member/interviews/${interviewId}/session-questions`, {
+        prompt,
+      });
+      foldRows(questionMap.current, [created]);
+      watermark.current = created.updatedAt || watermark.current;
+      publish();
+    } catch (err) {
+      setDraft(prompt);
+      setError(err.message || 'Could not add that question.');
+    }
+  };
+
+  const addFromBank = async (question) => {
+    setBusyId(question.id);
+    try {
+      const created = await apiClient.post(
+        `/member/interviews/${interviewId}/session-questions/bank`,
+        { questionId: question.id }
+      );
+      foldRows(questionMap.current, [created]);
+      watermark.current = created.updatedAt || watermark.current;
+      publish();
+      setNotice('Added to this interview.');
+    } catch (err) {
+      setError(err.message || 'Could not add that question.');
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  const removeQuestion = async (question) => {
+    setBusyId(question.id);
+    try {
+      const removed = await apiClient.delete(
+        `/member/interviews/${interviewId}/session-questions/${question.id}`
+      );
+      questionMap.current.delete(question.id);
+      watermark.current = removed?.updatedAt || watermark.current;
+      publish();
+    } catch (err) {
+      setError(err.message || 'Could not remove that question.');
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  const move = async (index, delta) => {
+    const next = index + delta;
+    if (next < 0 || next >= sessionQuestions.length) return;
+    const reordered = [...sessionQuestions];
+    const [moved] = reordered.splice(index, 1);
+    reordered.splice(next, 0, moved);
+    setSessionQuestions(reordered); // optimistic
+
+    try {
+      const rows = await apiClient.patch(
+        `/member/interviews/${interviewId}/session-questions/reorder`,
+        { order: reordered.map((q) => q.id) }
+      );
+      foldRows(questionMap.current, Array.isArray(rows) ? rows : []);
+      publish();
+    } catch (err) {
+      // A 409 means someone else added or removed a question while this list was on
+      // screen. Resyncing is the honest recovery - the local order was computed against
+      // a list that no longer exists.
+      if (/409/.test(err.message || '')) {
+        setNotice('Another interviewer changed the list. Reloaded.');
+      } else {
+        setError(err.message || 'Could not save the new order.');
+      }
+      watermark.current = null;
+      loadSession({ full: true });
+    }
+  };
+
+  const canRemove = (question) =>
+    user?.role === 'ADMIN' || question.addedBy === user?.id;
+
+  if (!interviewId) return null;
+
+  return (
+    <>
+      <button
+        type="button"
+        className="question-panel-tab"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        aria-label="Interview questions"
+      >
+        <QuestionMarkCircleIcon className="question-panel-tab__icon" />
+        <span className="question-panel-tab__label">Questions</span>
+        {sessionQuestions.length > 0 && (
+          <span className="question-panel-tab__count">{sessionQuestions.length}</span>
+        )}
+      </button>
+
+      {open && (
+        <aside className="question-panel" role="complementary" aria-label="Interview questions">
+          <header className="question-panel__header">
+            <div className="question-panel__heading">
+              <h4 className="question-panel__title">Questions</h4>
+              <p className="question-panel__subtitle">
+                {interviewTitle || 'This interview'}
+                {round ? ` · ${roundLabel(round)}` : ''}
+              </p>
+            </div>
+            <button
+              type="button"
+              className="question-panel__close"
+              onClick={() => setOpen(false)}
+              aria-label="Close questions"
+            >
+              <XMarkIcon />
+            </button>
+          </header>
+
+          <div className="question-panel__tabs" role="tablist">
+            <button
+              type="button"
+              role="tab"
+              aria-selected={tab === 'session'}
+              className={`question-panel__tab ${tab === 'session' ? 'is-active' : ''}`}
+              onClick={() => setTab('session')}
+            >
+              This interview {sessionQuestions.length > 0 && `(${sessionQuestions.length})`}
+            </button>
+            <button
+              type="button"
+              role="tab"
+              aria-selected={tab === 'bank'}
+              className={`question-panel__tab ${tab === 'bank' ? 'is-active' : ''}`}
+              onClick={() => setTab('bank')}
+            >
+              Question bank
+            </button>
+          </div>
+
+          {error && (
+            <div className="question-panel__error" role="alert">
+              {error}
+              <button type="button" onClick={() => setError(null)} aria-label="Dismiss error">
+                <XMarkIcon />
+              </button>
+            </div>
+          )}
+          {notice && <div className="question-panel__notice">{notice}</div>}
+
+          {tab === 'session' ? (
+            <>
+              <div className="question-panel__body">
+                {loadingSession && sessionQuestions.length === 0 ? (
+                  <p className="question-panel__muted">Loading…</p>
+                ) : sessionQuestions.length === 0 ? (
+                  <div className="question-panel__empty">
+                    <p>No questions queued for this interview yet.</p>
+                    <button type="button" className="question-panel__link" onClick={() => setTab('bank')}>
+                      Browse the question bank
+                    </button>
+                  </div>
+                ) : (
+                  <ol className="question-panel__list">
+                    {sessionQuestions.map((q, index) => (
+                      <li key={q.id} className="question-card">
+                        <div className="question-card__main">
+                          <p className="question-card__prompt">{q.prompt}</p>
+                          {q.guidance && <p className="question-card__guidance">{q.guidance}</p>}
+                          {!q.questionBankId && (
+                            <span className="question-card__badge">Added live</span>
+                          )}
+                        </div>
+                        <div className="question-card__actions">
+                          <button
+                            type="button"
+                            onClick={() => move(index, -1)}
+                            disabled={index === 0}
+                            aria-label={`Move up: ${q.prompt}`}
+                          >
+                            <ChevronUpIcon />
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => move(index, 1)}
+                            disabled={index === sessionQuestions.length - 1}
+                            aria-label={`Move down: ${q.prompt}`}
+                          >
+                            <ChevronDownIcon />
+                          </button>
+                          {canRemove(q) && (
+                            <button
+                              type="button"
+                              className="question-card__remove"
+                              onClick={() => removeQuestion(q)}
+                              disabled={busyId === q.id}
+                              aria-label={`Remove: ${q.prompt}`}
+                            >
+                              <TrashIcon />
+                            </button>
+                          )}
+                        </div>
+                      </li>
+                    ))}
+                  </ol>
+                )}
+              </div>
+
+              <form className="question-panel__composer" onSubmit={addAdHoc}>
+                <input
+                  type="text"
+                  value={draft}
+                  onChange={(e) => setDraft(e.target.value)}
+                  placeholder="Ask something else…"
+                  aria-label="Add a question to this interview"
+                />
+                <button type="submit" disabled={!draft.trim()} aria-label="Add question">
+                  <PlusIcon />
+                </button>
+              </form>
+            </>
+          ) : (
+            <>
+              <div className="question-panel__filters">
+                <div className="question-panel__search">
+                  <MagnifyingGlassIcon />
+                  <input
+                    type="text"
+                    value={search}
+                    onChange={(e) => setSearch(e.target.value)}
+                    placeholder="Search questions"
+                    aria-label="Search the question bank"
+                  />
+                </div>
+                <div className="question-panel__selects">
+                  <select
+                    value={roundFilter}
+                    onChange={(e) => setRoundFilter(e.target.value)}
+                    aria-label="Filter by round"
+                  >
+                    <option value="">All rounds</option>
+                    {facets.rounds.map((r) => (
+                      <option key={r} value={r}>
+                        {roundLabel(r)}
+                      </option>
+                    ))}
+                  </select>
+                  <select
+                    value={categoryFilter}
+                    onChange={(e) => setCategoryFilter(e.target.value)}
+                    aria-label="Filter by category"
+                  >
+                    <option value="">All categories</option>
+                    {facets.categories.map((c) => (
+                      <option key={c} value={c}>
+                        {c}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              </div>
+
+              <div className="question-panel__body">
+                {loadingBank ? (
+                  <p className="question-panel__muted">Loading…</p>
+                ) : visibleBank.length === 0 ? (
+                  <div className="question-panel__empty">
+                    <p>
+                      {bank.length === 0
+                        ? 'No published questions for this cycle yet.'
+                        : 'No questions match these filters.'}
+                    </p>
+                  </div>
+                ) : (
+                  <ul className="question-panel__list">
+                    {visibleBank.map((q) => {
+                      const already = addedBankIds.has(q.id);
+                      return (
+                        <li key={q.id} className="question-card">
+                          <div className="question-card__main">
+                            <p className="question-card__prompt">{q.prompt}</p>
+                            {q.guidance && <p className="question-card__guidance">{q.guidance}</p>}
+                            <div className="question-card__meta">
+                              <span className="question-card__chip">{roundLabel(q.round)}</span>
+                              {q.category && (
+                                <span className="question-card__chip">{q.category}</span>
+                              )}
+                            </div>
+                          </div>
+                          <div className="question-card__actions">
+                            <button
+                              type="button"
+                              className="question-card__add"
+                              onClick={() => addFromBank(q)}
+                              disabled={already || busyId === q.id}
+                              aria-label={already ? `Already added: ${q.prompt}` : `Add: ${q.prompt}`}
+                            >
+                              {already ? 'Added' : 'Add'}
+                            </button>
+                          </div>
+                        </li>
+                      );
+                    })}
+                  </ul>
+                )}
+              </div>
+            </>
+          )}
+        </aside>
+      )}
+    </>
+  );
+}

--- a/client/src/components/interview/InterviewQuestionPanel.test.jsx
+++ b/client/src/components/interview/InterviewQuestionPanel.test.jsx
@@ -1,0 +1,231 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, fireEvent, act } from '@testing-library/react';
+import InterviewQuestionPanel from './InterviewQuestionPanel';
+
+vi.mock('../../utils/api', () => ({
+  default: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn() },
+}));
+vi.mock('../../context/AuthContext', () => ({ useAuth: vi.fn() }));
+
+import apiClient from '../../utils/api';
+import { useAuth } from '../../context/AuthContext';
+
+const me = { id: 'me-1', role: 'MEMBER' };
+
+const mine = {
+  id: 'sq-1',
+  interviewId: 'int-1',
+  prompt: 'Tell me about a team you led.',
+  guidance: 'Look for ownership.',
+  questionBankId: 'bank-1',
+  addedBy: 'me-1',
+  position: 0,
+  updatedAt: '2026-08-27T10:00:00.000Z',
+  deletedAt: null,
+};
+
+const theirs = {
+  id: 'sq-2',
+  interviewId: 'int-1',
+  prompt: 'Why consulting?',
+  guidance: null,
+  questionBankId: null,
+  addedBy: 'someone-else',
+  position: 1,
+  updatedAt: '2026-08-27T10:01:00.000Z',
+  deletedAt: null,
+};
+
+const bankRows = [
+  { id: 'bank-1', prompt: 'Tell me about a team you led.', guidance: 'Look for ownership.', round: 'ROUND_ONE', category: 'Behavioral' },
+  { id: 'bank-2', prompt: 'Size the LA scooter market.', guidance: null, round: 'ROUND_ONE', category: 'Casing' },
+];
+
+const facets = { categories: ['Behavioral', 'Casing'], rounds: ['ROUND_ONE'] };
+
+function mockGets({ session = [me] && [mine, theirs], bank = bankRows } = {}) {
+  apiClient.get.mockImplementation((url) => {
+    if (url.includes('/interview-questions/facets')) return Promise.resolve(facets);
+    if (url.includes('/session-questions')) return Promise.resolve(session);
+    if (url.includes('/member/interview-questions')) return Promise.resolve(bank);
+    return Promise.resolve([]);
+  });
+}
+
+const renderPanel = () =>
+  render(<InterviewQuestionPanel interviewId="int-1" round="ROUND_ONE" interviewTitle="W26 Round 1" />);
+
+const openPanel = async () => {
+  fireEvent.click(screen.getByRole('button', { name: 'Interview questions' }));
+  await waitFor(() => expect(screen.getByText(mine.prompt)).toBeInTheDocument());
+};
+
+describe('InterviewQuestionPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useAuth.mockReturnValue({ user: me });
+    mockGets();
+  });
+
+  afterEach(() => vi.useRealTimers());
+
+  it('renders nothing without an interview', () => {
+    const { container } = render(<InterviewQuestionPanel interviewId={null} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('stays out of the way until opened, then shows the queued questions with guidance', async () => {
+    renderPanel();
+    expect(screen.queryByText(mine.prompt)).not.toBeInTheDocument();
+
+    await openPanel();
+    expect(screen.getByText('Why consulting?')).toBeInTheDocument();
+    expect(screen.getByText('Look for ownership.')).toBeInTheDocument();
+    expect(screen.getByText('W26 Round 1 · Round 1')).toBeInTheDocument();
+  });
+
+  it('does not fetch anything while closed', () => {
+    renderPanel();
+    expect(apiClient.get).not.toHaveBeenCalled();
+  });
+
+  it('only offers remove on questions the member added', async () => {
+    renderPanel();
+    await openPanel();
+
+    expect(screen.getByRole('button', { name: `Remove: ${mine.prompt}` })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: `Remove: ${theirs.prompt}` })).not.toBeInTheDocument();
+  });
+
+  it('lets an admin remove anyone’s question', async () => {
+    useAuth.mockReturnValue({ user: { id: 'admin-1', role: 'ADMIN' } });
+    renderPanel();
+    await openPanel();
+
+    expect(screen.getByRole('button', { name: `Remove: ${theirs.prompt}` })).toBeInTheDocument();
+  });
+
+  it('polls with a watermark taken from the rows, and drops tombstoned questions', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    renderPanel();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Interview questions' }));
+    await waitFor(() => expect(screen.getByText(mine.prompt)).toBeInTheDocument());
+
+    // The next poll reports that someone soft-deleted the second question.
+    apiClient.get.mockImplementation((url) => {
+      if (url.includes('/interview-questions/facets')) return Promise.resolve(facets);
+      if (url.includes('/session-questions')) {
+        return Promise.resolve([
+          { ...theirs, deletedAt: '2026-08-27T10:05:00.000Z', updatedAt: '2026-08-27T10:05:00.000Z' },
+        ]);
+      }
+      return Promise.resolve([]);
+    });
+
+    await act(async () => { vi.advanceTimersByTime(10000); });
+
+    await waitFor(() => expect(screen.queryByText(theirs.prompt)).not.toBeInTheDocument());
+    expect(screen.getByText(mine.prompt)).toBeInTheDocument();
+
+    // The since value is the newest updatedAt seen, not the browser clock.
+    const pollUrl = apiClient.get.mock.calls.map((c) => c[0]).find((u) => u.includes('since='));
+    expect(pollUrl).toContain(encodeURIComponent(theirs.updatedAt));
+  });
+
+  it('adds an ad-hoc question without waiting for the next poll', async () => {
+    const created = { ...theirs, id: 'sq-3', prompt: 'Anything for us?', addedBy: 'me-1', position: 2, updatedAt: '2026-08-27T10:02:00.000Z' };
+    apiClient.post.mockResolvedValue(created);
+    renderPanel();
+    await openPanel();
+
+    fireEvent.change(screen.getByLabelText('Add a question to this interview'), {
+      target: { value: 'Anything for us?' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Add question' }));
+
+    await waitFor(() => {
+      expect(apiClient.post).toHaveBeenCalledWith('/member/interviews/int-1/session-questions', {
+        prompt: 'Anything for us?',
+      });
+    });
+    expect(await screen.findByText('Anything for us?')).toBeInTheDocument();
+  });
+
+  it('adds from the bank and marks what is already queued', async () => {
+    apiClient.post.mockResolvedValue({ ...mine, id: 'sq-9', questionBankId: 'bank-2', prompt: 'Size the LA scooter market.', position: 2, updatedAt: '2026-08-27T10:03:00.000Z' });
+    renderPanel();
+    await openPanel();
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Question bank' }));
+    await waitFor(() => expect(screen.getByText('Size the LA scooter market.')).toBeInTheDocument());
+
+    // bank-1 is already in the session, so it cannot be added twice.
+    expect(screen.getByRole('button', { name: /Already added/ })).toBeDisabled();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add: Size the LA scooter market.' }));
+    await waitFor(() => {
+      expect(apiClient.post).toHaveBeenCalledWith(
+        '/member/interviews/int-1/session-questions/bank',
+        { questionId: 'bank-2' }
+      );
+    });
+  });
+
+  it('defaults the bank filter to the round being interviewed', async () => {
+    renderPanel();
+    await openPanel();
+    fireEvent.click(screen.getByRole('tab', { name: 'Question bank' }));
+
+    await waitFor(() => {
+      expect(apiClient.get).toHaveBeenCalledWith(
+        expect.stringContaining('/member/interview-questions?round=ROUND_ONE')
+      );
+    });
+  });
+
+  it('sends the whole order on reorder', async () => {
+    apiClient.patch.mockResolvedValue([
+      { ...theirs, position: 0 },
+      { ...mine, position: 1 },
+    ]);
+    renderPanel();
+    await openPanel();
+
+    fireEvent.click(screen.getByRole('button', { name: `Move down: ${mine.prompt}` }));
+
+    await waitFor(() => {
+      expect(apiClient.patch).toHaveBeenCalledWith(
+        '/member/interviews/int-1/session-questions/reorder',
+        { order: ['sq-2', 'sq-1'] }
+      );
+    });
+  });
+
+  it('resyncs and explains itself when someone else changed the list mid-reorder', async () => {
+    apiClient.patch.mockRejectedValue(new Error('order must list every active question (Status: 409)'));
+    renderPanel();
+    await openPanel();
+
+    const getsBefore = apiClient.get.mock.calls.length;
+    fireEvent.click(screen.getByRole('button', { name: `Move down: ${mine.prompt}` }));
+
+    expect(await screen.findByText('Another interviewer changed the list. Reloaded.')).toBeInTheDocument();
+    await waitFor(() => expect(apiClient.get.mock.calls.length).toBeGreaterThan(getsBefore));
+    // A resync must be a full read - the local watermark is no longer trustworthy.
+    const last = apiClient.get.mock.calls.at(-1)[0];
+    expect(last).not.toContain('since=');
+  });
+
+  it('surfaces a failed load rather than showing an empty question list', async () => {
+    apiClient.get.mockImplementation((url) => {
+      if (url.includes('/interview-questions/facets')) return Promise.resolve(facets);
+      return Promise.reject(new Error('Not assigned to this interview (Status: 403)'));
+    });
+    renderPanel();
+    fireEvent.click(screen.getByRole('button', { name: 'Interview questions' }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Not assigned to this interview');
+  });
+});

--- a/client/src/pages/AdminQuestionBank.jsx
+++ b/client/src/pages/AdminQuestionBank.jsx
@@ -1,0 +1,630 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import apiClient from '../utils/api';
+import AccessControl from '../components/AccessControl';
+import {
+  Box,
+  Typography,
+  Paper,
+  Stack,
+  Button,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TablePagination,
+  TableRow,
+  Chip,
+  CircularProgress,
+  Alert,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogContentText,
+  DialogActions,
+  TextField,
+  Select,
+  MenuItem,
+  FormControl,
+  InputLabel,
+  IconButton,
+  Tooltip,
+  Autocomplete,
+  InputAdornment,
+} from '@mui/material';
+import {
+  Add as AddIcon,
+  Edit as EditIcon,
+  Delete as DeleteIcon,
+  QuizOutlined as QuizIcon,
+  Search as SearchIcon,
+} from '@mui/icons-material';
+
+// `round` is a free-text column, so nothing stops two admins from typing "Round 1" and
+// "ROUND_ONE" for the same round. The picker is constrained to the InterviewType values
+// the rest of the app uses; any other value already in the data is still offered (and
+// labelled) so existing questions stay editable rather than silently rewritten.
+const ROUND_LABELS = {
+  COFFEE_CHAT: 'Coffee Chat',
+  ROUND_ONE: 'Round 1',
+  ROUND_TWO: 'Round 2',
+  FINAL_ROUND: 'Final Round',
+  DELIBERATIONS: 'Deliberations',
+};
+
+const STATUS_COLORS = {
+  DRAFT: 'default',
+  PUBLISHED: 'success',
+  ARCHIVED: 'warning',
+};
+
+const STATUSES = ['DRAFT', 'PUBLISHED', 'ARCHIVED'];
+
+const emptyQuestion = {
+  prompt: '',
+  guidance: '',
+  round: '',
+  category: '',
+  status: 'DRAFT',
+};
+
+function roundLabel(round) {
+  return ROUND_LABELS[round] || round;
+}
+
+function formatDate(value) {
+  if (!value) return '—';
+  return new Date(value).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    timeZone: 'America/Los_Angeles',
+  });
+}
+
+export default function AdminQuestionBank() {
+  const [cycles, setCycles] = useState([]);
+  const [cycleId, setCycleId] = useState('');
+  const [questions, setQuestions] = useState([]);
+  const [facets, setFacets] = useState({ categories: [], rounds: [] });
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  const [roundFilter, setRoundFilter] = useState('');
+  const [categoryFilter, setCategoryFilter] = useState('');
+  const [statusFilter, setStatusFilter] = useState('');
+  const [search, setSearch] = useState('');
+  const [page, setPage] = useState(0);
+  const [rowsPerPage, setRowsPerPage] = useState(25);
+
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [dialogMode, setDialogMode] = useState('create');
+  const [editingId, setEditingId] = useState(null);
+  const [form, setForm] = useState(emptyQuestion);
+  const [saving, setSaving] = useState(false);
+
+  const [deleteTarget, setDeleteTarget] = useState(null);
+
+  useEffect(() => {
+    apiClient
+      .get('/admin/cycles')
+      .then((data) => {
+        const list = Array.isArray(data) ? data : [];
+        setCycles(list);
+      })
+      .catch(() => setCycles([]));
+
+    apiClient
+      .get('/admin/cycles/active')
+      .then((active) => {
+        if (active?.id) setCycleId(active.id);
+      })
+      .catch(() => {});
+  }, []);
+
+  const fetchQuestions = () => {
+    setLoading(true);
+    setError(null);
+    const params = new URLSearchParams();
+    if (cycleId) params.set('cycleId', cycleId);
+    if (roundFilter) params.set('round', roundFilter);
+    if (categoryFilter) params.set('category', categoryFilter);
+    if (statusFilter) params.set('status', statusFilter);
+    const qs = params.toString();
+
+    apiClient
+      .get(`/admin/interview-questions${qs ? `?${qs}` : ''}`)
+      .then((data) => setQuestions(Array.isArray(data) ? data : []))
+      .catch((e) => setError(e.message || 'Failed to load questions.'))
+      .finally(() => setLoading(false));
+  };
+
+  const fetchFacets = () => {
+    const qs = cycleId ? `?cycleId=${encodeURIComponent(cycleId)}` : '';
+    apiClient
+      .get(`/admin/interview-questions/facets${qs}`)
+      .then((data) =>
+        setFacets({
+          categories: Array.isArray(data?.categories) ? data.categories : [],
+          rounds: Array.isArray(data?.rounds) ? data.rounds : [],
+        })
+      )
+      .catch(() => setFacets({ categories: [], rounds: [] }));
+  };
+
+  useEffect(() => {
+    fetchQuestions();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [cycleId, roundFilter, categoryFilter, statusFilter]);
+
+  useEffect(() => {
+    fetchFacets();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [cycleId]);
+
+  useEffect(() => {
+    setPage(0);
+  }, [cycleId, roundFilter, categoryFilter, statusFilter, search]);
+
+  // The list endpoint has no server-side search or paging yet, so both are applied here.
+  // That is fine at bank sizes of a few hundred; past that this needs to move server-side.
+  const filtered = useMemo(() => {
+    const needle = search.trim().toLowerCase();
+    if (!needle) return questions;
+    return questions.filter(
+      (q) =>
+        (q.prompt || '').toLowerCase().includes(needle) ||
+        (q.guidance || '').toLowerCase().includes(needle) ||
+        (q.category || '').toLowerCase().includes(needle)
+    );
+  }, [questions, search]);
+
+  const paged = useMemo(
+    () => filtered.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage),
+    [filtered, page, rowsPerPage]
+  );
+
+  const roundOptions = useMemo(() => {
+    const known = Object.keys(ROUND_LABELS);
+    const extra = facets.rounds.filter((r) => !known.includes(r));
+    return [...known, ...extra];
+  }, [facets.rounds]);
+
+  const openCreate = () => {
+    setDialogMode('create');
+    setEditingId(null);
+    setForm({ ...emptyQuestion, round: roundFilter || '' });
+    setError(null);
+    setDialogOpen(true);
+  };
+
+  const openEdit = (question) => {
+    setDialogMode('edit');
+    setEditingId(question.id);
+    setForm({
+      prompt: question.prompt || '',
+      guidance: question.guidance || '',
+      round: question.round || '',
+      category: question.category || '',
+      status: question.status || 'DRAFT',
+    });
+    setError(null);
+    setDialogOpen(true);
+  };
+
+  const handleChange = (field, value) => setForm((prev) => ({ ...prev, [field]: value }));
+
+  const handleSave = async () => {
+    if (!form.prompt.trim()) {
+      setError('Prompt is required.');
+      return;
+    }
+    if (!form.round) {
+      setError('Round is required.');
+      return;
+    }
+    if (dialogMode === 'create' && !cycleId) {
+      setError('Select a cycle before adding a question.');
+      return;
+    }
+
+    setSaving(true);
+    setError(null);
+    try {
+      const payload = {
+        prompt: form.prompt.trim(),
+        guidance: form.guidance.trim() || null,
+        round: form.round,
+        category: form.category.trim() || null,
+      };
+
+      if (dialogMode === 'create') {
+        await apiClient.post('/admin/interview-questions', {
+          ...payload,
+          cycleId,
+          status: form.status,
+        });
+      } else {
+        // PUT does not accept status - it is moved through its own endpoint so a
+        // publish is a deliberate action rather than a side effect of an edit.
+        await apiClient.put(`/admin/interview-questions/${editingId}`, payload);
+      }
+
+      setDialogOpen(false);
+      fetchQuestions();
+      fetchFacets();
+    } catch (e) {
+      setError(e.message || 'Failed to save question.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleStatusChange = async (question, status) => {
+    setError(null);
+    try {
+      await apiClient.patch(`/admin/interview-questions/${question.id}/status`, { status });
+      fetchQuestions();
+    } catch (e) {
+      setError(e.message || 'Failed to update status.');
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!deleteTarget) return;
+    setError(null);
+    try {
+      await apiClient.delete(`/admin/interview-questions/${deleteTarget.id}`);
+      setDeleteTarget(null);
+      fetchQuestions();
+      fetchFacets();
+    } catch (e) {
+      setError(e.message || 'Failed to delete question.');
+    }
+  };
+
+  const publishedCount = questions.filter((q) => q.status === 'PUBLISHED').length;
+
+  return (
+    <AccessControl allowedRoles={['ADMIN']}>
+      <Box sx={{ p: { xs: 2, md: 3 }, maxWidth: 1400 }}>
+        <Stack
+          direction={{ xs: 'column', sm: 'row' }}
+          spacing={2}
+          alignItems={{ xs: 'flex-start', sm: 'center' }}
+          justifyContent="space-between"
+          mb={3}
+        >
+          <Stack direction="row" spacing={1} alignItems="center">
+            <QuizIcon color="primary" />
+            <Box>
+              <Typography variant="h4" component="h1">
+                Question Bank
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                Only published questions appear to interviewers.
+              </Typography>
+            </Box>
+          </Stack>
+          <Button variant="contained" startIcon={<AddIcon />} onClick={openCreate}>
+            New question
+          </Button>
+        </Stack>
+
+        {error && (
+          <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError(null)}>
+            {error}
+          </Alert>
+        )}
+
+        <Paper sx={{ p: 2, mb: 2 }}>
+          <Stack direction={{ xs: 'column', md: 'row' }} spacing={2}>
+            <FormControl size="small" sx={{ minWidth: 220 }}>
+              <InputLabel id="qb-cycle-label">Cycle</InputLabel>
+              <Select
+                labelId="qb-cycle-label"
+                id="qb-cycle"
+                value={cycleId}
+                label="Cycle"
+                onChange={(e) => setCycleId(e.target.value)}
+              >
+                {cycles.map((c) => (
+                  <MenuItem key={c.id} value={c.id}>
+                    {c.name}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+
+            <FormControl size="small" sx={{ minWidth: 160 }}>
+              <InputLabel id="qb-round-filter-label">Round</InputLabel>
+              <Select
+                labelId="qb-round-filter-label"
+                id="qb-round-filter"
+                value={roundFilter}
+                label="Round"
+                onChange={(e) => setRoundFilter(e.target.value)}
+              >
+                <MenuItem value="">All rounds</MenuItem>
+                {facets.rounds.map((r) => (
+                  <MenuItem key={r} value={r}>
+                    {roundLabel(r)}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+
+            <FormControl size="small" sx={{ minWidth: 160 }}>
+              <InputLabel id="qb-category-filter-label">Category</InputLabel>
+              <Select
+                labelId="qb-category-filter-label"
+                id="qb-category-filter"
+                value={categoryFilter}
+                label="Category"
+                onChange={(e) => setCategoryFilter(e.target.value)}
+              >
+                <MenuItem value="">All categories</MenuItem>
+                {facets.categories.map((c) => (
+                  <MenuItem key={c} value={c}>
+                    {c}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+
+            <FormControl size="small" sx={{ minWidth: 150 }}>
+              <InputLabel id="qb-status-filter-label">Status</InputLabel>
+              <Select
+                labelId="qb-status-filter-label"
+                id="qb-status-filter"
+                value={statusFilter}
+                label="Status"
+                onChange={(e) => setStatusFilter(e.target.value)}
+              >
+                <MenuItem value="">All statuses</MenuItem>
+                {STATUSES.map((s) => (
+                  <MenuItem key={s} value={s}>
+                    {s.charAt(0) + s.slice(1).toLowerCase()}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+
+            <TextField
+              size="small"
+              placeholder="Search prompt, guidance, category"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              sx={{ flexGrow: 1, minWidth: 240 }}
+              InputProps={{
+                startAdornment: (
+                  <InputAdornment position="start">
+                    <SearchIcon fontSize="small" />
+                  </InputAdornment>
+                ),
+              }}
+            />
+          </Stack>
+        </Paper>
+
+        <Paper>
+          {loading ? (
+            <Box sx={{ display: 'flex', justifyContent: 'center', p: 6 }}>
+              <CircularProgress />
+            </Box>
+          ) : filtered.length === 0 ? (
+            <Box sx={{ p: 6, textAlign: 'center' }}>
+              <Typography variant="body1" color="text.secondary">
+                {questions.length === 0
+                  ? 'No questions in this cycle yet.'
+                  : 'No questions match these filters.'}
+              </Typography>
+            </Box>
+          ) : (
+            <>
+              <TableContainer>
+                <Table>
+                  <TableHead>
+                    <TableRow>
+                      <TableCell>Prompt</TableCell>
+                      <TableCell sx={{ width: 140 }}>Round</TableCell>
+                      <TableCell sx={{ width: 150 }}>Category</TableCell>
+                      <TableCell sx={{ width: 160 }}>Status</TableCell>
+                      <TableCell sx={{ width: 110 }}>Updated</TableCell>
+                      <TableCell sx={{ width: 110 }} align="right">
+                        Actions
+                      </TableCell>
+                    </TableRow>
+                  </TableHead>
+                  <TableBody>
+                    {paged.map((q) => (
+                      <TableRow key={q.id} hover>
+                        <TableCell>
+                          <Typography variant="body2">{q.prompt}</Typography>
+                          {q.guidance && (
+                            <Typography variant="caption" color="text.secondary">
+                              {q.guidance}
+                            </Typography>
+                          )}
+                        </TableCell>
+                        <TableCell>
+                          <Chip size="small" label={roundLabel(q.round)} variant="outlined" />
+                        </TableCell>
+                        <TableCell>
+                          <Typography variant="body2" color="text.secondary">
+                            {q.category || '—'}
+                          </Typography>
+                        </TableCell>
+                        <TableCell>
+                          <Select
+                            size="small"
+                            inputProps={{ 'aria-label': `Status for: ${q.prompt}` }}
+                            value={q.status}
+                            onChange={(e) => handleStatusChange(q, e.target.value)}
+                            variant="standard"
+                            disableUnderline
+                            renderValue={(value) => (
+                              <Chip
+                                size="small"
+                                label={value.charAt(0) + value.slice(1).toLowerCase()}
+                                color={STATUS_COLORS[value] || 'default'}
+                              />
+                            )}
+                          >
+                            {STATUSES.map((s) => (
+                              <MenuItem key={s} value={s}>
+                                {s.charAt(0) + s.slice(1).toLowerCase()}
+                              </MenuItem>
+                            ))}
+                          </Select>
+                        </TableCell>
+                        <TableCell>
+                          <Typography variant="caption" color="text.secondary">
+                            {formatDate(q.updatedAt || q.createdAt)}
+                          </Typography>
+                        </TableCell>
+                        <TableCell align="right">
+                          <Tooltip title="Edit">
+                            <IconButton size="small" onClick={() => openEdit(q)}>
+                              <EditIcon fontSize="small" />
+                            </IconButton>
+                          </Tooltip>
+                          <Tooltip title="Delete">
+                            <IconButton size="small" onClick={() => setDeleteTarget(q)}>
+                              <DeleteIcon fontSize="small" />
+                            </IconButton>
+                          </Tooltip>
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </TableContainer>
+              <TablePagination
+                component="div"
+                count={filtered.length}
+                page={page}
+                onPageChange={(e, next) => setPage(next)}
+                rowsPerPage={rowsPerPage}
+                onRowsPerPageChange={(e) => {
+                  setRowsPerPage(parseInt(e.target.value, 10));
+                  setPage(0);
+                }}
+                rowsPerPageOptions={[10, 25, 50, 100]}
+              />
+            </>
+          )}
+        </Paper>
+
+        <Typography variant="caption" color="text.secondary" sx={{ mt: 1, display: 'block' }}>
+          {questions.length} question{questions.length === 1 ? '' : 's'} in this cycle ·{' '}
+          {publishedCount} visible to interviewers
+        </Typography>
+
+        <Dialog open={dialogOpen} onClose={() => setDialogOpen(false)} maxWidth="sm" fullWidth>
+          <DialogTitle>{dialogMode === 'create' ? 'New question' : 'Edit question'}</DialogTitle>
+          <DialogContent>
+            <Stack spacing={2} sx={{ mt: 1 }}>
+              <TextField
+                label="Prompt"
+                value={form.prompt}
+                onChange={(e) => handleChange('prompt', e.target.value)}
+                multiline
+                minRows={2}
+                fullWidth
+                required
+              />
+              <TextField
+                label="Guidance for the interviewer"
+                value={form.guidance}
+                onChange={(e) => handleChange('guidance', e.target.value)}
+                multiline
+                minRows={3}
+                fullWidth
+                helperText="Shown alongside the question during the interview. Optional."
+              />
+              <FormControl fullWidth required>
+                <InputLabel id="qb-form-round-label">Round</InputLabel>
+                <Select
+                  labelId="qb-form-round-label"
+                  id="qb-form-round"
+                  value={form.round}
+                  label="Round"
+                  onChange={(e) => handleChange('round', e.target.value)}
+                >
+                  {roundOptions.map((r) => (
+                    <MenuItem key={r} value={r}>
+                      {roundLabel(r)}
+                      {!ROUND_LABELS[r] && ' (legacy value)'}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+              <Autocomplete
+                freeSolo
+                options={facets.categories}
+                value={form.category}
+                onChange={(e, value) => handleChange('category', value || '')}
+                onInputChange={(e, value) => handleChange('category', value || '')}
+                renderInput={(params) => (
+                  <TextField
+                    {...params}
+                    label="Category"
+                    helperText="Pick an existing category or type a new one. Optional."
+                  />
+                )}
+              />
+              {dialogMode === 'create' && (
+                <FormControl fullWidth>
+                  <InputLabel id="qb-form-status-label">Status</InputLabel>
+                  <Select
+                    labelId="qb-form-status-label"
+                    id="qb-form-status"
+                    value={form.status}
+                    label="Status"
+                    onChange={(e) => handleChange('status', e.target.value)}
+                  >
+                    {STATUSES.map((s) => (
+                      <MenuItem key={s} value={s}>
+                        {s.charAt(0) + s.slice(1).toLowerCase()}
+                      </MenuItem>
+                    ))}
+                  </Select>
+                </FormControl>
+              )}
+            </Stack>
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={() => setDialogOpen(false)}>Cancel</Button>
+            <Button variant="contained" onClick={handleSave} disabled={saving}>
+              {saving ? 'Saving…' : 'Save'}
+            </Button>
+          </DialogActions>
+        </Dialog>
+
+        <Dialog open={Boolean(deleteTarget)} onClose={() => setDeleteTarget(null)}>
+          <DialogTitle>Delete this question?</DialogTitle>
+          <DialogContent>
+            <DialogContentText component="div">
+              <Typography variant="body2" sx={{ mb: 2 }}>
+                “{deleteTarget?.prompt}”
+              </Typography>
+              <Typography variant="body2">
+                This removes it from the bank permanently. Interviews that already used it
+                keep their own copy of the wording, so past sessions are unaffected. To take
+                a question out of circulation without deleting it, set it to Archived
+                instead.
+              </Typography>
+            </DialogContentText>
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={() => setDeleteTarget(null)}>Cancel</Button>
+            <Button color="error" variant="contained" onClick={handleDelete}>
+              Delete
+            </Button>
+          </DialogActions>
+        </Dialog>
+      </Box>
+    </AccessControl>
+  );
+}

--- a/client/src/pages/AdminQuestionBank.test.jsx
+++ b/client/src/pages/AdminQuestionBank.test.jsx
@@ -1,0 +1,209 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent, within } from '@testing-library/react';
+import AdminQuestionBank from './AdminQuestionBank';
+
+vi.mock('../utils/api', () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+vi.mock('../context/AuthContext', () => ({
+  useAuth: vi.fn(),
+}));
+
+import apiClient from '../utils/api';
+import { useAuth } from '../context/AuthContext';
+
+const adminUser = { id: 'admin-1', fullName: 'Admin User', role: 'ADMIN' };
+const memberUser = { id: 'member-1', fullName: 'Member User', role: 'MEMBER' };
+
+const cycles = [{ id: 'cycle-1', name: 'Fall 2026' }];
+
+const questions = [
+  {
+    id: 'q-1',
+    cycleId: 'cycle-1',
+    prompt: 'Walk me through a time you led a team.',
+    guidance: 'Look for ownership.',
+    round: 'ROUND_ONE',
+    category: 'Behavioral',
+    status: 'PUBLISHED',
+    updatedAt: '2026-08-20T00:00:00.000Z',
+  },
+  {
+    id: 'q-2',
+    cycleId: 'cycle-1',
+    prompt: 'Size the market for electric scooters in LA.',
+    guidance: null,
+    round: 'ROUND_TWO',
+    category: 'Casing',
+    status: 'DRAFT',
+    updatedAt: '2026-08-21T00:00:00.000Z',
+  },
+];
+
+const facets = { categories: ['Behavioral', 'Casing'], rounds: ['ROUND_ONE', 'ROUND_TWO'] };
+
+function mockGets({ questionList = questions } = {}) {
+  apiClient.get.mockImplementation((url) => {
+    if (url === '/admin/cycles') return Promise.resolve(cycles);
+    if (url === '/admin/cycles/active') return Promise.resolve({ id: 'cycle-1', name: 'Fall 2026' });
+    if (url.startsWith('/admin/interview-questions/facets')) return Promise.resolve(facets);
+    if (url.startsWith('/admin/interview-questions')) return Promise.resolve(questionList);
+    return Promise.resolve([]);
+  });
+}
+
+describe('AdminQuestionBank', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useAuth.mockReturnValue({ user: adminUser });
+    mockGets();
+  });
+
+  it('blocks non-admins', () => {
+    useAuth.mockReturnValue({ user: memberUser });
+    render(<AdminQuestionBank />);
+    expect(screen.getByText('Access Denied')).toBeInTheDocument();
+    expect(screen.queryByText('Question Bank')).not.toBeInTheDocument();
+  });
+
+  it('lists questions for the active cycle and labels rounds readably', async () => {
+    render(<AdminQuestionBank />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Walk me through a time you led a team.')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Size the market for electric scooters in LA.')).toBeInTheDocument();
+    expect(screen.getByText('Round 1')).toBeInTheDocument();
+    expect(screen.getByText('Round 2')).toBeInTheDocument();
+
+    // The cycle is resolved before the list is fetched, so the request is scoped.
+    await waitFor(() => {
+      expect(apiClient.get).toHaveBeenCalledWith(
+        expect.stringContaining('/admin/interview-questions?cycleId=cycle-1')
+      );
+    });
+  });
+
+  it('reports how many questions interviewers can actually see', async () => {
+    render(<AdminQuestionBank />);
+    await waitFor(() => {
+      expect(screen.getByText(/1 visible to interviewers/)).toBeInTheDocument();
+    });
+  });
+
+  it('filters client-side on search without refetching', async () => {
+    render(<AdminQuestionBank />);
+    await waitFor(() => {
+      expect(screen.getByText('Walk me through a time you led a team.')).toBeInTheDocument();
+    });
+
+    const callsBefore = apiClient.get.mock.calls.length;
+    fireEvent.change(screen.getByPlaceholderText(/Search prompt/i), {
+      target: { value: 'scooters' },
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText('Walk me through a time you led a team.')).not.toBeInTheDocument();
+    });
+    expect(screen.getByText('Size the market for electric scooters in LA.')).toBeInTheDocument();
+    expect(apiClient.get.mock.calls.length).toBe(callsBefore);
+  });
+
+  it('creates a question against the selected cycle', async () => {
+    apiClient.post.mockResolvedValue({ id: 'q-3' });
+    render(<AdminQuestionBank />);
+    await waitFor(() => expect(screen.getByText('Round 1')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole('button', { name: /New question/i }));
+
+    fireEvent.change(screen.getByLabelText(/Prompt/i), {
+      target: { value: 'Why consulting?' },
+    });
+
+    const dialog = screen.getByRole('dialog');
+    fireEvent.mouseDown(within(dialog).getByRole('combobox', { name: /Round/ }));
+    fireEvent.click(await screen.findByRole('option', { name: 'Coffee Chat' }));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      expect(apiClient.post).toHaveBeenCalledWith('/admin/interview-questions', {
+        prompt: 'Why consulting?',
+        guidance: null,
+        round: 'COFFEE_CHAT',
+        category: null,
+        cycleId: 'cycle-1',
+        status: 'DRAFT',
+      });
+    });
+  });
+
+  it('refuses to save without a prompt', async () => {
+    render(<AdminQuestionBank />);
+    await waitFor(() => expect(screen.getByText('Round 1')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole('button', { name: /New question/i }));
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Prompt is required.')).toBeInTheDocument();
+    });
+    expect(apiClient.post).not.toHaveBeenCalled();
+  });
+
+  it('moves status through the dedicated status endpoint, not the edit endpoint', async () => {
+    apiClient.patch.mockResolvedValue({ ...questions[1], status: 'PUBLISHED' });
+    render(<AdminQuestionBank />);
+    await waitFor(() => expect(screen.getByText('Draft')).toBeInTheDocument());
+
+    fireEvent.mouseDown(screen.getByText('Draft'));
+    fireEvent.click(await screen.findByRole('option', { name: 'Published' }));
+
+    await waitFor(() => {
+      expect(apiClient.patch).toHaveBeenCalledWith('/admin/interview-questions/q-2/status', {
+        status: 'PUBLISHED',
+      });
+    });
+    expect(apiClient.put).not.toHaveBeenCalled();
+  });
+
+  it('warns that deleting keeps past interview copies, and deletes on confirm', async () => {
+    apiClient.delete.mockResolvedValue({ success: true });
+    render(<AdminQuestionBank />);
+    await waitFor(() => expect(screen.getByText('Round 1')).toBeInTheDocument());
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Delete' })[0]);
+
+    expect(await screen.findByText('Delete this question?')).toBeInTheDocument();
+    expect(screen.getByText(/keep their own copy of the wording/i)).toBeInTheDocument();
+
+    const dialog = screen.getByRole('dialog');
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Delete' }));
+
+    await waitFor(() => {
+      expect(apiClient.delete).toHaveBeenCalledWith('/admin/interview-questions/q-1');
+    });
+  });
+
+  it('surfaces a load failure instead of rendering an empty bank', async () => {
+    apiClient.get.mockImplementation((url) => {
+      if (url === '/admin/cycles') return Promise.resolve(cycles);
+      if (url === '/admin/cycles/active') return Promise.resolve({ id: 'cycle-1' });
+      if (url.startsWith('/admin/interview-questions/facets')) return Promise.resolve(facets);
+      return Promise.reject(new Error('Failed to fetch interview questions (Status: 500)'));
+    });
+
+    render(<AdminQuestionBank />);
+    await waitFor(() => {
+      expect(screen.getByText(/Failed to fetch interview questions/)).toBeInTheDocument();
+    });
+  });
+});

--- a/client/src/pages/FinalRoundInterviewInterface.jsx
+++ b/client/src/pages/FinalRoundInterviewInterface.jsx
@@ -20,6 +20,7 @@ import AccessControl from '../components/AccessControl';
 import DocumentPreviewModal from '../components/DocumentPreviewModal';
 import AuthenticatedImage from '../components/AuthenticatedImage';
 import InterviewChatWidget from '../components/chat/InterviewChatWidget';
+import InterviewQuestionPanel from '../components/interview/InterviewQuestionPanel';
 import CaseViewer from '../components/case/CaseViewer';
 import { usePreviewActive } from '../utils/previewMode';
 import '../styles/FinalRoundInterviewInterface.css';
@@ -917,9 +918,17 @@ export default function FinalRoundInterviewInterface() {
             title={preview.title}
           />
         )}
-        {/* Chat is hidden entirely during candidate preview so nothing pops over the exhibit. */}
+        {/* Chat and the question panel are hidden entirely during candidate preview so
+            nothing pops over the exhibit. */}
         {!candidatePreviewActive && (
-          <InterviewChatWidget interviewId={interviewId} interviewTitle={interview?.title} />
+          <>
+            <InterviewChatWidget interviewId={interviewId} interviewTitle={interview?.title} />
+            <InterviewQuestionPanel
+              interviewId={interviewId}
+              round={interview?.interviewType}
+              interviewTitle={interview?.title}
+            />
+          </>
         )}
       </div>
     </AccessControl>

--- a/client/src/pages/FirstRoundInterviewInterface.jsx
+++ b/client/src/pages/FirstRoundInterviewInterface.jsx
@@ -17,6 +17,7 @@ import AccessControl from '../components/AccessControl';
 import DocumentPreviewModal from '../components/DocumentPreviewModal';
 import AuthenticatedImage from '../components/AuthenticatedImage';
 import InterviewChatWidget from '../components/chat/InterviewChatWidget';
+import InterviewQuestionPanel from '../components/interview/InterviewQuestionPanel';
 import '../styles/FirstRoundInterviewInterface.css';
 
 export default function FirstRoundInterviewInterface() {
@@ -1166,6 +1167,11 @@ export default function FirstRoundInterviewInterface() {
           />
         )}
         <InterviewChatWidget interviewId={interviewId} interviewTitle={interview?.title} />
+        <InterviewQuestionPanel
+          interviewId={interviewId}
+          round={interview?.interviewType}
+          interviewTitle={interview?.title}
+        />
       </div>
     </AccessControl>
   );

--- a/client/src/pages/InterviewInterface.jsx
+++ b/client/src/pages/InterviewInterface.jsx
@@ -9,6 +9,7 @@ import {
 import apiClient from '../utils/api';
 import AccessControl from '../components/AccessControl';
 import InterviewChatWidget from '../components/chat/InterviewChatWidget';
+import InterviewQuestionPanel from '../components/interview/InterviewQuestionPanel';
 import '../styles/InterviewInterface.css';
 
 export default function InterviewInterface() {
@@ -641,6 +642,11 @@ export default function InterviewInterface() {
         </div>
       )}
       <InterviewChatWidget interviewId={interviewId} interviewTitle={interview?.title} />
+      <InterviewQuestionPanel
+        interviewId={interviewId}
+        round={interview?.interviewType}
+        interviewTitle={interview?.title}
+      />
     </div>
     </AccessControl>
   );

--- a/client/src/pages/MemberInterviewInterface.jsx
+++ b/client/src/pages/MemberInterviewInterface.jsx
@@ -9,6 +9,7 @@ import {
 import apiClient from '../utils/api';
 import AccessControl from '../components/AccessControl';
 import InterviewChatWidget from '../components/chat/InterviewChatWidget';
+import InterviewQuestionPanel from '../components/interview/InterviewQuestionPanel';
 import '../styles/InterviewInterface.css';
 
 export default function MemberInterviewInterface() {
@@ -633,6 +634,11 @@ export default function MemberInterviewInterface() {
         </div>
       )}
       <InterviewChatWidget interviewId={interviewId} interviewTitle={interview?.title} />
+      <InterviewQuestionPanel
+        interviewId={interviewId}
+        round={interview?.interviewType}
+        interviewTitle={interview?.title}
+      />
     </div>
     </AccessControl>
   );

--- a/server/prisma/migrations/20260827060000_add_interview_questions/migration.sql
+++ b/server/prisma/migrations/20260827060000_add_interview_questions/migration.sql
@@ -1,0 +1,20 @@
+-- Interview question bank (ATS-23 / ATS-68)
+
+CREATE TABLE IF NOT EXISTS "interview_questions" (
+    "id" TEXT NOT NULL,
+    "cycleId" TEXT NOT NULL,
+    "prompt" TEXT NOT NULL,
+    "guidance" TEXT,
+    "round" TEXT NOT NULL,
+    "category" TEXT,
+    "status" TEXT NOT NULL DEFAULT 'DRAFT',
+    "createdBy" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    CONSTRAINT "interview_questions_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX IF NOT EXISTS "interview_questions_cycleId_idx" ON "interview_questions"("cycleId");
+CREATE INDEX IF NOT EXISTS "interview_questions_round_idx" ON "interview_questions"("round");
+CREATE INDEX IF NOT EXISTS "interview_questions_category_idx" ON "interview_questions"("category");
+CREATE INDEX IF NOT EXISTS "interview_questions_status_idx" ON "interview_questions"("status");

--- a/server/prisma/migrations/20260827070000_add_interview_session_questions/migration.sql
+++ b/server/prisma/migrations/20260827070000_add_interview_session_questions/migration.sql
@@ -1,0 +1,16 @@
+-- Live interview session questions (ATS-13 / ATS-69)
+
+CREATE TABLE IF NOT EXISTS "interview_session_questions" (
+    "id" TEXT NOT NULL,
+    "interviewId" TEXT NOT NULL,
+    "prompt" TEXT NOT NULL,
+    "addedBy" TEXT NOT NULL,
+    "position" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "interview_session_questions_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX IF NOT EXISTS "interview_session_questions_interviewId_position_idx" ON "interview_session_questions"("interviewId", "position");
+
+ALTER TABLE "interview_session_questions" DROP CONSTRAINT IF EXISTS "interview_session_questions_interviewId_fkey";
+ALTER TABLE "interview_session_questions" ADD CONSTRAINT "interview_session_questions_interviewId_fkey" FOREIGN KEY ("interviewId") REFERENCES "interviews"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/server/prisma/migrations/20260827100000_add_sync_fields_to_session_questions/migration.sql
+++ b/server/prisma/migrations/20260827100000_add_sync_fields_to_session_questions/migration.sql
@@ -1,0 +1,6 @@
+-- Add polling sync fields to live interview session questions (ATS-13)
+
+ALTER TABLE "interview_session_questions" ADD COLUMN IF NOT EXISTS "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;
+ALTER TABLE "interview_session_questions" ADD COLUMN IF NOT EXISTS "deletedAt" TIMESTAMP(3);
+
+CREATE INDEX IF NOT EXISTS "interview_session_questions_interviewId_updatedAt_idx" ON "interview_session_questions"("interviewId", "updatedAt");

--- a/server/prisma/migrations/20260827110000_link_session_to_question_bank/migration.sql
+++ b/server/prisma/migrations/20260827110000_link_session_to_question_bank/migration.sql
@@ -1,0 +1,6 @@
+-- Link interview session questions to the question bank with snapshot fields (ATS-23)
+
+ALTER TABLE "interview_session_questions" ADD COLUMN IF NOT EXISTS "guidance" TEXT;
+ALTER TABLE "interview_session_questions" ADD COLUMN IF NOT EXISTS "questionBankId" TEXT;
+
+CREATE INDEX IF NOT EXISTS "interview_session_questions_questionBankId_idx" ON "interview_session_questions"("questionBankId");

--- a/server/prisma/migrations/20260827120000_fix_interview_question_status_enum/migration.sql
+++ b/server/prisma/migrations/20260827120000_fix_interview_question_status_enum/migration.sql
@@ -1,0 +1,36 @@
+-- The original interview_questions migration declared "status" as TEXT, but the Prisma
+-- model declares it as the InterviewQuestionStatus enum. Prisma casts every status
+-- parameter to public."InterviewQuestionStatus", so with no such type in the database
+-- the entire question bank failed at query time with 42704 (type does not exist).
+-- Create the type and convert the column to match the model.
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_type t
+    JOIN pg_namespace n ON n.oid = t.typnamespace
+    WHERE t.typname = 'InterviewQuestionStatus' AND n.nspname = 'public'
+  ) THEN
+    CREATE TYPE "InterviewQuestionStatus" AS ENUM ('DRAFT', 'PUBLISHED', 'ARCHIVED');
+  END IF;
+END
+$$;
+
+-- Guarded so the file stays safe to re-run: db execute has no transaction wrapper.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'interview_questions'
+      AND column_name = 'status'
+      AND data_type = 'text'
+  ) THEN
+    ALTER TABLE "interview_questions" ALTER COLUMN "status" DROP DEFAULT;
+    ALTER TABLE "interview_questions"
+      ALTER COLUMN "status" TYPE "InterviewQuestionStatus"
+      USING "status"::"InterviewQuestionStatus";
+    ALTER TABLE "interview_questions" ALTER COLUMN "status" SET DEFAULT 'DRAFT';
+  END IF;
+END
+$$;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -898,6 +898,31 @@ model Message {
   @@map("messages")
 }
 
+model InterviewQuestion {
+  id          String                  @id @default(uuid())
+  cycleId     String
+  prompt      String
+  guidance    String?
+  round       String
+  category    String?
+  status      InterviewQuestionStatus @default(DRAFT)
+  createdBy   String
+  createdAt   DateTime                @default(now())
+  updatedAt   DateTime                @updatedAt
+
+  @@index([cycleId])
+  @@index([round])
+  @@index([category])
+  @@index([status])
+  @@map("interview_questions")
+}
+
+enum InterviewQuestionStatus {
+  DRAFT
+  PUBLISHED
+  ARCHIVED
+}
+
 enum ConversationContextType {
   INTERVIEW
   APPLICATION

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -893,6 +893,9 @@ model Message {
   deletedAt      DateTime?
   conversation   Conversation @relation(fields: [conversationId], references: [id], onDelete: Cascade)
   sender         User         @relation("MessageSender", fields: [senderId], references: [id])
+
+  @@index([conversationId, createdAt])
+  @@map("messages")
 }
 
 model InterviewQuestion {
@@ -934,6 +937,7 @@ model InterviewSessionQuestion {
 
   @@index([interviewId, position])
   @@index([interviewId, updatedAt])
+  @@index([questionBankId])
   @@map("interview_session_questions")
 }
 

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -905,8 +905,11 @@ model InterviewSessionQuestion {
   addedBy     String
   position    Int       @default(0)
   createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @updatedAt
+  deletedAt   DateTime?
 
   @@index([interviewId, position])
+  @@index([interviewId, updatedAt])
   @@map("interview_session_questions")
 }
 

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -893,9 +893,6 @@ model Message {
   deletedAt      DateTime?
   conversation   Conversation @relation(fields: [conversationId], references: [id], onDelete: Cascade)
   sender         User         @relation("MessageSender", fields: [senderId], references: [id])
-
-  @@index([conversationId, createdAt])
-  @@map("messages")
 }
 
 model InterviewQuestion {
@@ -921,6 +918,23 @@ enum InterviewQuestionStatus {
   DRAFT
   PUBLISHED
   ARCHIVED
+}
+
+model InterviewSessionQuestion {
+  id          String    @id @default(uuid())
+  interviewId String
+  prompt      String
+  guidance    String?
+  questionBankId String?
+  addedBy     String
+  position    Int       @default(0)
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @updatedAt
+  deletedAt   DateTime?
+
+  @@index([interviewId, position])
+  @@index([interviewId, updatedAt])
+  @@map("interview_session_questions")
 }
 
 enum ConversationContextType {

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -898,6 +898,18 @@ model Message {
   @@map("messages")
 }
 
+model InterviewSessionQuestion {
+  id          String    @id @default(uuid())
+  interviewId String
+  prompt      String
+  addedBy     String
+  position    Int       @default(0)
+  createdAt   DateTime  @default(now())
+
+  @@index([interviewId, position])
+  @@map("interview_session_questions")
+}
+
 enum ConversationContextType {
   INTERVIEW
   APPLICATION

--- a/server/src/routes/admin.js
+++ b/server/src/routes/admin.js
@@ -6154,6 +6154,40 @@ router.put('/interview-questions/:id', async (req, res) => {
   }
 });
 
+// Distinct category and round values in use, for filter dropdowns. Both columns are
+// free text, so the only source of truth for "what can I filter by" is the data itself.
+// Registered ahead of the /:id routes so "facets" is never read as an id.
+router.get('/interview-questions/facets', async (req, res) => {
+  try {
+    const { cycleId } = req.query || {};
+    const where = {};
+    if (cycleId) where.cycleId = String(cycleId);
+
+    const [categories, rounds] = await Promise.all([
+      prisma.interviewQuestion.findMany({
+        where: { ...where, category: { not: null } },
+        distinct: ['category'],
+        select: { category: true },
+        orderBy: { category: 'asc' }
+      }),
+      prisma.interviewQuestion.findMany({
+        where,
+        distinct: ['round'],
+        select: { round: true },
+        orderBy: { round: 'asc' }
+      })
+    ]);
+
+    res.json({
+      categories: categories.map((c) => c.category).filter(Boolean),
+      rounds: rounds.map((r) => r.round).filter(Boolean)
+    });
+  } catch (error) {
+    console.error('[GET /api/admin/interview-questions/facets]', error);
+    res.status(500).json({ error: 'Failed to fetch interview question facets' });
+  }
+});
+
 // Update question status (DRAFT / PUBLISHED / ARCHIVED)
 router.patch('/interview-questions/:id/status', async (req, res) => {
   try {
@@ -6177,6 +6211,31 @@ router.patch('/interview-questions/:id/status', async (req, res) => {
       return res.status(404).json({ error: 'Interview question not found' });
     }
     res.status(500).json({ error: 'Failed to update interview question status' });
+  }
+});
+
+// Permanently delete a bank question. Session questions are independent snapshots, so
+// they survive this - but their questionBankId would otherwise point at a row that no
+// longer exists, so it is cleared in the same transaction.
+router.delete('/interview-questions/:id', async (req, res) => {
+  try {
+    const { id } = req.params;
+
+    const [detached] = await prisma.$transaction([
+      prisma.interviewSessionQuestion.updateMany({
+        where: { questionBankId: id },
+        data: { questionBankId: null }
+      }),
+      prisma.interviewQuestion.delete({ where: { id } })
+    ]);
+
+    res.json({ success: true, detachedSessionQuestions: detached.count });
+  } catch (error) {
+    console.error('[DELETE /api/admin/interview-questions/:id]', error);
+    if (error.code === 'P2025') {
+      return res.status(404).json({ error: 'Interview question not found' });
+    }
+    res.status(500).json({ error: 'Failed to delete interview question' });
   }
 });
 

--- a/server/src/routes/admin.js
+++ b/server/src/routes/admin.js
@@ -6069,4 +6069,115 @@ router.get('/talent-pool/stats', async (req, res) => {
   }
 });
 
+// -------------------- Interview Question Bank (ATS-23 / ATS-68) --------------------
+
+// Create a new interview question
+router.post('/interview-questions', async (req, res) => {
+  try {
+    const { cycleId, prompt, guidance, round, category, status } = req.body || {};
+
+    if (!cycleId || !prompt || !round) {
+      return res.status(400).json({ error: 'cycleId, prompt, and round are required' });
+    }
+
+    const validStatus = ['DRAFT', 'PUBLISHED', 'ARCHIVED'];
+    const questionStatus = status && validStatus.includes(status) ? status : 'DRAFT';
+
+    const question = await prisma.interviewQuestion.create({
+      data: {
+        cycleId,
+        prompt,
+        guidance: guidance || null,
+        round,
+        category: category || null,
+        status: questionStatus,
+        createdBy: req.user.id
+      }
+    });
+
+    res.status(201).json(question);
+  } catch (error) {
+    console.error('[POST /api/admin/interview-questions]', error);
+    res.status(500).json({ error: 'Failed to create interview question' });
+  }
+});
+
+// List and filter interview questions (admin sees all)
+router.get('/interview-questions', async (req, res) => {
+  try {
+    const { cycleId, round, category, status } = req.query || {};
+    const where = {};
+    if (cycleId) where.cycleId = String(cycleId);
+    if (round) where.round = String(round);
+    if (category) where.category = String(category);
+    if (status) where.status = String(status);
+
+    const questions = await prisma.interviewQuestion.findMany({
+      where,
+      orderBy: { createdAt: 'desc' }
+    });
+
+    res.json(questions);
+  } catch (error) {
+    console.error('[GET /api/admin/interview-questions]', error);
+    res.status(500).json({ error: 'Failed to fetch interview questions' });
+  }
+});
+
+// Update an interview question
+router.put('/interview-questions/:id', async (req, res) => {
+  try {
+    const { id } = req.params;
+    const { prompt, guidance, round, category } = req.body || {};
+
+    if (!prompt || !round) {
+      return res.status(400).json({ error: 'prompt and round are required' });
+    }
+
+    const question = await prisma.interviewQuestion.update({
+      where: { id },
+      data: {
+        prompt,
+        guidance: guidance || null,
+        round,
+        category: category || null
+      }
+    });
+
+    res.json(question);
+  } catch (error) {
+    console.error('[PUT /api/admin/interview-questions/:id]', error);
+    if (error.code === 'P2025') {
+      return res.status(404).json({ error: 'Interview question not found' });
+    }
+    res.status(500).json({ error: 'Failed to update interview question' });
+  }
+});
+
+// Update question status (DRAFT / PUBLISHED / ARCHIVED)
+router.patch('/interview-questions/:id/status', async (req, res) => {
+  try {
+    const { id } = req.params;
+    const { status } = req.body || {};
+    const validStatus = ['DRAFT', 'PUBLISHED', 'ARCHIVED'];
+
+    if (!status || !validStatus.includes(status)) {
+      return res.status(400).json({ error: 'status must be DRAFT, PUBLISHED, or ARCHIVED' });
+    }
+
+    const question = await prisma.interviewQuestion.update({
+      where: { id },
+      data: { status }
+    });
+
+    res.json(question);
+  } catch (error) {
+    console.error('[PATCH /api/admin/interview-questions/:id/status]', error);
+    if (error.code === 'P2025') {
+      return res.status(404).json({ error: 'Interview question not found' });
+    }
+    res.status(500).json({ error: 'Failed to update interview question status' });
+  }
+});
+
 export default router;

--- a/server/src/routes/member.js
+++ b/server/src/routes/member.js
@@ -2079,14 +2079,26 @@ router.post('/interviews/:interviewId/session-questions', requireAuth, requireAd
 router.get('/interviews/:interviewId/session-questions', requireAuth, requireAdminOrMember, async (req, res) => {
   try {
     const { interviewId } = req.params;
+    const { since } = req.query || {};
 
     if (!(await canAccessInterview(req, interviewId))) {
       return res.status(403).json({ error: 'Not assigned to this interview' });
     }
 
+    const where = { interviewId };
+    if (since) {
+      try {
+        where.updatedAt = { gte: new Date(since) };
+      } catch {
+        return res.status(400).json({ error: 'Invalid since timestamp' });
+      }
+    } else {
+      where.deletedAt = null;
+    }
+
     const questions = await prisma.interviewSessionQuestion.findMany({
-      where: { interviewId },
-      orderBy: [{ position: 'asc' }, { createdAt: 'asc' }]
+      where,
+      orderBy: [{ position: 'asc' }, { updatedAt: 'asc' }]
     });
 
     res.json(questions);
@@ -2116,9 +2128,12 @@ router.delete('/interviews/:interviewId/session-questions/:id', requireAuth, req
       return res.status(403).json({ error: 'You can only remove your own questions' });
     }
 
-    await prisma.interviewSessionQuestion.delete({ where: { id } });
+    const updated = await prisma.interviewSessionQuestion.update({
+      where: { id },
+      data: { deletedAt: new Date() }
+    });
 
-    res.status(204).send();
+    res.json(updated);
   } catch (error) {
     console.error('[DELETE /api/member/interviews/:interviewId/session-questions/:id]', error);
     res.status(500).json({ error: 'Failed to remove interview question' });

--- a/server/src/routes/member.js
+++ b/server/src/routes/member.js
@@ -2027,4 +2027,102 @@ router.delete('/resume', requireAuth, requireMemberRole, async (req, res) => {
   }
 });
 
+// Live interview session questions (ATS-13 / ATS-69)
+
+async function canAccessInterview(req, interviewId) {
+  if (req.user.role === 'ADMIN') return true;
+  const assignment = await prisma.interviewAssignment.findFirst({
+    where: { interviewId, userId: req.user.id }
+  });
+  return Boolean(assignment);
+}
+
+router.post('/interviews/:interviewId/session-questions', requireAuth, requireAdminOrMember, async (req, res) => {
+  try {
+    const { interviewId } = req.params;
+    const { prompt, position } = req.body || {};
+
+    if (!prompt || !prompt.trim()) {
+      return res.status(400).json({ error: 'prompt is required' });
+    }
+
+    if (!(await canAccessInterview(req, interviewId))) {
+      return res.status(403).json({ error: 'Not assigned to this interview' });
+    }
+
+    let targetPosition = Number(position);
+    if (Number.isNaN(targetPosition)) {
+      const last = await prisma.interviewSessionQuestion.findFirst({
+        where: { interviewId },
+        orderBy: { position: 'desc' },
+        select: { position: true }
+      });
+      targetPosition = (last?.position || 0) + 1;
+    }
+
+    const question = await prisma.interviewSessionQuestion.create({
+      data: {
+        interviewId,
+        prompt: prompt.trim(),
+        addedBy: req.user.id,
+        position: targetPosition
+      }
+    });
+
+    res.status(201).json(question);
+  } catch (error) {
+    console.error('[POST /api/member/interviews/:interviewId/session-questions]', error);
+    res.status(500).json({ error: 'Failed to add interview question' });
+  }
+});
+
+router.get('/interviews/:interviewId/session-questions', requireAuth, requireAdminOrMember, async (req, res) => {
+  try {
+    const { interviewId } = req.params;
+
+    if (!(await canAccessInterview(req, interviewId))) {
+      return res.status(403).json({ error: 'Not assigned to this interview' });
+    }
+
+    const questions = await prisma.interviewSessionQuestion.findMany({
+      where: { interviewId },
+      orderBy: [{ position: 'asc' }, { createdAt: 'asc' }]
+    });
+
+    res.json(questions);
+  } catch (error) {
+    console.error('[GET /api/member/interviews/:interviewId/session-questions]', error);
+    res.status(500).json({ error: 'Failed to fetch interview questions' });
+  }
+});
+
+router.delete('/interviews/:interviewId/session-questions/:id', requireAuth, requireAdminOrMember, async (req, res) => {
+  try {
+    const { interviewId, id } = req.params;
+
+    if (!(await canAccessInterview(req, interviewId))) {
+      return res.status(403).json({ error: 'Not assigned to this interview' });
+    }
+
+    const question = await prisma.interviewSessionQuestion.findFirst({
+      where: { id, interviewId }
+    });
+
+    if (!question) {
+      return res.status(404).json({ error: 'Question not found' });
+    }
+
+    if (req.user.role !== 'ADMIN' && question.addedBy !== req.user.id) {
+      return res.status(403).json({ error: 'You can only remove your own questions' });
+    }
+
+    await prisma.interviewSessionQuestion.delete({ where: { id } });
+
+    res.status(204).send();
+  } catch (error) {
+    console.error('[DELETE /api/member/interviews/:interviewId/session-questions/:id]', error);
+    res.status(500).json({ error: 'Failed to remove interview question' });
+  }
+});
+
 export default router;

--- a/server/src/routes/member.js
+++ b/server/src/routes/member.js
@@ -2057,4 +2057,167 @@ router.get('/interview-questions', requireAuth, requireAdminOrMember, async (req
   }
 });
 
+// Add a published bank question to the interview session as a snapshot (ATS-23)
+router.post('/interviews/:interviewId/session-questions/bank', requireAuth, requireAdminOrMember, async (req, res) => {
+  try {
+    const { interviewId } = req.params;
+    const { questionId, position } = req.body || {};
+
+    if (!questionId) {
+      return res.status(400).json({ error: 'questionId is required' });
+    }
+
+    if (!(await canAccessInterview(req, interviewId))) {
+      return res.status(403).json({ error: 'Not assigned to this interview' });
+    }
+
+    const bankQuestion = await prisma.interviewQuestion.findFirst({
+      where: { id: questionId, status: 'PUBLISHED' }
+    });
+
+    if (!bankQuestion) {
+      return res.status(404).json({ error: 'Published question not found' });
+    }
+
+    let targetPosition = Number(position);
+    if (Number.isNaN(targetPosition)) {
+      const last = await prisma.interviewSessionQuestion.findFirst({
+        where: { interviewId },
+        orderBy: { position: 'desc' },
+        select: { position: true }
+      });
+      targetPosition = (last?.position || 0) + 1;
+    }
+
+    const question = await prisma.interviewSessionQuestion.create({
+      data: {
+        interviewId,
+        prompt: bankQuestion.prompt,
+        guidance: bankQuestion.guidance,
+        questionBankId: bankQuestion.id,
+        addedBy: req.user.id,
+        position: targetPosition
+      }
+    });
+
+    res.status(201).json(question);
+  } catch (error) {
+    console.error('[POST /api/member/interviews/:interviewId/session-questions/bank]', error);
+    res.status(500).json({ error: 'Failed to add bank question' });
+  }
+});
+
+// Live interview session questions (ATS-13 / ATS-69)
+
+async function canAccessInterview(req, interviewId) {
+  if (req.user.role === 'ADMIN') return true;
+  const assignment = await prisma.interviewAssignment.findFirst({
+    where: { interviewId, userId: req.user.id }
+  });
+  return Boolean(assignment);
+}
+
+router.post('/interviews/:interviewId/session-questions', requireAuth, requireAdminOrMember, async (req, res) => {
+  try {
+    const { interviewId } = req.params;
+    const { prompt, position } = req.body || {};
+
+    if (!prompt || !prompt.trim()) {
+      return res.status(400).json({ error: 'prompt is required' });
+    }
+
+    if (!(await canAccessInterview(req, interviewId))) {
+      return res.status(403).json({ error: 'Not assigned to this interview' });
+    }
+
+    let targetPosition = Number(position);
+    if (Number.isNaN(targetPosition)) {
+      const last = await prisma.interviewSessionQuestion.findFirst({
+        where: { interviewId },
+        orderBy: { position: 'desc' },
+        select: { position: true }
+      });
+      targetPosition = (last?.position || 0) + 1;
+    }
+
+    const question = await prisma.interviewSessionQuestion.create({
+      data: {
+        interviewId,
+        prompt: prompt.trim(),
+        addedBy: req.user.id,
+        position: targetPosition
+      }
+    });
+
+    res.status(201).json(question);
+  } catch (error) {
+    console.error('[POST /api/member/interviews/:interviewId/session-questions]', error);
+    res.status(500).json({ error: 'Failed to add interview question' });
+  }
+});
+
+router.get('/interviews/:interviewId/session-questions', requireAuth, requireAdminOrMember, async (req, res) => {
+  try {
+    const { interviewId } = req.params;
+    const { since } = req.query || {};
+
+    if (!(await canAccessInterview(req, interviewId))) {
+      return res.status(403).json({ error: 'Not assigned to this interview' });
+    }
+
+    const where = { interviewId };
+    if (since) {
+      try {
+        where.updatedAt = { gte: new Date(since) };
+      } catch {
+        return res.status(400).json({ error: 'Invalid since timestamp' });
+      }
+    } else {
+      where.deletedAt = null;
+    }
+
+    const questions = await prisma.interviewSessionQuestion.findMany({
+      where,
+      orderBy: [{ position: 'asc' }, { updatedAt: 'asc' }]
+    });
+
+    res.json(questions);
+  } catch (error) {
+    console.error('[GET /api/member/interviews/:interviewId/session-questions]', error);
+    res.status(500).json({ error: 'Failed to fetch interview questions' });
+  }
+});
+
+router.delete('/interviews/:interviewId/session-questions/:id', requireAuth, requireAdminOrMember, async (req, res) => {
+  try {
+    const { interviewId, id } = req.params;
+
+    if (!(await canAccessInterview(req, interviewId))) {
+      return res.status(403).json({ error: 'Not assigned to this interview' });
+    }
+
+    const question = await prisma.interviewSessionQuestion.findFirst({
+      where: { id, interviewId }
+    });
+
+    if (!question) {
+      return res.status(404).json({ error: 'Question not found' });
+    }
+
+    if (req.user.role !== 'ADMIN' && question.addedBy !== req.user.id) {
+      return res.status(403).json({ error: 'You can only remove your own questions' });
+    }
+
+    const updated = await prisma.interviewSessionQuestion.update({
+      where: { id },
+      data: { deletedAt: new Date() }
+    });
+
+    res.json(updated);
+  } catch (error) {
+    console.error('[DELETE /api/member/interviews/:interviewId/session-questions/:id]', error);
+    res.status(500).json({ error: 'Failed to remove interview question' });
+  }
+});
+
 export default router;

--- a/server/src/routes/member.js
+++ b/server/src/routes/member.js
@@ -2057,6 +2057,44 @@ router.get('/interview-questions', requireAuth, requireAdminOrMember, async (req
   }
 });
 
+// Distinct category and round values across the published bank, for filter dropdowns.
+router.get('/interview-questions/facets', requireAuth, requireAdminOrMember, async (req, res) => {
+  try {
+    const { cycleId } = req.query || {};
+    const activeCycle = await resolveCycleForRequest(prisma, req);
+    const targetCycleId = cycleId || activeCycle?.id;
+
+    if (!targetCycleId) {
+      return res.json({ categories: [], rounds: [] });
+    }
+
+    const where = { cycleId: targetCycleId, status: 'PUBLISHED' };
+
+    const [categories, rounds] = await Promise.all([
+      prisma.interviewQuestion.findMany({
+        where: { ...where, category: { not: null } },
+        distinct: ['category'],
+        select: { category: true },
+        orderBy: { category: 'asc' }
+      }),
+      prisma.interviewQuestion.findMany({
+        where,
+        distinct: ['round'],
+        select: { round: true },
+        orderBy: { round: 'asc' }
+      })
+    ]);
+
+    res.json({
+      categories: categories.map((c) => c.category).filter(Boolean),
+      rounds: rounds.map((r) => r.round).filter(Boolean)
+    });
+  } catch (error) {
+    console.error('[GET /api/member/interview-questions/facets]', error);
+    res.status(500).json({ error: 'Failed to fetch interview question facets' });
+  }
+});
+
 // Add a published bank question to the interview session as a snapshot (ATS-23)
 router.post('/interviews/:interviewId/session-questions/bank', requireAuth, requireAdminOrMember, async (req, res) => {
   try {
@@ -2167,11 +2205,13 @@ router.get('/interviews/:interviewId/session-questions', requireAuth, requireAdm
 
     const where = { interviewId };
     if (since) {
-      try {
-        where.updatedAt = { gte: new Date(since) };
-      } catch {
+      const sinceDate = new Date(since);
+      if (Number.isNaN(sinceDate.getTime())) {
         return res.status(400).json({ error: 'Invalid since timestamp' });
       }
+      // Soft-deleted rows are returned on purpose here: they are the tombstones a
+      // polling client needs to drop questions removed since its last sync.
+      where.updatedAt = { gte: sinceDate };
     } else {
       where.deletedAt = null;
     }
@@ -2217,6 +2257,58 @@ router.delete('/interviews/:interviewId/session-questions/:id', requireAuth, req
   } catch (error) {
     console.error('[DELETE /api/member/interviews/:interviewId/session-questions/:id]', error);
     res.status(500).json({ error: 'Failed to remove interview question' });
+  }
+});
+
+// Renumber the whole active question list for an interview. Takes the full ordered id
+// list rather than a single moved id: positions are assigned on insert only, and two
+// interviewers adding at once can compute the same position, so a subset renumber would
+// interleave with the rows left out.
+router.patch('/interviews/:interviewId/session-questions/reorder', requireAuth, requireAdminOrMember, async (req, res) => {
+  try {
+    const { interviewId } = req.params;
+    const { order } = req.body || {};
+
+    if (!Array.isArray(order) || order.length === 0) {
+      return res.status(400).json({ error: 'order must be a non-empty array of question ids' });
+    }
+
+    if (!(await canAccessInterview(req, interviewId))) {
+      return res.status(403).json({ error: 'Not assigned to this interview' });
+    }
+
+    const active = await prisma.interviewSessionQuestion.findMany({
+      where: { interviewId, deletedAt: null },
+      select: { id: true }
+    });
+    const activeIds = new Set(active.map((q) => q.id));
+    const unique = new Set(order);
+
+    // A stale list means the client is reordering against questions someone else has
+    // already added or removed; renumbering it would silently discard their change.
+    if (
+      unique.size !== order.length ||
+      unique.size !== activeIds.size ||
+      order.some((id) => !activeIds.has(id))
+    ) {
+      return res.status(409).json({
+        error: 'order must list every active question for this interview exactly once'
+      });
+    }
+
+    const questions = await prisma.$transaction(
+      order.map((id, index) =>
+        prisma.interviewSessionQuestion.update({
+          where: { id },
+          data: { position: index }
+        })
+      )
+    );
+
+    res.json(questions);
+  } catch (error) {
+    console.error('[PATCH /api/member/interviews/:interviewId/session-questions/reorder]', error);
+    res.status(500).json({ error: 'Failed to reorder interview questions' });
   }
 });
 

--- a/server/src/routes/member.js
+++ b/server/src/routes/member.js
@@ -2027,4 +2027,34 @@ router.delete('/resume', requireAuth, requireMemberRole, async (req, res) => {
   }
 });
 
+// List published interview questions for the current cycle (ATS-23 / ATS-68)
+router.get('/interview-questions', requireAuth, requireAdminOrMember, async (req, res) => {
+  try {
+    const { cycleId, round, category } = req.query || {};
+    const activeCycle = await resolveCycleForRequest(prisma, req);
+    const targetCycleId = cycleId || activeCycle?.id;
+
+    if (!targetCycleId) {
+      return res.json([]);
+    }
+
+    const where = {
+      cycleId: targetCycleId,
+      status: 'PUBLISHED'
+    };
+    if (round) where.round = String(round);
+    if (category) where.category = String(category);
+
+    const questions = await prisma.interviewQuestion.findMany({
+      where,
+      orderBy: { createdAt: 'desc' }
+    });
+
+    res.json(questions);
+  } catch (error) {
+    console.error('[GET /api/member/interview-questions]', error);
+    res.status(500).json({ error: 'Failed to fetch interview questions' });
+  }
+});
+
 export default router;


### PR DESCRIPTION
Connects the admin-curated question bank to live interview sessions with snapshot support (ATS-23).\n\n- Adds guidance and questionBankId to InterviewSessionQuestion\n- New POST /api/member/interviews/:interviewId/session-questions/bank\n- Snapshots prompt/guidance from published InterviewQuestion so later edits do not change active interviews\n\nPart of ATS-23