### PR TITLE
Fix: TPN preview cap strands most of a large match

### DIFF
--- a/server/src/routes/talentPoolAdmin.js
+++ b/server/src/routes/talentPoolAdmin.js
@@ -17,6 +17,7 @@ import {
   APPLICATION_STATUSES,
   PREVIEW_CAP,
   NOT_OPTED_OUT,
+  dedupeApplicantsByPerson,
   sanitizeFilterDsl,
   buildApplicantWhere,
   buildMemberResumeWhere,
@@ -353,6 +354,7 @@ router.post('/clients/:id/preview', async (req, res) => {
     const excluded = {
       optedOut: 0,
       noBlindResume: 0,
+      duplicateApplications: 0,
       memberNoConsent: 0,
       externalNotAssignable: 0,
       alreadyAssigned: 0
@@ -384,7 +386,6 @@ router.post('/clients/:id/preview', async (req, res) => {
       // counted here because it is not a refusal - it is simply assignable.
       excluded.optedOut = Math.max(filterOnly - notOptedOut, 0);
       excluded.noBlindResume = Math.max(notOptedOut - matched, 0);
-      total += matched;
 
       const applications = remaining() === 0 ? [] : await prisma.application.findMany({
         where: applicant.where,
@@ -396,14 +397,27 @@ router.post('/clients/:id/preview', async (req, res) => {
           major1: true,
           major2: true,
           gender: true,
-          cumulativeGpa: true
+          cumulativeGpa: true,
+          // Identity, for collapsing repeat applicants to one row each.
+          candidateId: true,
+          email: true,
+          studentId: true
         },
         orderBy: { submittedAt: 'desc' },
         take: remaining()
       });
 
+      // One row per person, not per submission. `matched` counts applications,
+      // so a pool we fetched in full reports the person count instead - the
+      // number the admin recognises. A capped fetch cannot know how many
+      // duplicates lie past the cap, so it keeps the row count and lets
+      // `truncated` say the picture is partial.
+      const people = dedupeApplicantsByPerson(applications);
+      excluded.duplicateApplications = applications.length - people.length;
+      total += applications.length === matched ? people.length : matched;
+
       rows.push(
-        ...applications.map((a) => ({
+        ...people.map((a) => ({
           key: buildAssignmentKey('APPLICATION', a.id),
           kind: 'APPLICANT',
           name: `${a.firstName} ${a.lastName}`.trim(),
@@ -598,7 +612,17 @@ router.post('/clients/:id/assign', async (req, res) => {
       applicationIds.length
         ? prisma.application.findMany({
             where: { id: { in: applicationIds } },
-            select: { id: true, talentPoolOptIn: true, resumeUrl: true, blindResumeUrl: true }
+            select: {
+              id: true,
+              talentPoolOptIn: true,
+              resumeUrl: true,
+              blindResumeUrl: true,
+              // Consent belongs to the person, not the submission. A No on any
+              // of their applications disqualifies all of them - see
+              // NOT_OPTED_OUT. Read here too, because a commit never re-runs
+              // the filter and must not trust a key minted before this rule.
+              candidate: { select: { applications: { select: { talentPoolOptIn: true } } } }
+            }
           })
         : [],
       memberResumeIds.length
@@ -655,9 +679,13 @@ router.post('/clients/:id/assign', async (req, res) => {
         const app = appById.get(p.id);
         if (!app) {
           skipped.push({ key: p.key, reason: 'Application no longer exists' });
-        } else if (app.talentPoolOptIn === false) {
-          // An explicit No, and only that. A null means the applicant was never
-          // asked, which is not a refusal - see the gate in talentPoolFilters.js.
+        } else if (
+          app.talentPoolOptIn === false ||
+          app.candidate?.applications?.some((other) => other.talentPoolOptIn === false)
+        ) {
+          // An explicit No on ANY of this person's applications. A null means
+          // they were never asked, which is not a refusal - see the gate in
+          // talentPoolFilters.js.
           skipped.push({ key: p.key, reason: 'Applicant opted out of the Talent Partner Network' });
         } else if (!app.resumeUrl) {
           skipped.push({ key: p.key, reason: 'No resume on file' });

--- a/server/src/routes/talentPoolAdmin.js
+++ b/server/src/routes/talentPoolAdmin.js
@@ -361,6 +361,15 @@ router.post('/clients/:id/preview', async (req, res) => {
     const rows = [];
     let total = 0;
 
+    // PREVIEW_CAP is a budget for the WHOLE response, not for each pool. Each
+    // pool used to take the full cap and the concatenation was sliced back down
+    // at the end, so a filter matching cap-many applicants dropped every member
+    // and student row on the floor - the pools were queried, counted into
+    // `total`, and then silently cut. Spending from a shared remainder means a
+    // truncated preview loses the tail of the last pool rather than an entire
+    // pool nobody was told about.
+    const remaining = () => Math.max(PREVIEW_CAP - rows.length, 0);
+
     if (applicant.where) {
       // Diagnostics: how many the consent gate and the blind gate each removed.
       // filterOnlyWhere is never used to select rows for assignment.
@@ -377,7 +386,7 @@ router.post('/clients/:id/preview', async (req, res) => {
       excluded.noBlindResume = Math.max(notOptedOut - matched, 0);
       total += matched;
 
-      const applications = await prisma.application.findMany({
+      const applications = remaining() === 0 ? [] : await prisma.application.findMany({
         where: applicant.where,
         select: {
           id: true,
@@ -390,7 +399,7 @@ router.post('/clients/:id/preview', async (req, res) => {
           cumulativeGpa: true
         },
         orderBy: { submittedAt: 'desc' },
-        take: PREVIEW_CAP
+        take: remaining()
       });
 
       rows.push(
@@ -415,7 +424,7 @@ router.post('/clients/:id/preview', async (req, res) => {
       excluded.memberNoConsent = Math.max(filterOnly - matched, 0);
       total += matched;
 
-      const memberResumes = await prisma.memberResume.findMany({
+      const memberResumes = remaining() === 0 ? [] : await prisma.memberResume.findMany({
         where: member.where,
         select: {
           id: true,
@@ -426,7 +435,7 @@ router.post('/clients/:id/preview', async (req, res) => {
           member: { select: { fullName: true } }
         },
         orderBy: { createdAt: 'desc' },
-        take: PREVIEW_CAP
+        take: remaining()
       });
 
       rows.push(
@@ -459,7 +468,7 @@ router.post('/clients/:id/preview', async (req, res) => {
       excluded.externalNotAssignable = Math.max(filterOnly - matched, 0);
       total += matched;
 
-      const externalResumes = await prisma.externalResume.findMany({
+      const externalResumes = remaining() === 0 ? [] : await prisma.externalResume.findMany({
         where: external.where,
         select: {
           id: true,
@@ -470,7 +479,7 @@ router.post('/clients/:id/preview', async (req, res) => {
           user: { select: { fullName: true } }
         },
         orderBy: { createdAt: 'desc' },
-        take: PREVIEW_CAP
+        take: remaining()
       });
 
       rows.push(
@@ -525,10 +534,20 @@ router.post('/clients/:id/preview', async (req, res) => {
       if (row.alreadyAssigned) excluded.alreadyAssigned += 1;
     }
 
+    // rows can no longer exceed the cap - remaining() enforces it - so this is
+    // a comparison against what the admin is actually looking at rather than
+    // against a longer list that was about to be sliced.
+    const truncated = total > rows.length;
+    if (truncated) {
+      notes.push(
+        `Showing ${rows.length} of ${total} matches. The same ${rows.length} come back every time this filter runs, so narrow it - by cycle, class, or major - to reach the rest.`
+      );
+    }
+
     res.json({
-      rows: rows.slice(0, PREVIEW_CAP),
+      rows,
       total,
-      truncated: total > rows.length,
+      truncated,
       cap: PREVIEW_CAP,
       excluded,
       notes,

--- a/server/src/routes/talentPoolAdmin.js
+++ b/server/src/routes/talentPoolAdmin.js
@@ -18,6 +18,7 @@ import {
   PREVIEW_CAP,
   NOT_OPTED_OUT,
   dedupeApplicantsByPerson,
+  personKey,
   sanitizeFilterDsl,
   buildApplicantWhere,
   buildMemberResumeWhere,
@@ -363,6 +364,11 @@ router.post('/clients/:id/preview', async (req, res) => {
     const rows = [];
     let total = 0;
 
+    // rowKey -> person, for applicant rows only. Kept beside the rows rather
+    // than on them: the person key is built from email and student id, and the
+    // response has no business carrying either.
+    const personOfRow = new Map();
+
     // PREVIEW_CAP is a budget for the WHOLE response, not for each pool. Each
     // pool used to take the full cap and the concatenation was sliced back down
     // at the end, so a filter matching cap-many applicants dropped every member
@@ -413,6 +419,7 @@ router.post('/clients/:id/preview', async (req, res) => {
       // duplicates lie past the cap, so it keeps the row count and lets
       // `truncated` say the picture is partial.
       const people = dedupeApplicantsByPerson(applications);
+      for (const a of people) personOfRow.set(buildAssignmentKey('APPLICATION', a.id), personKey(a));
       excluded.duplicateApplications = applications.length - people.length;
       total += applications.length === matched ? people.length : matched;
 
@@ -512,39 +519,33 @@ router.post('/clients/:id/preview', async (req, res) => {
     }
 
     // Flag rows this client already has so the admin is not re-assigning blind.
-    const idsOfKind = (kind) =>
-      rows
-        .map((r) => parseAssignmentKey(r.key))
-        .filter((p) => p?.kind === kind)
-        .map((p) => p.id);
-
-    const applicationIds = idsOfKind('APPLICATION');
-    const memberResumeIds = idsOfKind('MEMBER_RESUME');
-    const externalResumeIds = idsOfKind('EXTERNAL_RESUME');
-
+    //
+    // Scoped to the client's whole live library rather than to the ids in this
+    // preview, because for applicants the question is not "do you hold this
+    // application" but "do you hold this PERSON". Dedupe hands back everyone's
+    // newest application; if the client was assigned an older one, an id-only
+    // check reads as not-assigned and a second row for the same person gets
+    // created - which is how a library reaches 521 rows for 456 people.
     const live = await prisma.clientResumeAssignment.findMany({
-      where: {
-        clientId: client.id,
-        revokedAt: null,
-        OR: [
-          { applicationId: { in: applicationIds } },
-          { memberResumeId: { in: memberResumeIds } },
-          { externalResumeId: { in: externalResumeIds } }
-        ]
-      },
-      select: { applicationId: true, memberResumeId: true, externalResumeId: true }
+      where: { clientId: client.id, revokedAt: null },
+      select: {
+        memberResumeId: true,
+        externalResumeId: true,
+        application: { select: { id: true, candidateId: true, email: true, studentId: true } }
+      }
     });
 
     const liveKeys = new Set([
-      ...live.filter((l) => l.applicationId).map((l) => buildAssignmentKey('APPLICATION', l.applicationId)),
       ...live.filter((l) => l.memberResumeId).map((l) => buildAssignmentKey('MEMBER_RESUME', l.memberResumeId)),
       ...live
         .filter((l) => l.externalResumeId)
         .map((l) => buildAssignmentKey('EXTERNAL_RESUME', l.externalResumeId))
     ]);
+    const livePeople = new Set(live.filter((l) => l.application).map((l) => personKey(l.application)));
 
     for (const row of rows) {
-      row.alreadyAssigned = liveKeys.has(row.key);
+      const person = personOfRow.get(row.key);
+      row.alreadyAssigned = person ? livePeople.has(person) : liveKeys.has(row.key);
       if (row.alreadyAssigned) excluded.alreadyAssigned += 1;
     }
 
@@ -617,6 +618,11 @@ router.post('/clients/:id/assign', async (req, res) => {
               talentPoolOptIn: true,
               resumeUrl: true,
               blindResumeUrl: true,
+              // Identity, so a second application for someone the client
+              // already holds is refused rather than duplicated.
+              candidateId: true,
+              email: true,
+              studentId: true,
               // Consent belongs to the person, not the submission. A No on any
               // of their applications disqualifies all of them - see
               // NOT_OPTED_OUT. Read here too, because a commit never re-runs
@@ -651,24 +657,25 @@ router.post('/clients/:id/assign', async (req, res) => {
             }
           })
         : [],
+      // The client's whole live library, not just the ids being posted: an
+      // applicant is a duplicate when the PERSON is already held, whichever of
+      // their applications carries them. The commit never re-runs the preview,
+      // so this check has to stand on its own.
       prisma.clientResumeAssignment.findMany({
-        where: {
-          clientId: client.id,
-          revokedAt: null,
-          OR: [
-            { applicationId: { in: applicationIds } },
-            { memberResumeId: { in: memberResumeIds } },
-            { externalResumeId: { in: externalResumeIds } }
-          ]
-        },
-        select: { applicationId: true, memberResumeId: true, externalResumeId: true }
+        where: { clientId: client.id, revokedAt: null },
+        select: {
+          applicationId: true,
+          memberResumeId: true,
+          externalResumeId: true,
+          application: { select: { id: true, candidateId: true, email: true, studentId: true } }
+        }
       })
     ]);
 
     const appById = new Map(applications.map((a) => [a.id, a]));
     const memberById = new Map(memberResumes.map((m) => [m.id, m]));
     const externalById = new Map(externalResumes.map((e) => [e.id, e]));
-    const liveApps = new Set(live.map((l) => l.applicationId).filter(Boolean));
+    const livePeople = new Set(live.filter((l) => l.application).map((l) => personKey(l.application)));
     const liveMembers = new Set(live.map((l) => l.memberResumeId).filter(Boolean));
     const liveExternals = new Set(live.map((l) => l.externalResumeId).filter(Boolean));
 
@@ -691,9 +698,14 @@ router.post('/clients/:id/assign', async (req, res) => {
           skipped.push({ key: p.key, reason: 'No resume on file' });
         } else if (client.visibility === 'BLIND' && !app.blindResumeUrl) {
           skipped.push({ key: p.key, reason: 'No redacted resume, and this client is blind-visibility' });
-        } else if (liveApps.has(p.id)) {
+        } else if (livePeople.has(personKey(app))) {
+          // By person, so re-running an unfiltered assign is idempotent rather
+          // than additive.
           skipped.push({ key: p.key, reason: 'Already assigned to this client' });
         } else {
+          // Within-batch too: two applications by the same person can both be
+          // ticked, and neither is in `live` yet.
+          livePeople.add(personKey(app));
           toCreate.push({ applicationId: p.id, memberResumeId: null, externalResumeId: null });
         }
         continue;

--- a/server/src/routes/talentPoolAdmin.routes.test.js
+++ b/server/src/routes/talentPoolAdmin.routes.test.js
@@ -9,6 +9,7 @@ import jwt from 'jsonwebtoken';
 import prisma from '../prismaClient.js';
 import talentPoolAdminRoutes from './talentPoolAdmin.js';
 import { requireAuth, requireAdmin } from '../middleware/auth.js';
+import { PREVIEW_CAP } from '../utils/talentPoolFilters.js';
 
 vi.mock('../prismaClient.js', () => {
   const tx = {
@@ -223,6 +224,42 @@ describe('preview', () => {
     expect(body.errors.join(' ')).toMatch(/None of those filters could be used/i);
   });
 
+  it('spends the row cap as one budget, so a full applicant pool cannot starve the others', async () => {
+    // The bug this replaces: every pool took the full cap and the concatenated
+    // list was sliced back down at the end, so cap-many applicants pushed every
+    // member row out of the response - counted in `total`, then dropped without
+    // a word. That is the "ticking Members shows nothing" symptom again.
+    const applicants = Array.from({ length: PREVIEW_CAP }, (_, i) => ({
+      id: `app-${i}`,
+      firstName: 'A',
+      lastName: String(i),
+      graduationYear: '2029'
+    }));
+    prisma.application.count.mockResolvedValue(PREVIEW_CAP + 300);
+    prisma.application.findMany.mockImplementation(({ take }) => applicants.slice(0, take));
+    prisma.memberResume.count.mockResolvedValue(6);
+    prisma.memberResume.findMany.mockImplementation(({ take }) =>
+      Array.from({ length: Math.min(6, take) }, (_, i) => ({
+        id: `mr-${i}`,
+        member: { fullName: `Member ${i}` }
+      }))
+    );
+
+    const res = await request('/api/admin/talent-pool/clients/partner-1/preview', {
+      user: adminUser,
+      method: 'POST',
+      body: { filter: { pools: ['APPLICANTS', 'MEMBERS'], rows: [] } }
+    });
+
+    const body = await res.json();
+    // Never more than the cap, and the count the UI prints matches the rows it got.
+    expect(body.rows.length).toBe(PREVIEW_CAP);
+    expect(body.truncated).toBe(true);
+    // And the truncation is now something the admin can act on, rather than a
+    // page that returns identically forever.
+    expect(body.notes.join(' ')).toMatch(/narrow it/i);
+  });
+
   it('reports how many rows each consent gate excluded', async () => {
     // 10 match the filter, 7 have not opted out, 5 of those have a blind resume.
     prisma.application.count
@@ -408,14 +445,14 @@ describe('assign - consent gates cannot be bypassed by posting keys directly', (
   });
 
   it('caps a single assignment batch', async () => {
-    const keys = Array.from({ length: 501 }, (_, i) => `APPLICATION:app-${i}`);
+    const keys = Array.from({ length: PREVIEW_CAP + 1 }, (_, i) => `APPLICATION:app-${i}`);
     const res = await request('/api/admin/talent-pool/clients/partner-1/assign', {
       user: adminUser,
       method: 'POST',
       body: { keys }
     });
     expect(res.status).toBe(400);
-    expect((await res.json()).error).toMatch(/at most 500/i);
+    expect((await res.json()).error).toMatch(new RegExp(`at most ${PREVIEW_CAP}`, 'i'));
   });
 });
 

--- a/server/src/routes/talentPoolAdmin.routes.test.js
+++ b/server/src/routes/talentPoolAdmin.routes.test.js
@@ -260,6 +260,52 @@ describe('preview', () => {
     expect(body.notes.join(' ')).toMatch(/narrow it/i);
   });
 
+  it('collapses repeat applicants to one row per person', async () => {
+    // 762 assignable applications are 627 people. Assigning both of someone's
+    // forms puts them in a client's library twice, which is how one client came
+    // to hold 521 rows for 456 people.
+    const apps = [
+      { id: 'a1', firstName: 'Jin', lastName: 'Kim', candidateId: 'cand-1' },
+      { id: 'a2', firstName: 'Jin', lastName: 'Kim', candidateId: 'cand-1' },
+      { id: 'a3', firstName: 'Ada', lastName: 'L', email: 'Ada@ucla.edu' },
+      { id: 'a4', firstName: 'Ada', lastName: 'L', email: 'ada@ucla.edu' },
+      { id: 'a5', firstName: 'Solo', lastName: 'One', candidateId: 'cand-2' }
+    ];
+    prisma.application.count.mockResolvedValue(apps.length);
+    prisma.application.findMany.mockResolvedValue(apps);
+
+    const res = await request('/api/admin/talent-pool/clients/partner-1/preview', {
+      user: adminUser,
+      method: 'POST',
+      body: { filter: { pools: ['APPLICANTS'], rows: [] } }
+    });
+
+    const body = await res.json();
+    expect(body.rows.map((r) => r.key)).toEqual([
+      'APPLICATION:a1',
+      'APPLICATION:a3',
+      'APPLICATION:a5'
+    ]);
+    // The headline count is people, not submissions, when the whole pool fit.
+    expect(body.total).toBe(3);
+    expect(body.excluded.duplicateApplications).toBe(2);
+  });
+
+  it('keeps the row count when the fetch was capped, since duplicates past the cap are unknown', async () => {
+    prisma.application.count.mockResolvedValue(5000);
+    prisma.application.findMany.mockResolvedValue(
+      Array.from({ length: PREVIEW_CAP }, (_, i) => ({ id: `a${i}`, candidateId: `c${i}` }))
+    );
+    const res = await request('/api/admin/talent-pool/clients/partner-1/preview', {
+      user: adminUser,
+      method: 'POST',
+      body: { filter: { pools: ['APPLICANTS'], rows: [] } }
+    });
+    const body = await res.json();
+    expect(body.total).toBe(5000);
+    expect(body.truncated).toBe(true);
+  });
+
   it('reports how many rows each consent gate excluded', async () => {
     // 10 match the filter, 7 have not opted out, 5 of those have a blind resume.
     prisma.application.count

--- a/server/src/routes/talentPoolAdmin.routes.test.js
+++ b/server/src/routes/talentPoolAdmin.routes.test.js
@@ -467,10 +467,10 @@ describe('assign - consent gates cannot be bypassed by posting keys directly', (
 
   it('skips a resume already live-assigned to this client', async () => {
     prisma.application.findMany.mockResolvedValue([
-      { id: 'app-1', talentPoolOptIn: true, resumeUrl: 'drive-1', blindResumeUrl: 'blind-1' }
+      { id: 'app-1', candidateId: 'cand-1', talentPoolOptIn: true, resumeUrl: 'drive-1', blindResumeUrl: 'blind-1' }
     ]);
     prisma.clientResumeAssignment.findMany.mockResolvedValue([
-      { applicationId: 'app-1', memberResumeId: null }
+      { applicationId: 'app-1', memberResumeId: null, application: { id: 'app-1', candidateId: 'cand-1' } }
     ]);
 
     const res = await request('/api/admin/talent-pool/clients/partner-1/assign', {
@@ -479,6 +479,42 @@ describe('assign - consent gates cannot be bypassed by posting keys directly', (
       body: { keys: ['APPLICATION:app-1'] }
     });
     expect((await res.json()).skipped[0].reason).toMatch(/already assigned/i);
+  });
+
+  it('skips a DIFFERENT application by someone the client already holds', async () => {
+    // Dedupe hands back everyone's newest application. If the client was
+    // assigned an older one, an id-only check reads as not-assigned and the
+    // person lands in the library twice.
+    prisma.application.findMany.mockResolvedValue([
+      { id: 'app-new', candidateId: 'cand-1', talentPoolOptIn: null, resumeUrl: 'drive-2', blindResumeUrl: 'blind-2' }
+    ]);
+    prisma.clientResumeAssignment.findMany.mockResolvedValue([
+      { applicationId: 'app-old', memberResumeId: null, application: { id: 'app-old', candidateId: 'cand-1' } }
+    ]);
+
+    const res = await request('/api/admin/talent-pool/clients/partner-1/assign', {
+      user: adminUser,
+      method: 'POST',
+      body: { keys: ['APPLICATION:app-new'] }
+    });
+    expect((await res.json()).skipped[0].reason).toMatch(/already assigned/i);
+  });
+
+  it('assigns only one row when two applications by the same person are ticked', async () => {
+    prisma.application.findMany.mockResolvedValue([
+      { id: 'app-a', candidateId: 'cand-9', talentPoolOptIn: null, resumeUrl: 'd1', blindResumeUrl: 'b1' },
+      { id: 'app-b', candidateId: 'cand-9', talentPoolOptIn: null, resumeUrl: 'd2', blindResumeUrl: 'b2' }
+    ]);
+    prisma.clientResumeAssignment.findMany.mockResolvedValue([]);
+
+    const res = await request('/api/admin/talent-pool/clients/partner-1/assign', {
+      user: adminUser,
+      method: 'POST',
+      body: { keys: ['APPLICATION:app-a', 'APPLICATION:app-b'] }
+    });
+    const body = await res.json();
+    expect(body.created).toBe(1);
+    expect(body.skipped[0].reason).toMatch(/already assigned/i);
   });
 
   it('rejects a malformed key rather than guessing', async () => {

--- a/server/src/utils/talentPoolFilters.js
+++ b/server/src/utils/talentPoolFilters.js
@@ -84,7 +84,20 @@ export const NUMBER_OPS = ['gte', 'lte'];
 
 // The preview never renders more than this, and a commit never accepts more.
 // A runaway filter therefore cannot quietly hand a client thousands of resumes.
-export const PREVIEW_CAP = 500;
+//
+// It was 500, set when "every opted-in application in the system" was ~250 rows
+// and the cap was therefore twice the entire assignable universe. Reading the
+// consent gate as "has not opted out" tripled that universe to ~760, which put
+// the cap BELOW it - and because the preview always takes the same first page
+// by submitted date, the rows past the cap became unreachable: re-running the
+// filter returned the identical page, every row already assigned, with nothing
+// new to tick. An admin could get to 521 of 762 and then stall with no
+// indication why.
+//
+// 2000 restores the original intent - comfortably above the whole assignable
+// set - and matches MAX_MATERIALIZED in clientResumeQuery.js, which bounds the
+// same universe from the portal side.
+export const PREVIEW_CAP = 2000;
 
 const isPlainObject = (v) => typeof v === 'object' && v !== null && !Array.isArray(v);
 

--- a/server/src/utils/talentPoolFilters.js
+++ b/server/src/utils/talentPoolFilters.js
@@ -253,12 +253,26 @@ const majorAnyOf = (values) => ({
 });
 
 /**
- * The applicant consent gate, read as "has not said no".
+ * The applicant consent gate, read as "this PERSON has not said no".
  *
  * An explicit No is the one answer that makes an applicant permanently
  * unassignable. A null - every Fall 2025 applicant, and anyone whose form
  * predates the question - is not a refusal, it is an absence, and treating the
  * two the same hid the entire back catalogue from the network.
+ *
+ * The second clause is the part that is easy to get wrong, and did. Opt-in is
+ * stored per APPLICATION, but consent belongs to the person: someone who
+ * applied twice and answered No on one form has said no, full stop. Checking
+ * only the row in hand let their other application - submitted before the
+ * question existed, so null - stay assignable, which put two people who had
+ * explicitly refused in front of a client. `applications: { none: ... }` asks
+ * the question of every form they have ever submitted.
+ *
+ * Rows with no candidateId are matched on their own answer alone: an
+ * unlinked application has no other rows to be contradicted by. Sync links
+ * applications to a Candidate by studentId or email, so this is a small and
+ * shrinking set - but it fails safe either way, because an unlinked row that
+ * says No is still excluded by the first clause.
  *
  * Written as an OR rather than `{ not: false }` so the null branch is visible
  * at the call site: this clause decides who may be shared with an outside
@@ -266,7 +280,17 @@ const majorAnyOf = (values) => ({
  * NULL under a negation. Exported so the preview's diagnostics count exactly
  * what the gate excludes, rather than a restatement that could drift from it.
  */
-export const NOT_OPTED_OUT = { OR: [{ talentPoolOptIn: true }, { talentPoolOptIn: null }] };
+export const NOT_OPTED_OUT = {
+  AND: [
+    { OR: [{ talentPoolOptIn: true }, { talentPoolOptIn: null }] },
+    {
+      OR: [
+        { candidateId: null },
+        { candidate: { applications: { none: { talentPoolOptIn: false } } } }
+      ]
+    }
+  ]
+};
 
 /**
  * Build the Prisma where clause for the applicant pool.
@@ -504,6 +528,40 @@ export const buildExternalResumeWhere = (dsl, { visibility = 'BLIND' } = {}) => 
     unnarrowedBy: unsupported,
     notes
   };
+};
+
+/**
+ * Collapse applications to one row per PERSON, newest first.
+ *
+ * The applicant pool is keyed on Application, not on Candidate, so someone who
+ * applied in two cycles is two rows - and assigning both puts the same person
+ * in a client's library twice. 762 assignable rows are 627 people, and one
+ * client was already holding 521 rows for 456 people.
+ *
+ * Rows must arrive newest-first: the first one seen for a person wins, which is
+ * their most recent application and therefore their most recent resume. Same
+ * key and same rule as the all-cycles roster in routes/admin.js, so the two
+ * views of "how many applicants are there" cannot disagree.
+ *
+ * The `app:` fallback keeps an unlinked, email-less row as its own person
+ * rather than collapsing every such row into one.
+ */
+export const personKey = (app) =>
+  app.candidateId
+  || (app.email ? `email:${String(app.email).trim().toLowerCase()}` : null)
+  || (app.studentId ? `student:${String(app.studentId).trim()}` : null)
+  || `app:${app.id}`;
+
+export const dedupeApplicantsByPerson = (applications) => {
+  const seen = new Set();
+  const out = [];
+  for (const app of applications) {
+    const key = personKey(app);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(app);
+  }
+  return out;
 };
 
 // Assignment keys are opaque to the client UI and are what a commit sends back.

--- a/server/src/utils/talentPoolFilters.test.js
+++ b/server/src/utils/talentPoolFilters.test.js
@@ -286,8 +286,11 @@ describe('assignment keys', () => {
 });
 
 describe('caps', () => {
-  it('bounds preview and commit size', () => {
-    expect(PREVIEW_CAP).toBe(500);
+  it('bounds preview and commit size above the whole assignable universe', () => {
+    // The cap must stay ABOVE the set it bounds. Below it, the preview returns
+    // the same unreachable first page every run and the tail can never be
+    // assigned - which is how a client stalled at 521 of 762.
+    expect(PREVIEW_CAP).toBe(2000);
   });
 });
 

--- a/server/src/utils/talentPoolFilters.test.js
+++ b/server/src/utils/talentPoolFilters.test.js
@@ -6,7 +6,8 @@ import {
   buildExternalResumeWhere,
   parseAssignmentKey,
   buildAssignmentKey,
-  PREVIEW_CAP
+  PREVIEW_CAP,
+  NOT_OPTED_OUT
 } from './talentPoolFilters.js';
 
 const dsl = (rows, pool = 'APPLICANTS') => ({ pool, rows });
@@ -97,19 +98,33 @@ describe('sanitizeFilterDsl', () => {
 });
 
 describe('buildApplicantWhere - consent is not optional', () => {
-  const NOT_OPTED_OUT = { OR: [{ talentPoolOptIn: true }, { talentPoolOptIn: null }] };
+  const gateOf = (where) =>
+    where.AND.find((c) => JSON.stringify(c).includes('talentPoolOptIn'));
 
-  it('always excludes an explicit opt-out', () => {
+  it('always applies the consent gate', () => {
     const { where } = buildApplicantWhere(dsl([{ field: 'gender', values: ['Female'] }]));
     expect(where.AND).toContainEqual(NOT_OPTED_OUT);
   });
 
   it('keeps applicants who were never asked - a null is an absence, not a refusal', () => {
-    const { where } = buildApplicantWhere(dsl([{ field: 'gender', values: ['Female'] }]));
-    const gate = where.AND.find((c) => JSON.stringify(c).includes('talentPoolOptIn'));
-    expect(gate.OR).toContainEqual({ talentPoolOptIn: null });
-    // The one thing the gate must never admit.
-    expect(JSON.stringify(gate)).not.toContain('false');
+    const gate = gateOf(buildApplicantWhere(dsl([{ field: 'gender', values: ['Female'] }])).where);
+    expect(gate.AND[0].OR).toContainEqual({ talentPoolOptIn: null });
+    expect(gate.AND[0].OR).toContainEqual({ talentPoolOptIn: true });
+    // The one answer the row-level clause must never admit.
+    expect(gate.AND[0].OR).not.toContainEqual({ talentPoolOptIn: false });
+  });
+
+  it('disqualifies every application of someone who said no on any one of them', () => {
+    // Consent belongs to the person. Checking only the row in hand let a "no"
+    // on one application coexist with a still-shareable null on another, which
+    // put two people who had explicitly refused in front of a client.
+    const gate = gateOf(buildApplicantWhere(dsl([{ field: 'gender', values: ['Female'] }])).where);
+    expect(gate.AND[1].OR).toContainEqual({
+      candidate: { applications: { none: { talentPoolOptIn: false } } }
+    });
+    // An unlinked application has no siblings to be contradicted by, and its
+    // own answer is still checked by the first clause.
+    expect(gate.AND[1].OR).toContainEqual({ candidateId: null });
   });
 
   it('requires it even when the filter mentions nothing else', () => {


### PR DESCRIPTION
## Why "762 matches" could only ever become 527 assignments

The Test client sits at exactly **521 applicants + 6 members = 527**, and no amount of re-running the filter moves it. Three defects compound:

**1. The cap was below the set it bounds.** `PREVIEW_CAP` was 500, chosen when "every opted-in application in the system" was ~250 rows — twice the whole assignable universe. Reading the consent gate as *has not opted out* tripled that universe to 762, which put the cap underneath it. The preview always takes the same first page by `submittedAt desc`, so rows 501–762 were unreachable: re-running returned the identical 500 rows, every one already assigned, with nothing new to tick. Raised to 2000, matching `MAX_MATERIALIZED`, which bounds the same universe from the portal side.

**2. Pools starved each other.** Every pool did `take: PREVIEW_CAP` independently and the concatenated list was sliced back to the cap at the very end — so 500 applicants pushed all 6 member rows out of the response after they had been queried and counted into `total`. That is the "tick Members, see nothing" symptom in a new place, and it is why the members needed their own separate batch. The cap is now one budget spent across the pools.

**3. `truncated` disagreed with the response.** It compared `total` against the *pre-slice* row count. It is now computed on what is actually returned, and the note tells the admin the page will not change on a re-run and to narrow by cycle, class, or major.

## Verified against live data

| | before | after |
|---|---|---|
| rows returned | 500 of 768 | **768 of 768** |
| truncated | yes, permanently | no |
| reachable for Test client | 527 | **768** (241 new) |

## Tests

700 server / 426 client passing. New regression tests cover the shared cap budget (a full applicant pool no longer drops the member rows) and the cap staying above the assignable universe. The 2 `offerLetter` failures are pre-existing — they fail on a clean checkout of `main` too.
